### PR TITLE
Monoid and Abelian

### DIFF
--- a/examples/monoid-bfs.rs
+++ b/examples/monoid-bfs.rs
@@ -1,0 +1,173 @@
+extern crate rand;
+extern crate timely;
+extern crate differential_dataflow;
+
+#[macro_use]
+extern crate abomonation_derive;
+extern crate abomonation;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
+
+
+use rand::{Rng, SeedableRng, StdRng};
+
+use timely::dataflow::*;
+use timely::dataflow::operators::probe::Handle;
+
+use differential_dataflow::input::Input;
+use differential_dataflow::Collection;
+use differential_dataflow::operators::*;
+use differential_dataflow::lattice::Lattice;
+
+type Node = u32;
+type Edge = (Node, Node);
+
+#[derive(Abomonation, Copy, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Hash)]
+pub struct MinSum {
+    value: u32,
+}
+
+use std::ops::{Add, Mul};
+use differential_dataflow::difference::Monoid;
+
+impl Add<Self> for MinSum {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        MinSum { value: std::cmp::min(self.value, rhs.value) }
+    }
+}
+
+impl Mul<Self> for MinSum {
+    type Output = Self;
+    fn mul(self, rhs: Self) -> Self {
+        MinSum { value: self.value + rhs.value }
+    }
+}
+
+impl Monoid for MinSum {
+    fn zero() -> MinSum { MinSum { value: u32::max_value() } }
+}
+
+fn main() {
+
+    let nodes: u32 = std::env::args().nth(1).unwrap().parse().unwrap();
+    let edges: u32 = std::env::args().nth(2).unwrap().parse().unwrap();
+    let weight: u32 = std::env::args().nth(3).unwrap().parse().unwrap();
+    let batch: u32 = std::env::args().nth(4).unwrap().parse().unwrap();
+    let rounds: u32 = std::env::args().nth(5).unwrap().parse().unwrap();
+    let inspect: bool = std::env::args().nth(6).unwrap() == "inspect";
+
+    // define a new computational scope, in which to run BFS
+    timely::execute_from_args(std::env::args(), move |worker| {
+
+        let timer = ::std::time::Instant::now();
+
+        // define BFS dataflow; return handles to roots and edges inputs
+        let mut probe = Handle::new();
+        let (mut roots, mut graph) = worker.dataflow(|scope| {
+
+            let (root_input, roots) = scope.new_collection();
+            let (edge_input, graph) = scope.new_collection();
+
+            let mut result = bfs(&graph, &roots);
+
+            if !inspect {
+                result = result.filter(|_| false);
+            }
+
+            result.count()
+                  .map(|(_,l)| l)
+                  .consolidate()
+                  .inspect(|x| println!("\t{:?}", x))
+                  .probe_with(&mut probe);
+
+            (root_input, edge_input)
+        });
+
+        let seed: &[_] = &[1, 2, 3, 4];
+        let mut rng1: StdRng = SeedableRng::from_seed(seed);    // rng for edge additions
+
+        roots.update_at(0, Default::default(), MinSum { value: 0 });
+        roots.close();
+
+        println!("performing BFS on {} nodes, {} edges:", nodes, edges);
+
+        if worker.index() == 0 {
+            for _ in 0 .. edges {
+                graph.update_at(
+                    (rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)),
+                    Default::default(),
+                    MinSum { value: rng1.gen_range(0, weight) },
+                );
+            }
+        }
+
+        println!("{:?}\tloaded", timer.elapsed());
+
+        graph.advance_to(1);
+        graph.flush();
+        worker.step_while(|| probe.less_than(graph.time()));
+
+        println!("{:?}\tstable", timer.elapsed());
+
+        for round in 0 .. rounds {
+            for element in 0 .. batch {
+                if worker.index() == 0 {
+                    graph.update_at(
+                        (rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)),
+                        round+1,
+                        MinSum { value: rng1.gen_range(0, weight) },
+                    );
+                }
+                graph.advance_to(2 + round * batch + element);
+            }
+            graph.flush();
+
+            let timer2 = ::std::time::Instant::now();
+            worker.step_while(|| probe.less_than(&graph.time()));
+
+            if worker.index() == 0 {
+                let elapsed = timer2.elapsed();
+                println!("{:?}\t{:?}:\t{}", timer.elapsed(), round, elapsed.as_secs() * 1000000000 + (elapsed.subsec_nanos() as u64));
+            }
+        }
+        println!("finished; elapsed: {:?}", timer.elapsed());
+    }).unwrap();
+}
+
+// returns pairs (n, s) indicating node n can be reached from a root in s steps.
+fn bfs<G: Scope>(edges: &Collection<G, Edge, MinSum>, roots: &Collection<G, Node, MinSum>) -> Collection<G, Node, MinSum>
+where G::Timestamp: Lattice+Ord {
+
+    // repeatedly update minimal distances each node can be reached from each root
+    roots.scope().iterative::<u32,_,_>(|scope| {
+
+        use differential_dataflow::operators::iterate::MonoidVariable;
+        use differential_dataflow::operators::group::GroupArranged;
+        use differential_dataflow::trace::implementations::ord::OrdKeySpine as DefaultKeyTrace;
+
+
+        use timely::order::Product;
+        let variable = MonoidVariable::new(scope, Product::new(Default::default(), 1));
+
+        let edges = edges.enter(scope);
+        let roots = roots.enter(scope);
+
+        let result =
+        variable
+            .map(|n| (n,()))
+            .join_map(&edges, |_k,&(),d| *d)
+            .concat(&roots)
+            .map(|x| (x,()))
+            .group_solve::<_,_,DefaultKeyTrace<_,_,_>,_>(|_key, input, output, updates| {
+                if output.is_empty() || input[0].1 < output[0].1 {
+                    updates.push(((), input[0].1));
+                }
+            })
+            .as_collection(|k,()| *k);
+
+        variable.set(&result);
+        result.leave()
+     })
+}

--- a/interactive/.gitignore
+++ b/interactive/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+/target

--- a/interactive/Cargo.toml
+++ b/interactive/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "interactive"
+version = "0.1.0"
+authors = ["Frank McSherry <fmcsherry@me.com>"]
+
+[dependencies]
+serde = "1"
+serde_derive = "1"
+differential-dataflow = { path = "../" }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }

--- a/interactive/src/bin/server.rs
+++ b/interactive/src/bin/server.rs
@@ -1,0 +1,68 @@
+extern crate timely;
+extern crate interactive;
+
+use std::time::{Instant, Duration};
+
+use timely::synchronization::Sequencer;
+use interactive::{Manager, Command, Query, Rule, Plan};
+
+use interactive::plan::join::Join;
+use interactive::plan::project::Project;
+
+type Value = usize;
+
+fn main() {
+
+    let mut args = std::env::args();
+    args.next();
+
+    timely::execute_from_args(args, |worker| {
+
+        let timer = Instant::now();
+        let mut manager = Manager::new();
+        let mut sequencer = Some(Sequencer::<Command<Value>>::new(worker, Instant::now()));
+
+        if worker.index() == 0 {
+
+            let edges = (0 .. 100).map(|x| vec![x, (x+1)%100]).collect::<Vec<_>>();
+
+            sequencer.as_mut().map(|x| x.push(Command::CreateInput("edges".to_string(), edges)));
+            worker.step();
+            sequencer.as_mut().map(|x| x.push(Command::AdvanceTime(1)));
+            worker.step();
+            sequencer.as_mut().map(|x| x.push(Command::Query(
+                Query {
+                    rules: vec![Rule {
+                        name: "fof".to_string(),
+                        plan: Plan::source("edges").join(Plan::source("edges"), vec![(0,1)])
+                                                   .project(vec![1,2])
+                                                   .inspect("fof"),
+                    }]
+                }
+            )));
+            worker.step();
+            sequencer.as_mut().map(|x| x.push(Command::AdvanceTime(2)));
+            worker.step();
+            sequencer.as_mut().map(|x| x.push(Command::CloseInput("edges".to_string())));
+            worker.step();
+            sequencer.as_mut().map(|x| x.push(Command::Shutdown));
+        }
+
+        let mut shutdown = false;
+
+        while !shutdown {
+
+            if let Some(command) = sequencer.as_mut().unwrap().next() {
+                println!("{:?}\tExecuting {:#?}", timer.elapsed(), command);
+                if command == Command::Shutdown {
+                    shutdown = true;
+                    sequencer = None;
+                }
+                command.execute(&mut manager, worker);
+            }
+
+            worker.step();
+        }
+
+    }).expect("Timely computation did not exit cleanly");
+}

--- a/interactive/src/command.rs
+++ b/interactive/src/command.rs
@@ -1,0 +1,100 @@
+
+use std::hash::Hash;
+
+use timely::communication::Allocate;
+use timely::worker::Worker;
+use differential_dataflow::{Data};
+
+use super::{Query, Rule, Plan, Time, Diff, Manager};
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum Command<Value> {
+    /// Installs the query and publishes public rules.
+    Query(Query<Value>),
+    /// Advances all inputs and traces to `time`, and advances computation.
+    AdvanceTime(Time),
+    /// Creates a new named input, with initial input.
+    CreateInput(String, Vec<Vec<Value>>),
+    /// Introduces updates to a specified input.
+    UpdateInput(String, Vec<(Vec<Value>, Time, Diff)>),
+    /// Closes a specified input.
+    CloseInput(String),
+    /// Terminates the system.
+    Shutdown,
+}
+
+impl<Value: Data+Hash> Command<Value> {
+
+    pub fn execute<A: Allocate>(self, manager: &mut Manager<Value>, worker: &mut Worker<A>) {
+
+        match self {
+
+            Command::Query(query) => {
+
+                worker.dataflow(|scope| {
+
+                    use timely::dataflow::operators::Probe;
+                    use differential_dataflow::operators::arrange::ArrangeBySelf;
+                    use plan::Render;
+
+                    for Rule { name, plan } in query.rules.into_iter() {
+                        let collection =
+                        plan.render(scope, &mut manager.traces)
+                            .arrange_by_self();
+
+                        collection.stream.probe_with(&mut manager.probe);
+                        let trace = collection.trace;
+
+                        // Can bind the trace to both the plan and the name.
+                        manager.traces.set_unkeyed(&plan, &trace);
+                        manager.traces.set_unkeyed(&Plan::Source(name), &trace);
+                    }
+
+                });
+            },
+
+            Command::AdvanceTime(time) => {
+                manager.advance_time(&time);
+                while manager.probe.less_than(&time) {
+                    worker.step();
+                }
+            },
+
+            Command::CreateInput(name, updates) => {
+
+                use differential_dataflow::input::Input;
+                use differential_dataflow::operators::arrange::ArrangeBySelf;
+
+                let (input, trace) = worker.dataflow(|scope| {
+                    let (input, collection) = scope.new_collection_from(updates.into_iter());
+                    let trace = collection.arrange_by_self().trace;
+                    (input, trace)
+                });
+
+                manager.insert_input(name, input, trace);
+
+            },
+
+            Command::UpdateInput(name, updates) => {
+                if let Some(input) = manager.inputs.sessions.get_mut(&name) {
+                    for (data, time, diff) in updates.into_iter() {
+                        input.update_at(data, time, diff);
+                    }
+                }
+                else {
+                    println!("Input not found: {:?}", name);
+                }
+            },
+
+            Command::CloseInput(name) => {
+                manager.inputs.sessions.remove(&name);
+            },
+
+            Command::Shutdown => {
+                println!("Shutdown received");
+            }
+        }
+
+    }
+
+}

--- a/interactive/src/lib.rs
+++ b/interactive/src/lib.rs
@@ -1,0 +1,33 @@
+extern crate timely;
+extern crate differential_dataflow;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+
+pub mod plan;
+pub use plan::Plan;
+
+pub mod manager;
+pub use manager::{Manager, TraceManager, InputManager};
+
+pub mod command;
+pub use command::Command;
+
+pub type Time = usize;
+pub type Diff = isize;
+
+/// Multiple related collection definitions.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Query<Value> {
+    /// A list of bindings of names to plans.
+    pub rules: Vec<Rule<Value>>,
+}
+
+/// Definition of a single collection.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Rule<Value> {
+    /// Name of the rule.
+    pub name: String,
+    /// Plan describing contents of the rule.
+    pub plan: Plan<Value>,
+}

--- a/interactive/src/manager.rs
+++ b/interactive/src/manager.rs
@@ -1,0 +1,146 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use timely::dataflow::ProbeHandle;
+
+use differential_dataflow::Data;
+use differential_dataflow::trace::implementations::ord::{OrdKeySpine, OrdValSpine};
+use differential_dataflow::operators::arrange::TraceAgent;
+use differential_dataflow::input::InputSession;
+
+use super::{Time, Diff, Plan};
+
+
+pub type TraceKeyHandle<K, T, R> = TraceAgent<K, (), T, R, OrdKeySpine<K, T, R>>;
+pub type TraceValHandle<K, V, T, R> = TraceAgent<K, V, T, R, OrdValSpine<K, V, T, R>>;
+
+pub type KeysOnlyHandle<V> = TraceKeyHandle<Vec<V>, Time, Diff>;
+pub type KeysValsHandle<V> = TraceValHandle<Vec<V>, Vec<V>, Time, Diff>;
+
+
+pub struct Manager<Value: Data> {
+    pub inputs: InputManager<Value>,
+    pub traces: TraceManager<Value>,
+    pub probe: ProbeHandle<Time>,
+}
+
+impl<Value: Data+Hash> Manager<Value> {
+
+    pub fn new() -> Self {
+        Manager {
+            inputs: InputManager::new(),
+            traces: TraceManager::new(),
+            probe: ProbeHandle::new(),
+        }
+    }
+
+    pub fn insert_input(
+        &mut self,
+        name: String,
+        input: InputSession<Time, Vec<Value>, Diff>,
+        trace: KeysOnlyHandle<Value>)
+    {
+        self.inputs.sessions.insert(name.clone(), input);
+        self.traces.set_unkeyed(&Plan::Source(name), &trace);
+    }
+
+    /// Advances inputs and traces to `time`.
+    pub fn advance_time(&mut self, time: &Time) {
+        self.inputs.advance_time(time);
+        self.traces.advance_time(time);
+    }
+
+}
+
+pub struct InputManager<Value: Data> {
+    pub sessions: HashMap<String, InputSession<Time, Vec<Value>, Diff>>,
+}
+
+impl<Value: Data> InputManager<Value> {
+
+    pub fn new() -> Self { Self { sessions: HashMap::new() } }
+
+    pub fn advance_time(&mut self, time: &Time) {
+        for session in self.sessions.values_mut() {
+            session.advance_to(time.clone());
+            session.flush();
+        }
+    }
+
+}
+
+/// Root handles to maintained collections.
+///
+/// Manages a map from plan (describing a collection)
+/// to various arranged forms of that collection.
+pub struct TraceManager<Value: Data> {
+
+    /// Arrangements where the record itself is they key.
+    ///
+    /// This contains both input collections, which are here cached so that
+    /// they can be re-used, intermediate collections that are cached, and
+    /// any collections that are explicitly published.
+    inputs: HashMap<Plan<Value>, KeysOnlyHandle<Value>>,
+
+    /// Arrangements of collections by key.
+    arrangements: HashMap<Plan<Value>, HashMap<Vec<usize>, KeysValsHandle<Value>>>,
+
+}
+
+impl<Value: Data+Hash> TraceManager<Value> {
+
+    pub fn new() -> Self { Self { inputs: HashMap::new(), arrangements: HashMap::new() } }
+
+    /// Advances the frontier of each maintained trace.
+    pub fn advance_time(&mut self, time: &Time) {
+        use differential_dataflow::trace::TraceReader;
+
+        let frontier = &[time.clone()];
+        for trace in self.inputs.values_mut() {
+            trace.advance_by(frontier);
+        }
+        for map in self.arrangements.values_mut() {
+            for trace in map.values_mut() {
+                trace.advance_by(frontier)
+            }
+        }
+    }
+
+    /// Recover an arrangement by plan and keys, if it is cached.
+    pub fn get_unkeyed(&self, plan: &Plan<Value>) -> Option<KeysOnlyHandle<Value>> {
+        self.inputs
+            .get(plan)
+            .map(|x| x.clone())
+    }
+
+    /// Installs an unkeyed arrangement for a specified plan.
+    pub fn set_unkeyed(&mut self, plan: &Plan<Value>, handle: &KeysOnlyHandle<Value>) {
+
+        println!("Setting unkeyed: {:?}", plan);
+
+        use differential_dataflow::trace::TraceReader;
+        let mut handle = handle.clone();
+        handle.distinguish_since(&[]);
+        self.inputs
+            .insert(plan.clone(), handle);
+    }
+
+    /// Recover an arrangement by plan and keys, if it is cached.
+    pub fn get_keyed(&self, plan: &Plan<Value>, keys: &[usize]) -> Option<KeysValsHandle<Value>> {
+        self.arrangements
+            .get(plan)
+            .and_then(|map| map.get(keys).map(|x| x.clone()))
+    }
+
+    /// Installs a keyed arrangement for a specified plan and sequence of keys.
+    pub fn set_keyed(&mut self, plan: &Plan<Value>, keys: &[usize], handle: &KeysValsHandle<Value>) {
+        use differential_dataflow::trace::TraceReader;
+        let mut handle = handle.clone();
+        handle.distinguish_since(&[]);
+        self.arrangements
+            .entry(plan.clone())
+            .or_insert(HashMap::new())
+            .insert(keys.to_vec(), handle);
+    }
+
+}

--- a/interactive/src/plan/concat.rs
+++ b/interactive/src/plan/concat.rs
@@ -1,0 +1,40 @@
+//! Concat expression plan.
+
+use std::hash::Hash;
+
+use timely::dataflow::Scope;
+
+use differential_dataflow::{Collection, Data};
+use plan::{Plan, Render};
+use {TraceManager, Time, Diff};
+
+/// Merges the source collections.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Concat<V> {
+    /// Plan for the data source.
+    pub plans: Vec<Plan<V>>,
+}
+
+impl<V: Data+Hash> Render for Concat<V> {
+
+    type Value = V;
+
+    fn render<S: Scope<Timestamp = Time>>(
+        &self,
+        scope: &mut S,
+        arrangements: &mut TraceManager<Self::Value>) -> Collection<S, Vec<Self::Value>, Diff>
+    {
+        use timely::dataflow::operators::Concatenate;
+        use differential_dataflow::AsCollection;
+
+        let collections =
+        self.plans
+            .iter()
+            .map(|plan| plan.render(scope, arrangements).inner)
+            .collect::<Vec<_>>();
+
+        scope
+            .concatenate(collections)
+            .as_collection()
+    }
+}

--- a/interactive/src/plan/filter.rs
+++ b/interactive/src/plan/filter.rs
@@ -1,0 +1,93 @@
+//! Predicate expression plan.
+
+use std::hash::Hash;
+
+use timely::dataflow::Scope;
+
+use differential_dataflow::{Collection, Data};
+use plan::{Plan, Render};
+use {TraceManager, Time, Diff};
+
+/// What to compare against.
+///
+/// A second argument is either a constant or the index of another value.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum SecondArgument<Value> {
+    /// A constant value.
+    Constant(Value),
+    /// An index of another value.
+    Position(usize),
+}
+
+impl<Value> SecondArgument<Value> {
+    /// Produces the indicated value.
+    pub fn value<'a>(&'a self, values: &'a [Value]) -> &'a Value {
+        match self {
+            SecondArgument::Constant(value) => value,
+            SecondArgument::Position(index) => &values[*index],
+        }
+    }
+}
+
+/// Possible predicates to apply.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum Predicate<Value> {
+    /// Strictly less than.
+    LessThan(usize, SecondArgument<Value>),
+    /// Less than or equal.
+    LessEqual(usize, SecondArgument<Value>),
+    /// Strictly greater than.
+    GreaterThan(usize, SecondArgument<Value>),
+    /// Greater than or equal.
+    GreaterEqual(usize, SecondArgument<Value>),
+    /// Equal.
+    Equal(usize, SecondArgument<Value>),
+    /// Not equal.
+    NotEqual(usize, SecondArgument<Value>),
+    /// Any of a list of predicates.
+    Any(Vec<Predicate<Value>>),
+    /// All of a list of predicates.
+    All(Vec<Predicate<Value>>),
+}
+
+impl<Value: Ord> Predicate<Value> {
+    pub fn satisfied(&self, values: &[Value]) -> bool {
+        match self {
+            Predicate::LessThan(index, other) => values[*index].lt(other.value(values)),
+            Predicate::LessEqual(index, other) => values[*index].le(other.value(values)),
+            Predicate::GreaterThan(index, other) => values[*index].gt(other.value(values)),
+            Predicate::GreaterEqual(index, other) => values[*index].ge(other.value(values)),
+            Predicate::Equal(index, other) => values[*index].eq(other.value(values)),
+            Predicate::NotEqual(index, other) => values[*index].ne(other.value(values)),
+            Predicate::Any(predicates) => predicates.iter().any(|p| p.satisfied(values)),
+            Predicate::All(predicates) => predicates.iter().all(|p| p.satisfied(values)),
+        }
+    }
+}
+
+/// A plan stage filtering source tuples by the specified
+/// predicate. Frontends are responsible for ensuring that the source
+/// binds the argument symbols.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Filter<V> {
+    /// Logical predicate to apply.
+    pub predicate: Predicate<V>,
+    /// Plan for the data source.
+    pub plan: Box<Plan<V>>,
+}
+
+impl<V: Data+Hash> Render for Filter<V> {
+
+    type Value = V;
+
+    fn render<S: Scope<Timestamp = Time>>(
+        &self,
+        scope: &mut S,
+        arrangements: &mut TraceManager<Self::Value>) -> Collection<S, Vec<Self::Value>, Diff>
+    {
+        let predicate = self.predicate.clone();
+        self.plan
+            .render(scope, arrangements)
+            .filter(move |tuple| predicate.satisfied(tuple))
+    }
+}

--- a/interactive/src/plan/join.rs
+++ b/interactive/src/plan/join.rs
@@ -1,0 +1,107 @@
+//! Equijoin expression plan.
+
+use std::hash::Hash;
+
+use timely::dataflow::Scope;
+
+use differential_dataflow::operators::JoinCore;
+
+use differential_dataflow::{Collection, Data};
+use plan::{Plan, Render};
+use {TraceManager, Time, Diff};
+
+/// A plan stage joining two source relations on the specified
+/// symbols. Throws if any of the join symbols isn't bound by both
+/// sources.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Join<Value> {
+    pub keys: Vec<(usize, usize)>,
+    /// Plan for the left input.
+    pub plan1: Box<Plan<Value>>,
+    /// Plan for the right input.
+    pub plan2: Box<Plan<Value>>,
+}
+
+impl<V: Data+Hash> Render for Join<V> {
+
+    type Value = V;
+
+    fn render<S: Scope<Timestamp = Time>>(
+        &self,
+        scope: &mut S,
+        arrangements: &mut TraceManager<Self::Value>) -> Collection<S, Vec<Self::Value>, Diff>
+    {
+        use differential_dataflow::operators::arrange::ArrangeByKey;
+
+        // acquire arrangements for each input.
+        let keys1 = self.keys.iter().map(|key| key.0).collect::<Vec<_>>();
+        let mut trace1 =
+        if let Some(arrangement) = arrangements.get_keyed(&self.plan1, &keys1[..]) {
+            arrangement
+        }
+        else {
+            let keys = keys1.clone();
+            let arrangement =
+            self.plan1
+                .render(scope, arrangements)
+                .map(move |tuple|
+                    (
+                        // TODO: Re-use `tuple` for values.
+                        keys.iter().map(|index| tuple[*index].clone()).collect::<Vec<_>>(),
+                        tuple
+                            .into_iter()
+                            .enumerate()
+                            .filter(|(index,_value)| !keys.contains(index))
+                            .map(|(_index,value)| value)
+                            .collect::<Vec<_>>(),
+                    )
+                )
+                .arrange_by_key();
+
+            arrangements.set_keyed(&self.plan1, &keys1[..], &arrangement.trace);
+            arrangement.trace
+        };
+
+        // extract relevant fields for each index.
+        let keys2 = self.keys.iter().map(|key| key.1).collect::<Vec<_>>();
+        let mut trace2 =
+        if let Some(arrangement) = arrangements.get_keyed(&self.plan2, &keys2[..]) {
+            arrangement
+        }
+        else {
+            let keys = keys2.clone();
+            let arrangement =
+            self.plan1
+                .render(scope, arrangements)
+                .map(move |tuple|
+                    (
+                        // TODO: Re-use `tuple` for values.
+                        keys.iter().map(|index| tuple[*index].clone()).collect::<Vec<_>>(),
+                        tuple
+                            .into_iter()
+                            .enumerate()
+                            .filter(|(index,_value)| !keys.contains(index))
+                            .map(|(_index,value)| value)
+                            .collect::<Vec<_>>(),
+                    )
+                )
+                .arrange_by_key();
+
+            arrangements.set_keyed(&self.plan2, &keys2[..], &arrangement.trace);
+            arrangement.trace
+        };
+
+        let arrange1 = trace1.import(scope);
+        let arrange2 = trace2.import(scope);
+
+        arrange1
+            .join_core(&arrange2, |keys, vals1, vals2| {
+                Some(
+                    keys.iter().cloned()
+                        .chain(vals1.iter().cloned())
+                        .chain(vals2.iter().cloned())
+                        .collect()
+                )
+            })
+    }
+}

--- a/interactive/src/plan/mod.rs
+++ b/interactive/src/plan/mod.rs
@@ -1,0 +1,129 @@
+//! Types and traits for implementing query plans.
+
+use std::hash::Hash;
+
+use timely::dataflow::Scope;
+use differential_dataflow::{Collection, Data};
+
+use {TraceManager, Time, Diff};
+
+// pub mod count;
+pub mod concat;
+pub mod filter;
+pub mod join;
+pub mod project;
+
+// pub use self::count::Count;
+pub use self::concat::Concat;
+pub use self::filter::{Filter, Predicate};
+pub use self::join::Join;
+pub use self::project::Project;
+
+pub trait Render : Sized {
+
+    /// Value type produced.
+    type Value: Data;
+
+    /// Renders the instance as a collection in the supplied scope.
+    ///
+    /// This method has access to arranged data, and may rely on and update the set
+    /// of arrangements based on the needs and offerings of the rendering process.
+    fn render<S: Scope<Timestamp = Time>>(
+        &self,
+        scope: &mut S,
+        arrangements: &mut TraceManager<Self::Value>) -> Collection<S, Vec<Self::Value>, Diff>;
+}
+
+/// Possible query plan types.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum Plan<Value> {
+    /// Projection / Permutation
+    Project(Project<Value>),
+    /// Distinct
+    Distinct(Box<Plan<Value>>),
+    /// Concat
+    Concat(Concat<Value>),
+    /// Equijoin
+    Join(Join<Value>),
+    /// Negation
+    Negate(Box<Plan<Value>>),
+    /// Filters bindings by one of the built-in predicates
+    Filter(Filter<Value>),
+    /// Sources data from another relation.
+    Source(String),
+    /// Prints resulting updates.
+    Inspect(String, Box<Plan<Value>>),
+}
+
+impl<V: Data+Hash> Plan<V> {
+    pub fn project(self, indices: Vec<usize>) -> Self {
+        Plan::Project(Project {
+            indices,
+            plan: Box::new(self),
+        })
+    }
+    pub fn distinct(self) -> Self {
+        Plan::Distinct(Box::new(self))
+    }
+    pub fn concat(plans: Vec<Self>) -> Self {
+        Plan::Concat(Concat { plans } )
+    }
+    pub fn join(self, other: Plan<V>, keys: Vec<(usize, usize)>) -> Self {
+        Plan::Join(Join {
+            keys,
+            plan1: Box::new(self),
+            plan2: Box::new(other),
+        })
+    }
+    pub fn negate(self) -> Self {
+        Plan::Negate(Box::new(self))
+    }
+    pub fn filter(self, predicate: Predicate<V>) -> Self {
+        Plan::Filter(Filter { predicate, plan: Box::new(self) } )
+    }
+    pub fn source(name: &str) -> Self {
+        Plan::Source(name.to_string())
+    }
+    pub fn inspect(self, text: &str) -> Self {
+        Plan::Inspect(text.to_string(), Box::new(self))
+    }
+}
+
+impl<V: Data+Hash> Render for Plan<V> {
+
+    type Value = V;
+
+    fn render<S: Scope<Timestamp = Time>>(
+        &self,
+        scope: &mut S,
+        arrangements: &mut TraceManager<Self::Value>) -> Collection<S, Vec<Self::Value>, Diff>
+    {
+        match self {
+            Plan::Project(projection) => projection.render(scope, arrangements),
+            Plan::Distinct(distinct) => {
+                // TODO: Check for existing arrangement.
+                use differential_dataflow::operators::Threshold;
+                distinct.render(scope, arrangements).distinct()
+            },
+            // Plan::Count(count) => count.render(scope, arrangements),
+            Plan::Concat(concat) => concat.render(scope, arrangements),
+            Plan::Join(join) => join.render(scope, arrangements),
+            Plan::Negate(negate) => {
+                negate.render(scope, arrangements).negate()
+            },
+            Plan::Filter(filter) => filter.render(scope, arrangements),
+            Plan::Source(source) => {
+                arrangements
+                    .get_unkeyed(self)
+                    .expect(&format!("Failed to find source collection: {:?}", source))
+                    .import(scope)
+                    .as_collection(|k,()| k.to_vec())
+            },
+            Plan::Inspect(text, plan) => {
+                let text = text.clone();
+                plan.render(scope, arrangements)
+                    .inspect(move |x| println!("{}\t{:?}", text, x))
+            },
+        }
+    }
+}

--- a/interactive/src/plan/project.rs
+++ b/interactive/src/plan/project.rs
@@ -1,0 +1,40 @@
+//! Projection expression plan.
+
+use std::hash::Hash;
+
+use timely::dataflow::Scope;
+
+use differential_dataflow::{Collection, Data};
+use plan::{Plan, Render};
+use {TraceManager, Time, Diff};
+
+/// A plan which retains values at specified locations.
+///
+/// The plan does not ascribe meaning to specific locations (e.g. bindings)
+/// to variable names, and simply selects out the indicated sequence of values,
+/// panicking if some input record is insufficiently long.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Project<V> {
+    /// Sequence (and order) of indices to be retained.
+    pub indices: Vec<usize>,
+    /// Plan for the data source.
+    pub plan: Box<Plan<V>>,
+}
+
+impl<V: Data+Hash> Render for Project<V> {
+
+    type Value = V;
+
+    fn render<S: Scope<Timestamp = Time>>(
+        &self,
+        scope: &mut S,
+        arrangements: &mut TraceManager<Self::Value>) -> Collection<S, Vec<Self::Value>, Diff>
+    {
+        let indices = self.indices.clone();
+
+        // TODO: re-use `tuple` allocation.
+        self.plan
+            .render(scope, arrangements)
+            .map(move |tuple| indices.iter().map(|index| tuple[*index].clone()).collect())
+    }
+}

--- a/src/algorithms/identifiers.rs
+++ b/src/algorithms/identifiers.rs
@@ -5,10 +5,10 @@ use timely::dataflow::Scope;
 use ::{Collection, Data, Hashable};
 use ::lattice::Lattice;
 use ::operators::*;
-use difference::Diff;
+use ::difference::Abelian;
 
 /// Assign unique identifiers to elements of a collection.
-pub trait Identifiers<G: Scope, D: Data, R: Diff> {
+pub trait Identifiers<G: Scope, D: Data, R: Abelian> {
     /// Assign unique identifiers to elements of a collection.
     ///
     /// # Example
@@ -41,7 +41,7 @@ where
     G: Scope,
     G::Timestamp: Lattice,
     D: Data+::std::hash::Hash,
-    R: Diff,
+    R: Abelian,
 {
     fn identifiers(&self) -> Collection<G, (D, u64), R> {
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -18,7 +18,7 @@ use timely::dataflow::scopes::{Child, child::Iterative};
 use timely::dataflow::{Scope, Stream};
 use timely::dataflow::operators::*;
 
-use ::Diff;
+use ::difference::{Monoid, Abelian};
 use lattice::Lattice;
 use hashable::Hashable;
 
@@ -38,7 +38,7 @@ use hashable::Hashable;
 /// The `R` parameter represents the types of changes that the data undergo, and is most commonly (and
 /// defaults to) `isize`, representing changes to the occurrence count of each record.
 #[derive(Clone)]
-pub struct Collection<G: Scope, D, R: Diff = isize> {
+pub struct Collection<G: Scope, D, R: Monoid = isize> {
     /// The underlying timely dataflow stream.
     ///
     /// This field is exposed to support direct timely dataflow manipulation when required, but it is
@@ -46,7 +46,7 @@ pub struct Collection<G: Scope, D, R: Diff = isize> {
     pub inner: Stream<G, (D, G::Timestamp, R)>
 }
 
-impl<G: Scope, D: Data, R: Diff> Collection<G, D, R> where G::Timestamp: Data {
+impl<G: Scope, D: Data, R: Monoid> Collection<G, D, R> where G::Timestamp: Data {
     /// Creates a new Collection from a timely dataflow stream.
     ///
     /// This method seems to be rarely used, with the `as_collection` method on streams being a more
@@ -142,39 +142,6 @@ impl<G: Scope, D: Data, R: Diff> Collection<G, D, R> where G::Timestamp: Data {
             .flat_map(move |(data, time, delta)| logic(data).into_iter().map(move |x| (x, time.clone(), delta)))
             .as_collection()
     }
-    /// Creates a new collection whose counts are the negation of those in the input.
-    ///
-    /// This method is most commonly used with `concat` to get those element in one collection but not another.
-    /// However, differential dataflow computations are still defined for all values of the difference type `R`,
-    /// including negative counts.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
-    /// use differential_dataflow::input::Input;
-    ///
-    /// fn main() {
-    ///     ::timely::example(|scope| {
-    ///
-    ///         let data = scope.new_collection_from(1 .. 10).1;
-    ///
-    ///         let odds = data.filter(|x| x % 2 == 1);
-    ///         let evens = data.filter(|x| x % 2 == 0);
-    ///
-    ///         odds.negate()
-    ///             .concat(&data)
-    ///             .assert_eq(&evens);
-    ///     });
-    /// }
-    /// ```
-    pub fn negate(&self) -> Collection<G, D, R> {
-        self.inner
-            .map_in_place(|x| x.2 = -x.2)
-            .as_collection()
-    }
     /// Creates a new collection containing those input records satisfying the supplied predicate.
     ///
     /// # Examples
@@ -259,8 +226,8 @@ impl<G: Scope, D: Data, R: Diff> Collection<G, D, R> where G::Timestamp: Data {
     /// ```
     pub fn explode<D2, R2, I, L>(&self, logic: L) -> Collection<G, D2, <R2 as Mul<R>>::Output>
     where D2: Data,
-          R2: Diff+Mul<R>,
-          <R2 as Mul<R>>::Output: Data+Diff,
+          R2: Monoid+Mul<R>,
+          <R2 as Mul<R>>::Output: Data+Monoid,
           I: IntoIterator<Item=(D2,R2)>,
           L: Fn(D)->I+'static,
     {
@@ -450,43 +417,6 @@ impl<G: Scope, D: Data, R: Diff> Collection<G, D, R> where G::Timestamp: Data {
             .as_collection()
     }
 
-    /// Assert if the collections are ever different.
-    ///
-    /// Because this is a dataflow fragment, the test is only applied as the computation is run. If the computation
-    /// is not run, or not run to completion, there may be un-exercised times at which the collections could vary.
-    /// Typically, a timely dataflow computation runs to completion on drop, and so clean exit from a program should
-    /// indicate that this assertion never found cause to complain.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
-    /// use differential_dataflow::input::Input;
-    ///
-    /// fn main() {
-    ///     ::timely::example(|scope| {
-    ///
-    ///         let data = scope.new_collection_from(1 .. 10).1;
-    ///
-    ///         let odds = data.filter(|x| x % 2 == 1);
-    ///         let evens = data.filter(|x| x % 2 == 0);
-    ///
-    ///         odds.concat(&evens)
-    ///             .assert_eq(&data);
-    ///     });
-    /// }
-    /// ```
-    pub fn assert_eq(&self, other: &Self)
-    where D: ::Data+Hashable,
-          G::Timestamp: Lattice+Ord
-    {
-        self.negate()
-            .concat(other)
-            .assert_empty();
-    }
-
     /// Assert if the collection is ever non-empty.
     ///
     /// Because this is a dataflow fragment, the test is only applied as the computation is run. If the computation
@@ -529,7 +459,7 @@ impl<G: Scope, D: Data, R: Diff> Collection<G, D, R> where G::Timestamp: Data {
 use timely::dataflow::scopes::ScopeParent;
 use timely::progress::timestamp::Refines;
 
-impl<'a, G: Scope, T: Timestamp, D: Data, R: Diff> Collection<Child<'a, G, T>, D, R>
+impl<'a, G: Scope, T: Timestamp, D: Data, R: Monoid> Collection<Child<'a, G, T>, D, R>
 where
     T: Refines<<G as ScopeParent>::Timestamp>,
 {
@@ -566,13 +496,87 @@ where
     }
 }
 
+impl<G: Scope, D: Data, R: Abelian> Collection<G, D, R> where G::Timestamp: Data {
+    /// Creates a new collection whose counts are the negation of those in the input.
+    ///
+    /// This method is most commonly used with `concat` to get those element in one collection but not another.
+    /// However, differential dataflow computations are still defined for all values of the difference type `R`,
+    /// including negative counts.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate timely;
+    /// extern crate differential_dataflow;
+    ///
+    /// use differential_dataflow::input::Input;
+    ///
+    /// fn main() {
+    ///     ::timely::example(|scope| {
+    ///
+    ///         let data = scope.new_collection_from(1 .. 10).1;
+    ///
+    ///         let odds = data.filter(|x| x % 2 == 1);
+    ///         let evens = data.filter(|x| x % 2 == 0);
+    ///
+    ///         odds.negate()
+    ///             .concat(&data)
+    ///             .assert_eq(&evens);
+    ///     });
+    /// }
+    /// ```
+    pub fn negate(&self) -> Collection<G, D, R> {
+        self.inner
+            .map_in_place(|x| x.2 = -x.2)
+            .as_collection()
+    }
+
+
+    /// Assert if the collections are ever different.
+    ///
+    /// Because this is a dataflow fragment, the test is only applied as the computation is run. If the computation
+    /// is not run, or not run to completion, there may be un-exercised times at which the collections could vary.
+    /// Typically, a timely dataflow computation runs to completion on drop, and so clean exit from a program should
+    /// indicate that this assertion never found cause to complain.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate timely;
+    /// extern crate differential_dataflow;
+    ///
+    /// use differential_dataflow::input::Input;
+    ///
+    /// fn main() {
+    ///     ::timely::example(|scope| {
+    ///
+    ///         let data = scope.new_collection_from(1 .. 10).1;
+    ///
+    ///         let odds = data.filter(|x| x % 2 == 1);
+    ///         let evens = data.filter(|x| x % 2 == 0);
+    ///
+    ///         odds.concat(&evens)
+    ///             .assert_eq(&data);
+    ///     });
+    /// }
+    /// ```
+    pub fn assert_eq(&self, other: &Self)
+    where D: ::Data+Hashable,
+          G::Timestamp: Lattice+Ord
+    {
+        self.negate()
+            .concat(other)
+            .assert_empty();
+    }
+}
+
 /// Conversion to a differential dataflow Collection.
-pub trait AsCollection<G: Scope, D: Data, R: Diff> {
+pub trait AsCollection<G: Scope, D: Data, R: Monoid> {
     /// Converts the type to a differential dataflow collection.
     fn as_collection(&self) -> Collection<G, D, R>;
 }
 
-impl<G: Scope, D: Data, R: Diff> AsCollection<G, D, R> for Stream<G, (D, G::Timestamp, R)> {
+impl<G: Scope, D: Data, R: Monoid> AsCollection<G, D, R> for Stream<G, (D, G::Timestamp, R)> {
     fn as_collection(&self) -> Collection<G, D, R> {
         Collection::new(self.clone())
     }

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -59,7 +59,7 @@ pub struct DiffPair<R1, R2> {
 	pub element2: R2,
 }
 
-impl<R1: Diff, R2: Diff> DiffPair<R1, R2> {
+impl<R1, R2> DiffPair<R1, R2> {
 	/// Creates a new Diff pair from two elements.
 	#[inline(always)] pub fn new(elt1: R1, elt2: R2) -> Self {
 		DiffPair {
@@ -74,9 +74,9 @@ impl<R1: Diff, R2: Diff> Diff for DiffPair<R1, R2> {
 	#[inline(always)] fn zero() -> Self { DiffPair { element1: R1::zero(), element2: R2::zero() } }
 }
 
-impl<R1: Diff, R2: Diff> Add<DiffPair<R1, R2>> for DiffPair<R1, R2> {
-	type Output = Self;
-	#[inline(always)] fn add(self, rhs: Self) -> Self {
+impl<R1: Add, R2: Add> Add<DiffPair<R1, R2>> for DiffPair<R1, R2> {
+	type Output = DiffPair<<R1 as Add>::Output, <R2 as Add>::Output>;
+	#[inline(always)] fn add(self, rhs: Self) -> Self::Output {
 		DiffPair {
 			element1: self.element1 + rhs.element1,
 			element2: self.element2 + rhs.element2,
@@ -84,9 +84,9 @@ impl<R1: Diff, R2: Diff> Add<DiffPair<R1, R2>> for DiffPair<R1, R2> {
 	}
 }
 
-impl<R1: Diff, R2: Diff> Sub<DiffPair<R1, R2>> for DiffPair<R1, R2> {
-	type Output = DiffPair<R1, R2>;
-	#[inline(always)] fn sub(self, rhs: Self) -> Self {
+impl<R1: Sub, R2: Sub> Sub<DiffPair<R1, R2>> for DiffPair<R1, R2> {
+	type Output = DiffPair<<R1 as Sub>::Output, <R2 as Sub>::Output>;
+	#[inline(always)] fn sub(self, rhs: Self) -> Self::Output {
 		DiffPair {
 			element1: self.element1 - rhs.element1,
 			element2: self.element2 - rhs.element2,
@@ -94,9 +94,9 @@ impl<R1: Diff, R2: Diff> Sub<DiffPair<R1, R2>> for DiffPair<R1, R2> {
 	}
 }
 
-impl<R1: Diff, R2: Diff> Neg for DiffPair<R1, R2> {
-	type Output = Self;
-	#[inline(always)] fn neg(self) -> Self {
+impl<R1: Neg, R2: Neg> Neg for DiffPair<R1, R2> {
+	type Output = DiffPair<<R1 as Neg>::Output, <R2 as Neg>::Output>;
+	#[inline(always)] fn neg(self) -> Self::Output {
 		DiffPair {
 			element1: -self.element1,
 			element2: -self.element2,
@@ -104,8 +104,7 @@ impl<R1: Diff, R2: Diff> Neg for DiffPair<R1, R2> {
 	}
 }
 
-impl<T: Copy, R1: Diff+Mul<T>, R2: Diff+Mul<T>> Mul<T> for DiffPair<R1,R2>
-where <R1 as Mul<T>>::Output: Diff, <R2 as Mul<T>>::Output: Diff {
+impl<T: Copy, R1: Mul<T>, R2: Mul<T>> Mul<T> for DiffPair<R1,R2> {
 	type Output = DiffPair<<R1 as Mul<T>>::Output, <R2 as Mul<T>>::Output>;
 	fn mul(self, other: T) -> Self::Output {
 		DiffPair::new(

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -24,7 +24,7 @@ pub trait Monoid : Add<Self, Output=Self> + ::std::marker::Sized + Data + Copy {
 	/// This is primarily used by differential dataflow to know when it is safe to delete and update.
 	/// When a difference accumulates to zero, the difference has no effect on any accumulation and can
 	/// be removed.
-	fn is_zero(&self) -> bool;
+	fn is_zero(&self) -> bool { self.eq(&Self::zero()) }
 	/// The additive identity.
 	///
 	/// This method is primarily used by differential dataflow internals as part of consolidation, when

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -10,6 +10,8 @@ use std::ops::{Add, Sub, Neg, Mul};
 
 use ::Data;
 
+pub use self::Abelian as Diff;
+
 /// A type that can be treated as a difference.
 ///
 /// The mathematical requirements are, I believe, an Abelian group, in that we require addition, inverses,

--- a/src/input.rs
+++ b/src/input.rs
@@ -11,7 +11,8 @@ use timely::dataflow::operators::Input as TimelyInput;
 use timely::dataflow::operators::input::Handle;
 use timely::dataflow::scopes::ScopeParent;
 
-use ::{Data, Diff};
+use ::Data;
+use ::difference::Monoid;
 use collection::{Collection, AsCollection};
 
 /// Create a new collection and input handle to control the collection.
@@ -46,7 +47,7 @@ pub trait Input : TimelyInput {
     /// }
     /// ```
     fn new_collection<D, R>(&mut self) -> (InputSession<<Self as ScopeParent>::Timestamp, D, R>, Collection<Self, D, R>)
-    where D: Data, R: Diff;
+    where D: Data, R: Monoid;
     /// Create a new collection and input handle from initial data.
     ///
     /// # Examples
@@ -108,13 +109,13 @@ pub trait Input : TimelyInput {
     /// }
     /// ```
     fn new_collection_from_raw<D, R, I>(&mut self, data: I) -> (InputSession<<Self as ScopeParent>::Timestamp, D, R>, Collection<Self, D, R>)
-    where I: IntoIterator<Item=(D,<Self as ScopeParent>::Timestamp,R)>+'static, D: Data, R: Diff+Data;
+    where I: IntoIterator<Item=(D,<Self as ScopeParent>::Timestamp,R)>+'static, D: Data, R: Monoid+Data;
 }
 
 use lattice::Lattice;
 impl<G: TimelyInput> Input for G where <G as ScopeParent>::Timestamp: Lattice {
     fn new_collection<D, R>(&mut self) -> (InputSession<<G as ScopeParent>::Timestamp, D, R>, Collection<G, D, R>)
-    where D: Data, R: Diff{
+    where D: Data, R: Monoid{
 		let (handle, stream) = self.new_input();
 		(InputSession::from(handle), stream.as_collection())
     }
@@ -125,7 +126,7 @@ impl<G: TimelyInput> Input for G where <G as ScopeParent>::Timestamp: Lattice {
     fn new_collection_from_raw<D,R,I>(&mut self, data: I) -> (InputSession<<G as ScopeParent>::Timestamp, D, R>, Collection<G, D, R>)
     where
         D: Data,
-        R: Diff+Data,
+        R: Monoid+Data,
         I: IntoIterator<Item=(D,<Self as ScopeParent>::Timestamp,R)>+'static,
     {
         use timely::dataflow::operators::ToStream;
@@ -185,7 +186,7 @@ impl<G: TimelyInput> Input for G where <G as ScopeParent>::Timestamp: Lattice {
 ///		}).unwrap();
 /// }
 /// ```
-pub struct InputSession<T: Timestamp+Clone, D: Data, R: Diff> {
+pub struct InputSession<T: Timestamp+Clone, D: Data, R: Monoid> {
 	time: T,
 	buffer: Vec<(D, T, R)>,
 	handle: Handle<T,(D,T,R)>,
@@ -212,7 +213,7 @@ impl<T: Timestamp+Clone, D: Data> InputSession<T, D, isize> {
 //     pub fn remove(&mut self, element: D) { self.update(element,-1); }
 // }
 
-impl<T: Timestamp+Clone, D: Data, R: Diff> InputSession<T, D, R> {
+impl<T: Timestamp+Clone, D: Data, R: Monoid> InputSession<T, D, R> {
 
     /// Introduces a handle as collection.
     pub fn to_collection<G: TimelyInput>(&mut self, scope: &mut G) -> Collection<G, D, R>
@@ -300,7 +301,7 @@ impl<T: Timestamp+Clone, D: Data, R: Diff> InputSession<T, D, R> {
 	pub fn close(self) { }
 }
 
-impl<T: Timestamp+Clone, D: Data, R: Diff> Drop for InputSession<T, D, R> {
+impl<T: Timestamp+Clone, D: Data, R: Monoid> Drop for InputSession<T, D, R> {
 	fn drop(&mut self) {
 		self.flush();
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ use std::fmt::Debug;
 
 pub use collection::{Collection, AsCollection};
 pub use hashable::Hashable;
-pub use difference::Diff;
+pub use difference::Abelian as Diff;
 
 /// A composite trait for data types usable in differential dataflow.
 ///

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -8,7 +8,8 @@
 
 use timely::dataflow::Scope;
 
-use ::{Collection, Data, Diff, Hashable};
+use ::{Collection, Data, Hashable};
+use ::difference::Monoid;
 use operators::arrange::ArrangeBySelf;
 
 /// An extension method for consolidating weighted streams.
@@ -45,7 +46,7 @@ pub trait Consolidate<D: Data+Hashable> {
 impl<G: Scope, D, R> Consolidate<D> for Collection<G, D, R>
 where
     D: Data+Hashable,
-    R: Diff,
+    R: Monoid,
     G::Timestamp: ::lattice::Lattice+Ord,
  {
     fn consolidate(&self) -> Self {
@@ -90,7 +91,7 @@ pub trait ConsolidateStream<D: Data+Hashable> {
 impl<G: Scope, D, R> ConsolidateStream<D> for Collection<G, D, R>
 where
     D: Data+Hashable,
-    R: Diff,
+    R: Monoid,
     G::Timestamp: ::lattice::Lattice+Ord,
  {
     fn consolidate_stream(&self) -> Self {

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -19,14 +19,15 @@ use timely::dataflow::operators::Operator;
 use timely::dataflow::channels::pact::Pipeline;
 
 use lattice::Lattice;
-use ::{Data, Collection, Diff};
+use ::{Data, Collection};
+use ::difference::Monoid;
 use hashable::Hashable;
 use collection::AsCollection;
 use operators::arrange::{Arranged, ArrangeBySelf};
 use trace::{BatchReader, Cursor, TraceReader};
 
 /// Extension trait for the `count` differential dataflow method.
-pub trait CountTotal<G: Scope, K: Data, R: Diff> where G::Timestamp: TotalOrder+Lattice+Ord {
+pub trait CountTotal<G: Scope, K: Data, R: Monoid> where G::Timestamp: TotalOrder+Lattice+Ord {
     /// Counts the number of occurrences of each element.
     ///
     /// # Examples
@@ -50,7 +51,7 @@ pub trait CountTotal<G: Scope, K: Data, R: Diff> where G::Timestamp: TotalOrder+
     fn count_total(&self) -> Collection<G, (K, R), isize>;
 }
 
-impl<G: Scope, K: Data+Hashable, R: Diff> CountTotal<G, K, R> for Collection<G, K, R>
+impl<G: Scope, K: Data+Hashable, R: Monoid> CountTotal<G, K, R> for Collection<G, K, R>
 where G::Timestamp: TotalOrder+Lattice+Ord {
     fn count_total(&self) -> Collection<G, (K, R), isize> {
         self.arrange_by_self()
@@ -58,7 +59,7 @@ where G::Timestamp: TotalOrder+Lattice+Ord {
     }
 }
 
-impl<G: Scope, K: Data, R: Diff, T1> CountTotal<G, K, R> for Arranged<G, K, (), R, T1>
+impl<G: Scope, K: Data, R: Monoid, T1> CountTotal<G, K, R> for Arranged<G, K, (), R, T1>
 where
     G::Timestamp: TotalOrder+Lattice+Ord,
     T1: TraceReader<K, (), G::Timestamp, R>+Clone+'static,

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -260,7 +260,11 @@ pub trait GroupArranged<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestam
             })
         }
 
-    /// Solves for a new
+    /// Solves for output updates when presented with inputs and would-be outputs.
+    ///
+    /// Unlike `group_arranged`, this method may be called with an empty `input`,
+    /// and it may not be safe to index into the first element.
+    /// At least one of the two collections will be non-empty.
     fn group_solve<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>
         where
             V2: Data,

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -14,7 +14,8 @@
 //! elements are required.
 
 use hashable::Hashable;
-use ::{Data, Collection, Diff};
+use ::{Data, Collection};
+use ::difference::{Monoid, Abelian};
 
 use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
@@ -33,7 +34,7 @@ use trace::implementations::ord::OrdKeySpine as DefaultKeyTrace;
 use trace::TraceReader;
 
 /// Extension trait for the `group` differential dataflow method.
-pub trait Group<G: Scope, K: Data, V: Data, R: Diff> where G::Timestamp: Lattice+Ord {
+pub trait Group<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestamp: Lattice+Ord {
     /// Groups records by their first field, and applies reduction logic to the associated values.
     ///
     /// # Examples
@@ -56,7 +57,7 @@ pub trait Group<G: Scope, K: Data, V: Data, R: Diff> where G::Timestamp: Lattice
     ///     });
     /// }
     /// ```
-    fn group<L, V2: Data, R2: Diff>(&self, logic: L) -> Collection<G, (K, V2), R2>
+    fn group<L, V2: Data, R2: Abelian>(&self, logic: L) -> Collection<G, (K, V2), R2>
     where L: Fn(&K, &[(&V, R)], &mut Vec<(V2, R2)>)+'static;
 }
 
@@ -66,9 +67,9 @@ impl<G, K, V, R> Group<G, K, V, R> for Collection<G, (K, V), R>
         G::Timestamp: Lattice+Ord,
         K: Data+Hashable,
         V: Data,
-        R: Diff,
+        R: Monoid,
  {
-    fn group<L, V2: Data, R2: Diff>(&self, logic: L) -> Collection<G, (K, V2), R2>
+    fn group<L, V2: Data, R2: Abelian>(&self, logic: L) -> Collection<G, (K, V2), R2>
         where L: Fn(&K, &[(&V, R)], &mut Vec<(V2, R2)>)+'static {
         self.arrange_by_key()
             .group_arranged::<_,_,DefaultValTrace<_,_,_,_>,_>(logic)
@@ -76,13 +77,13 @@ impl<G, K, V, R> Group<G, K, V, R> for Collection<G, (K, V), R>
     }
 }
 
-impl<G: Scope, K: Data, V: Data, T1, R: Diff> Group<G, K, V, R> for Arranged<G, K, V, R, T1>
+impl<G: Scope, K: Data, V: Data, T1, R: Monoid> Group<G, K, V, R> for Arranged<G, K, V, R, T1>
 where
     G::Timestamp: Lattice+Ord,
     T1: TraceReader<K, V, G::Timestamp, R>+Clone+'static,
     T1::Batch: BatchReader<K, V, G::Timestamp, R>
 {
-    fn group<L, V2: Data, R2: Diff>(&self, logic: L) -> Collection<G, (K, V2), R2>
+    fn group<L, V2: Data, R2: Abelian>(&self, logic: L) -> Collection<G, (K, V2), R2>
         where L: Fn(&K, &[(&V, R)], &mut Vec<(V2, R2)>)+'static {
         self.group_arranged::<_,_,DefaultValTrace<_,_,_,_>,_>(logic)
             .as_collection(|k,v| (k.clone(), v.clone()))
@@ -90,7 +91,7 @@ where
 }
 
 /// Extension trait for the `distinct` differential dataflow method.
-pub trait Threshold<G: Scope, K: Data, R1: Diff> where G::Timestamp: Lattice+Ord {
+pub trait Threshold<G: Scope, K: Data, R1: Monoid> where G::Timestamp: Lattice+Ord {
     /// Transforms the multiplicity of records.
     ///
     /// The `threshold` function is obliged to map `R1::zero` to `R2::zero`, or at
@@ -115,7 +116,7 @@ pub trait Threshold<G: Scope, K: Data, R1: Diff> where G::Timestamp: Lattice+Ord
     ///     });
     /// }
     /// ```
-    fn threshold<R2: Diff, F: Fn(&K, R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2>;
+    fn threshold<R2: Abelian, F: Fn(&K, R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2>;
     /// Reduces the collection to one occurrence of each distinct element.
     ///
     /// # Examples
@@ -141,28 +142,28 @@ pub trait Threshold<G: Scope, K: Data, R1: Diff> where G::Timestamp: Lattice+Ord
     }
 }
 
-impl<G: Scope, K: Data+Hashable, R1: Diff> Threshold<G, K, R1> for Collection<G, K, R1>
+impl<G: Scope, K: Data+Hashable, R1: Monoid> Threshold<G, K, R1> for Collection<G, K, R1>
 where G::Timestamp: Lattice+Ord {
-    fn threshold<R2: Diff, F: Fn(&K,R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
+    fn threshold<R2: Abelian, F: Fn(&K,R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
         self.arrange_by_self()
             .group_arranged::<_,_,DefaultKeyTrace<_,_,_>,_>(move |k,s,t| t.push(((), thresh(k,s[0].1))))
             .as_collection(|k,_| k.clone())
     }
 }
 
-impl<G: Scope, K: Data, T1, R1: Diff> Threshold<G, K, R1> for Arranged<G, K, (), R1, T1>
+impl<G: Scope, K: Data, T1, R1: Monoid> Threshold<G, K, R1> for Arranged<G, K, (), R1, T1>
 where
     G::Timestamp: Lattice+Ord,
     T1: TraceReader<K, (), G::Timestamp, R1>+Clone+'static,
     T1::Batch: BatchReader<K, (), G::Timestamp, R1> {
-    fn threshold<R2: Diff, F: Fn(&K,R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
+    fn threshold<R2: Abelian, F: Fn(&K,R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
         self.group_arranged::<_,_,DefaultKeyTrace<_,_,_>,_>(move |k,s,t| t.push(((), thresh(k,s[0].1))))
             .as_collection(|k,_| k.clone())
     }
 }
 
 /// Extension trait for the `count` differential dataflow method.
-pub trait Count<G: Scope, K: Data, R: Diff> where G::Timestamp: Lattice+Ord {
+pub trait Count<G: Scope, K: Data, R: Monoid> where G::Timestamp: Lattice+Ord {
     /// Counts the number of occurrences of each element.
     ///
     /// # Examples
@@ -186,7 +187,7 @@ pub trait Count<G: Scope, K: Data, R: Diff> where G::Timestamp: Lattice+Ord {
     fn count(&self) -> Collection<G, (K, R), isize>;
 }
 
-impl<G: Scope, K: Data+Hashable, R: Diff> Count<G, K, R> for Collection<G, K, R>
+impl<G: Scope, K: Data+Hashable, R: Monoid> Count<G, K, R> for Collection<G, K, R>
 where
     G::Timestamp: Lattice+Ord,
 {
@@ -197,7 +198,7 @@ where
     }
 }
 
-impl<G: Scope, K: Data, T1, R: Diff> Count<G, K, R> for Arranged<G, K, (), R, T1>
+impl<G: Scope, K: Data, T1, R: Monoid> Count<G, K, R> for Arranged<G, K, (), R, T1>
 where
     G::Timestamp: Lattice+Ord,
     T1: TraceReader<K, (), G::Timestamp, R>+Clone+'static,
@@ -210,7 +211,7 @@ where
 }
 
 /// Extension trait for the `group_arranged` differential dataflow method.
-pub trait GroupArranged<G: Scope, K: Data, V: Data, R: Diff> where G::Timestamp: Lattice+Ord {
+pub trait GroupArranged<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestamp: Lattice+Ord {
     /// Applies `group` to arranged data, and returns an arrangement of output data.
     ///
     /// This method is used by the more ergonomic `group`, `distinct`, and `count` methods, although
@@ -245,7 +246,7 @@ pub trait GroupArranged<G: Scope, K: Data, V: Data, R: Diff> where G::Timestamp:
     fn group_arranged<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>
         where
             V2: Data,
-            R2: Diff,
+            R2: Abelian,
             T2: Trace<K, V2, G::Timestamp, R2>+'static,
             T2::Batch: Batch<K, V2, G::Timestamp, R2>,
             L: Fn(&K, &[(&V, R)], &mut Vec<(V2, R2)>)+'static
@@ -258,12 +259,12 @@ where
     G::Timestamp: Lattice+Ord,
     K: Data+Hashable,
     V: Data,
-    R: Diff,
+    R: Monoid,
 {
     fn group_arranged<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>
         where
             V2: Data,
-            R2: Diff,
+            R2: Abelian,
             T2: Trace<K, V2, G::Timestamp, R2>+'static,
             T2::Batch: Batch<K, V2, G::Timestamp, R2>,
             L: Fn(&K, &[(&V, R)], &mut Vec<(V2, R2)>)+'static
@@ -273,7 +274,7 @@ where
     }
 }
 
-impl<G: Scope, K: Data, V: Data, T1, R: Diff> GroupArranged<G, K, V, R> for Arranged<G, K, V, R, T1>
+impl<G: Scope, K: Data, V: Data, T1, R: Monoid> GroupArranged<G, K, V, R> for Arranged<G, K, V, R, T1>
 where
     G::Timestamp: Lattice+Ord,
     T1: TraceReader<K, V, G::Timestamp, R>+Clone+'static,
@@ -282,7 +283,7 @@ where
     fn group_arranged<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>
         where
             V2: Data,
-            R2: Diff,
+            R2: Abelian,
             T2: Trace<K, V2, G::Timestamp, R2>+'static,
             T2::Batch: Batch<K, V2, G::Timestamp, R2>,
             L: Fn(&K, &[(&V, R)], &mut Vec<(V2, R2)>)+'static {
@@ -580,7 +581,7 @@ fn sort_dedup<T: Ord>(list: &mut Vec<T>) {
 /// Consolidats a vector of (element, diff) by sorting by element and collapsing all tuples with the same element.
 /// Elements with diff 0 will be removed.
 #[inline(never)]
-fn consolidate<T: Ord, R: Diff>(list: &mut Vec<(T, R)>) {
+fn consolidate<T: Ord, R: Monoid>(list: &mut Vec<(T, R)>) {
     list.sort_by(|x,y| x.0.cmp(&y.0));
     for index in 1 .. list.len() {
         if list[index].0 == list[index-1].0 {
@@ -593,7 +594,7 @@ fn consolidate<T: Ord, R: Diff>(list: &mut Vec<(T, R)>) {
 
 /// Scans `vec[off..]` and consolidates differences of adjacent equivalent elements (after sorting by element).
 // #[inline(never)]
-pub fn consolidate_from<T: Ord+Clone, R: Diff>(vec: &mut Vec<(T, R)>, off: usize) {
+pub fn consolidate_from<T: Ord+Clone, R: Monoid>(vec: &mut Vec<(T, R)>, off: usize) {
 
     // We should do an insertion-sort like initial scan which builds up sorted, consolidated runs.
     // In a world where there are not many results, we may never even need to call in to merge sort.
@@ -622,8 +623,8 @@ where
     V1: Ord+Clone+'a,
     V2: Ord+Clone+'a,
     T: Lattice+Ord+Clone,
-    R1: Diff,
-    R2: Diff,
+    R1: Monoid,
+    R2: Abelian,
 {
     fn new() -> Self;
     fn compute<K, C1, C2, C3, L>(
@@ -649,7 +650,7 @@ where
 /// Implementation based on replaying historical and new updates together.
 mod history_replay {
 
-    use ::Diff;
+    use ::difference::{Monoid, Abelian};
     use lattice::Lattice;
     use trace::Cursor;
     use operators::ValueHistory;
@@ -664,8 +665,8 @@ mod history_replay {
         V1: Ord+Clone+'a,
         V2: Ord+Clone+'a,
         T: Lattice+Ord+Clone,
-        R1: Diff,
-        R2: Diff,
+        R1: Monoid,
+        R2: Monoid,
     {
         batch_history: ValueHistory<'a, V1, T, R1>,
         input_history: ValueHistory<'a, V1, T, R1>,
@@ -684,8 +685,8 @@ mod history_replay {
         V1: Ord+Clone,
         V2: Ord+Clone,
         T: Lattice+Ord+Clone,
-        R1: Diff,
-        R2: Diff,
+        R1: Monoid,
+        R2: Abelian,
     {
         fn new() -> Self {
             HistoryReplayer {

--- a/src/operators/iterate.rs
+++ b/src/operators/iterate.rs
@@ -201,7 +201,7 @@ impl<G: Scope, D: Data, R: Abelian> Deref for Variable<G, D, R> where G::Timesta
 /// use timely::dataflow::Scope;
 ///
 /// use differential_dataflow::input::Input;
-/// use differential_dataflow::operators::iterate::Variable;
+/// use differential_dataflow::operators::iterate::MonoidVariable;
 /// use differential_dataflow::operators::Consolidate;
 ///
 /// fn main() {
@@ -211,7 +211,7 @@ impl<G: Scope, D: Data, R: Abelian> Deref for Variable<G, D, R> where G::Timesta
 ///
 ///         scope.iterative::<u64,_,_>(|nested| {
 ///             let summary = Product::new(Default::default(), 1);
-///             let variable = MonoidVariable::new(summary);
+///             let variable = MonoidVariable::<_,usize,isize>::new(nested, summary);
 ///             let result = variable.map(|x| if x % 2 == 0 { x/2 } else { x })
 ///                                  .consolidate();
 ///             variable.set(&result)

--- a/src/operators/iterate.rs
+++ b/src/operators/iterate.rs
@@ -41,11 +41,12 @@ use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::operators::{Feedback, ConnectLoop, Map};
 use timely::dataflow::operators::feedback::Handle;
 
-use ::{Data, Collection, Diff};
+use ::{Data, Collection};
+use ::difference::Abelian;
 use lattice::Lattice;
 
 /// An extension trait for the `iterate` method.
-pub trait Iterate<G: Scope, D: Data, R: Diff> {
+pub trait Iterate<G: Scope, D: Data, R: Abelian> {
     /// Iteratively apply `logic` to the source collection until convergence.
     ///
     /// Importantly, this method does not automatically consolidate results.
@@ -81,7 +82,7 @@ pub trait Iterate<G: Scope, D: Data, R: Diff> {
             for<'a> F: FnOnce(&Collection<Iterative<'a, G, u64>, D, R>)->Collection<Iterative<'a, G, u64>, D, R>;
 }
 
-impl<G: Scope, D: Ord+Data+Debug, R: Diff> Iterate<G, D, R> for Collection<G, D, R> {
+impl<G: Scope, D: Ord+Data+Debug, R: Abelian> Iterate<G, D, R> for Collection<G, D, R> {
     fn iterate<F>(&self, logic: F) -> Collection<G, D, R>
         where G::Timestamp: Lattice,
               for<'a> F: FnOnce(&Collection<Iterative<'a, G, u64>, D, R>)->Collection<Iterative<'a, G, u64>, D, R> {
@@ -138,7 +139,7 @@ impl<G: Scope, D: Ord+Data+Debug, R: Diff> Iterate<G, D, R> for Collection<G, D,
 ///     })
 /// }
 /// ```
-pub struct Variable<G: Scope, D: Data, R: Diff>
+pub struct Variable<G: Scope, D: Data, R: Abelian>
 where G::Timestamp: Lattice {
     collection: Collection<G, D, R>,
     feedback: Handle<G, (D, G::Timestamp, R)>,
@@ -146,7 +147,7 @@ where G::Timestamp: Lattice {
     step: <G::Timestamp as Timestamp>::Summary,
 }
 
-impl<G: Scope, D: Data, R: Diff> Variable<G, D, R> where G::Timestamp: Lattice {
+impl<G: Scope, D: Data, R: Abelian> Variable<G, D, R> where G::Timestamp: Lattice {
     /// Creates a new initially empty `Variable`.
     pub fn new(scope: &mut G, step: <G::Timestamp as Timestamp>::Summary) -> Self {
         use collection::AsCollection;
@@ -175,7 +176,7 @@ impl<G: Scope, D: Data, R: Diff> Variable<G, D, R> where G::Timestamp: Lattice {
     }
 }
 
-impl<G: Scope, D: Data, R: Diff> Deref for Variable<G, D, R> where G::Timestamp: Lattice {
+impl<G: Scope, D: Data, R: Abelian> Deref for Variable<G, D, R> where G::Timestamp: Lattice {
     type Target = Collection<G, D, R>;
     fn deref(&self) -> &Self::Target {
         &self.collection

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -9,14 +9,15 @@ use timely::dataflow::operators::Operator;
 use timely::dataflow::channels::pact::Pipeline;
 
 use lattice::Lattice;
-use ::{Data, Collection, Diff};
+use ::{Data, Collection};
+use ::difference::{Monoid, Abelian};
 use hashable::Hashable;
 use collection::AsCollection;
 use operators::arrange::{Arranged, ArrangeBySelf};
 use trace::{BatchReader, Cursor, TraceReader};
 
 /// Extension trait for the `distinct` differential dataflow method.
-pub trait ThresholdTotal<G: Scope, K: Data, R: Diff> where G::Timestamp: TotalOrder+Lattice+Ord {
+pub trait ThresholdTotal<G: Scope, K: Data, R: Monoid> where G::Timestamp: TotalOrder+Lattice+Ord {
     /// Reduces the collection to one occurrence of each distinct element.
     ///
     /// # Examples
@@ -37,7 +38,7 @@ pub trait ThresholdTotal<G: Scope, K: Data, R: Diff> where G::Timestamp: TotalOr
     ///     });
     /// }
     /// ```
-    fn threshold_total<R2: Diff, F: Fn(&K,R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2>;
+    fn threshold_total<R2: Abelian, F: Fn(&K,R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2>;
     /// Reduces the collection to one occurrence of each distinct element.
     ///
     /// This reduction only tests whether the weight associated with a record is non-zero, and otherwise
@@ -67,21 +68,21 @@ pub trait ThresholdTotal<G: Scope, K: Data, R: Diff> where G::Timestamp: TotalOr
     }
 }
 
-impl<G: Scope, K: Data+Hashable, R: Diff> ThresholdTotal<G, K, R> for Collection<G, K, R>
+impl<G: Scope, K: Data+Hashable, R: Monoid> ThresholdTotal<G, K, R> for Collection<G, K, R>
 where G::Timestamp: TotalOrder+Lattice+Ord {
-    fn threshold_total<R2: Diff, F: Fn(&K,R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
+    fn threshold_total<R2: Abelian, F: Fn(&K,R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
         self.arrange_by_self()
             .threshold_total(thresh)
     }
 }
 
-impl<G: Scope, K: Data, R: Diff, T1> ThresholdTotal<G, K, R> for Arranged<G, K, (), R, T1>
+impl<G: Scope, K: Data, R: Monoid, T1> ThresholdTotal<G, K, R> for Arranged<G, K, (), R, T1>
 where
     G::Timestamp: TotalOrder+Lattice+Ord,
     T1: TraceReader<K, (), G::Timestamp, R>+Clone+'static,
     T1::Batch: BatchReader<K, (), G::Timestamp, R> {
 
-    fn threshold_total<R2: Diff, F:Fn(&K,R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
+    fn threshold_total<R2: Abelian, F:Fn(&K,R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
 
         let mut trace = self.trace.clone();
         let mut buffer = Vec::new();

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -2,13 +2,13 @@
 
 use timely::progress::frontier::Antichain;
 
-use ::Diff;
+use ::difference::Monoid;
 
 use lattice::Lattice;
 use trace::{Batch, Batcher, Builder};
 
 /// Creates batches from unordered tuples.
-pub struct MergeBatcher<K: Ord, V: Ord, T: Ord, R: Diff, B: Batch<K, V, T, R>> {
+pub struct MergeBatcher<K: Ord, V: Ord, T: Ord, R: Monoid, B: Batch<K, V, T, R>> {
     sorter: MergeSorter<(K, V), T, R>,
     lower: Vec<T>,
     frontier: Antichain<T>,
@@ -20,7 +20,7 @@ where
     K: Ord+Clone,
     V: Ord+Clone,
     T: Lattice+Ord+Clone,
-    R: Diff,
+    R: Monoid,
     B: Batch<K, V, T, R>,
 {
     fn new() -> Self {
@@ -170,12 +170,12 @@ unsafe fn push_unchecked<T>(vec: &mut Vec<T>, element: T) {
     vec.set_len(len + 1);
 }
 
-pub struct MergeSorter<D: Ord, T: Ord, R: Diff> {
+pub struct MergeSorter<D: Ord, T: Ord, R: Monoid> {
     queue: Vec<Vec<Vec<(D, T, R)>>>,    // each power-of-two length list of allocations.
     stash: Vec<Vec<(D, T, R)>>,
 }
 
-impl<D: Ord, T: Ord, R: Diff> MergeSorter<D, T, R> {
+impl<D: Ord, T: Ord, R: Monoid> MergeSorter<D, T, R> {
 
     #[inline]
     pub fn new() -> Self { MergeSorter { queue: Vec::new(), stash: Vec::new() } }

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -10,7 +10,7 @@
 
 use std::rc::Rc;
 
-use ::Diff;
+use ::difference::Monoid;
 use lattice::Lattice;
 
 use trace::layers::{Trie, TupleBuilder};
@@ -52,7 +52,7 @@ pub struct OrdValBatch<K: Ord, V: Ord, T: Lattice, R> {
 }
 
 impl<K, V, T, R> BatchReader<K, V, T, R> for OrdValBatch<K, V, T, R>
-where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
+where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Monoid {
 	type Cursor = OrdValCursor<V, T, R>;
 	fn cursor(&self) -> Self::Cursor { OrdValCursor { cursor: self.layer.cursor() } }
 	fn len(&self) -> usize { <OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>> as Trie>::tuples(&self.layer) }
@@ -60,7 +60,7 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, 
 }
 
 impl<K, V, T, R> Batch<K, V, T, R> for OrdValBatch<K, V, T, R>
-where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Diff {
+where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Monoid {
 	type Batcher = MergeBatcher<K, V, T, R, Self>;
 	type Builder = OrdValBuilder<K, V, T, R>;
 	type Merger = OrdValMerger<K, V, T, R>;
@@ -71,7 +71,7 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fm
 }
 
 impl<K, V, T, R> OrdValBatch<K, V, T, R>
-where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Diff {
+where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Monoid {
 	fn advance_builder_from(layer: &mut OrderedBuilder<K, OrderedBuilder<V, OrderedLeafBuilder<T, R>>>, frontier: &[T], key_pos: usize) {
 
 		let key_start = key_pos;
@@ -175,7 +175,7 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fm
 }
 
 /// State for an in-progress merge.
-pub struct OrdValMerger<K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Diff> {
+pub struct OrdValMerger<K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Monoid> {
 	// first batch, and position therein.
 	lower1: usize,
 	upper1: usize,
@@ -188,7 +188,7 @@ pub struct OrdValMerger<K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+O
 }
 
 impl<K, V, T, R> Merger<K, V, T, R, OrdValBatch<K, V, T, R>> for OrdValMerger<K, V, T, R>
-where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Diff {
+where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Monoid {
 	fn new(batch1: &OrdValBatch<K, V, T, R>, batch2: &OrdValBatch<K, V, T, R>) -> Self {
 
 		assert!(batch1.upper() == batch2.lower());
@@ -254,12 +254,12 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fm
 
 /// A cursor for navigating a single layer.
 #[derive(Debug)]
-pub struct OrdValCursor<V: Ord+Clone, T: Lattice+Ord+Clone, R: Diff> {
+pub struct OrdValCursor<V: Ord+Clone, T: Lattice+Ord+Clone, R: Monoid> {
 	cursor: OrderedCursor<OrderedLayer<V, OrderedLeaf<T, R>>>,
 }
 
 impl<K, V, T, R> Cursor<K, V, T, R> for OrdValCursor<V, T, R>
-where K: Ord+Clone, V: Ord+Clone, T: Lattice+Ord+Clone, R: Diff {
+where K: Ord+Clone, V: Ord+Clone, T: Lattice+Ord+Clone, R: Monoid {
 
 	type Storage = OrdValBatch<K, V, T, R>;
 
@@ -284,12 +284,12 @@ where K: Ord+Clone, V: Ord+Clone, T: Lattice+Ord+Clone, R: Diff {
 
 
 /// A builder for creating layers from unsorted update tuples.
-pub struct OrdValBuilder<K: Ord, V: Ord, T: Ord+Lattice, R: Diff> {
+pub struct OrdValBuilder<K: Ord, V: Ord, T: Ord+Lattice, R: Monoid> {
 	builder: OrderedBuilder<K, OrderedBuilder<V, OrderedLeafBuilder<T, R>>>,
 }
 
 impl<K, V, T, R> Builder<K, V, T, R, OrdValBatch<K, V, T, R>> for OrdValBuilder<K, V, T, R>
-where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Diff {
+where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Monoid {
 
 	fn new() -> Self {
 		OrdValBuilder {
@@ -329,7 +329,7 @@ pub struct OrdKeyBatch<K: Ord, T: Lattice, R> {
 }
 
 impl<K, T, R> BatchReader<K, (), T, R> for OrdKeyBatch<K, T, R>
-where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
+where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Monoid {
 	type Cursor = OrdKeyCursor<T, R>;
 	fn cursor(&self) -> Self::Cursor {
 		OrdKeyCursor {
@@ -343,7 +343,7 @@ where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
 }
 
 impl<K, T, R> Batch<K, (), T, R> for OrdKeyBatch<K, T, R>
-where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
+where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Monoid {
 	type Batcher = MergeBatcher<K, (), T, R, Self>;
 	type Builder = OrdKeyBuilder<K, T, R>;
 	type Merger = OrdKeyMerger<K, T, R>;
@@ -354,7 +354,7 @@ where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
 }
 
 impl<K, T, R> OrdKeyBatch<K, T, R>
-where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
+where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Monoid {
 	fn advance_builder_from(layer: &mut OrderedBuilder<K, OrderedLeafBuilder<T, R>>, frontier: &[T], key_pos: usize) {
 
 		let key_start = key_pos;
@@ -428,7 +428,7 @@ where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
 }
 
 /// State for an in-progress merge.
-pub struct OrdKeyMerger<K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff> {
+pub struct OrdKeyMerger<K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Monoid> {
 	// first batch, and position therein.
 	lower1: usize,
 	upper1: usize,
@@ -441,7 +441,7 @@ pub struct OrdKeyMerger<K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: D
 }
 
 impl<K, T, R> Merger<K, (), T, R, OrdKeyBatch<K, T, R>> for OrdKeyMerger<K, T, R>
-where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
+where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Monoid {
 	fn new(batch1: &OrdKeyBatch<K, T, R>, batch2: &OrdKeyBatch<K, T, R>) -> Self {
 
 		assert!(batch1.upper() == batch2.lower());
@@ -507,13 +507,13 @@ where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
 
 /// A cursor for navigating a single layer.
 #[derive(Debug)]
-pub struct OrdKeyCursor<T: Lattice+Ord+Clone, R: Diff> {
+pub struct OrdKeyCursor<T: Lattice+Ord+Clone, R: Monoid> {
 	valid: bool,
 	empty: (),
 	cursor: OrderedCursor<OrderedLeaf<T, R>>,
 }
 
-impl<K: Ord+Clone, T: Lattice+Ord+Clone, R: Diff> Cursor<K, (), T, R> for OrdKeyCursor<T, R> {
+impl<K: Ord+Clone, T: Lattice+Ord+Clone, R: Monoid> Cursor<K, (), T, R> for OrdKeyCursor<T, R> {
 
 	type Storage = OrdKeyBatch<K, T, R>;
 
@@ -538,12 +538,12 @@ impl<K: Ord+Clone, T: Lattice+Ord+Clone, R: Diff> Cursor<K, (), T, R> for OrdKey
 
 
 /// A builder for creating layers from unsorted update tuples.
-pub struct OrdKeyBuilder<K: Ord, T: Ord+Lattice, R: Diff> {
+pub struct OrdKeyBuilder<K: Ord, T: Ord+Lattice, R: Monoid> {
 	builder: OrderedBuilder<K, OrderedLeafBuilder<T, R>>,
 }
 
 impl<K, T, R> Builder<K, (), T, R, OrdKeyBatch<K, T, R>> for OrdKeyBuilder<K, T, R>
-where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Diff {
+where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Monoid {
 
 	fn new() -> Self {
 		OrdKeyBuilder {

--- a/src/trace/implementations/spine_fueled.rs
+++ b/src/trace/implementations/spine_fueled.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::Debug;
 
-use ::Diff;
+use ::difference::Monoid;
 use lattice::Lattice;
 use trace::{Batch, BatchReader, Trace, TraceReader};
 // use trace::cursor::cursor_list::CursorList;
@@ -95,7 +95,7 @@ impl<K, V, T: Eq, R, B: Batch<K, V, T, R>> MergeState<K, V, T, R, B> {
 /// A spine maintains a small number of immutable collections of update tuples, merging the collections when
 /// two have similar sizes. In this way, it allows the addition of more tuples, which may then be merged with
 /// other immutable collections.
-pub struct Spine<K, V, T: Lattice+Ord, R: Diff, B: Batch<K, V, T, R>> {
+pub struct Spine<K, V, T: Lattice+Ord, R: Monoid, B: Batch<K, V, T, R>> {
     operator: OperatorInfo,
     logger: Option<::logging::Logger>,
     phantom: ::std::marker::PhantomData<(K, V, R)>,
@@ -112,7 +112,7 @@ where
     K: Ord+Clone,           // Clone is required by `batch::advance_*` (in-place could remove).
     V: Ord+Clone,           // Clone is required by `batch::advance_*` (in-place could remove).
     T: Lattice+Ord+Clone+Debug,   // Clone is required by `advance_by` and `batch::advance_*`.
-    R: Diff,
+    R: Monoid,
     B: Batch<K, V, T, R>+Clone+'static,
 {
     type Batch = B;
@@ -202,7 +202,7 @@ where
     K: Ord+Clone,
     V: Ord+Clone,
     T: Lattice+Ord+Clone+Debug,
-    R: Diff,
+    R: Monoid,
     B: Batch<K, V, T, R>+Clone+'static,
 {
 
@@ -248,7 +248,7 @@ where
     K: Ord+Clone,
     V: Ord+Clone,
     T: Lattice+Ord+Clone+Debug,
-    R: Diff,
+    R: Monoid,
     B: Batch<K, V, T, R>,
 {
     /// Allocates a fueled `Spine` with a specified effort multiplier.

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -13,7 +13,7 @@ pub mod implementations;
 pub mod layers;
 pub mod wrappers;
 
-use ::Diff;
+use ::difference::Monoid;
 pub use self::cursor::Cursor;
 pub use self::description::Description;
 
@@ -453,12 +453,12 @@ pub mod abomonated_blanket_impls {
 
 
 /// Scans `vec[off..]` and consolidates differences of adjacent equivalent elements.
-pub fn consolidate<T: Ord+Clone, R: Diff>(vec: &mut Vec<(T, R)>, off: usize) {
+pub fn consolidate<T: Ord+Clone, R: Monoid>(vec: &mut Vec<(T, R)>, off: usize) {
 	consolidate_by(vec, off, |x,y| x.cmp(&y));
 }
 
 /// Scans `vec[off..]` and consolidates differences of adjacent equivalent elements.
-pub fn consolidate_by<T: Eq+Clone, L: Fn(&T, &T)->::std::cmp::Ordering, R: Diff>(vec: &mut Vec<(T, R)>, off: usize, cmp: L) {
+pub fn consolidate_by<T: Eq+Clone, L: Fn(&T, &T)->::std::cmp::Ordering, R: Monoid>(vec: &mut Vec<(T, R)>, off: usize, cmp: L) {
 	vec[off..].sort_by(|x,y| cmp(&x.0, &y.0));
 	for index in (off + 1) .. vec.len() {
 		if vec[index].0 == vec[index - 1].0 {


### PR DESCRIPTION
This shifts the `Diff` trait to be an alias of `Abelian`, corresponding to an Abelian (commutative) group. There is also a `Monoid` trait corresponding to a commutative monoid. `Abelian` is `Monoid` with the addition of the `Sub` and `Neg` traits.

In many cases `Monoid` is sufficient, and `Abelian` is only required where subtraction is needed. Operators like `join` do not require subtraction, though `antijoin` does in its current implementation.

More generally, we should think about shifting some of the uses of negation to other forms. Iteration requires negation to correct for its initial input, but this is only required when we have an initial input and not otherwise.

cc @eoxxs 