### PR TITLE
Monoid simplifications

### DIFF
--- a/examples/monoid-bfs.rs
+++ b/examples/monoid-bfs.rs
@@ -28,13 +28,12 @@ pub struct MinSum {
     value: u32,
 }
 
-use std::ops::{Add, Mul};
+use std::ops::{AddAssign, Mul};
 use differential_dataflow::difference::Monoid;
 
-impl Add<Self> for MinSum {
-    type Output = Self;
-    fn add(self, rhs: Self) -> Self {
-        MinSum { value: std::cmp::min(self.value, rhs.value) }
+impl AddAssign<Self> for MinSum {
+    fn add_assign(&mut self, rhs: Self) {
+        self.value = std::cmp::min(self.value, rhs.value);
     }
 }
 

--- a/src/algorithms/identifiers.rs
+++ b/src/algorithms/identifiers.rs
@@ -72,13 +72,13 @@ where
                         // keep round-positive records as changes.
                         let ((round, record), count) = &input[0];
                         if *round > 0 {
-                            output.push(((0, record.clone()), -*count));
-                            output.push(((*round, record.clone()), *count));
+                            output.push(((0, record.clone()), -count.clone()));
+                            output.push(((*round, record.clone()), count.clone()));
                         }
                         // if any losers, increment their rounds.
                         for ((round, record), count) in input[1..].iter() {
-                            output.push(((0, record.clone()), -*count));
-                            output.push(((*round+1, record.clone()), *count));
+                            output.push(((0, record.clone()), -count.clone()));
+                            output.push(((*round+1, record.clone()), count.clone()));
                         }
                     })
                     .map(|(_hash, pair)| pair)

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -139,7 +139,7 @@ impl<G: Scope, D: Data, R: Monoid> Collection<G, D, R> where G::Timestamp: Data 
               I::Item: Data,
               L: Fn(D) -> I + 'static {
         self.inner
-            .flat_map(move |(data, time, delta)| logic(data).into_iter().map(move |x| (x, time.clone(), delta)))
+            .flat_map(move |(data, time, delta)| logic(data).into_iter().map(move |x| (x, time.clone(), delta.clone())))
             .as_collection()
     }
     /// Creates a new collection containing those input records satisfying the supplied predicate.
@@ -232,7 +232,7 @@ impl<G: Scope, D: Data, R: Monoid> Collection<G, D, R> where G::Timestamp: Data 
           L: Fn(D)->I+'static,
     {
         self.inner
-            .flat_map(move |(x, t, d)| logic(x).into_iter().map(move |(x,d2)| (x, t.clone(), d2 * d)))
+            .flat_map(move |(x, t, d)| logic(x).into_iter().map(move |(x,d2)| (x, t.clone(), d2 * d.clone())))
             .as_collection()
     }
 
@@ -527,7 +527,7 @@ impl<G: Scope, D: Data, R: Abelian> Collection<G, D, R> where G::Timestamp: Data
     /// ```
     pub fn negate(&self) -> Collection<G, D, R> {
         self.inner
-            .map_in_place(|x| x.2 = -x.2)
+            .map_in_place(|x| x.2 = -x.2.clone())
             .as_collection()
     }
 

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -42,17 +42,14 @@ pub trait Abelian : Monoid + Neg<Output=Self> { }
 impl<T: Monoid + Neg<Output=Self>> Abelian for T { }
 
 impl Monoid for isize {
-	#[inline(always)] fn is_zero(&self) -> bool { *self == 0 }
 	#[inline(always)] fn zero() -> Self { 0 }
 }
 
 impl Monoid for i64 {
-	#[inline(always)] fn is_zero(&self) -> bool { *self == 0 }
 	#[inline(always)] fn zero() -> Self { 0 }
 }
 
 impl Monoid for i32 {
-	#[inline(always)] fn is_zero(&self) -> bool { *self == 0 }
 	#[inline(always)] fn zero() -> Self { 0 }
 }
 
@@ -81,8 +78,12 @@ impl<R1, R2> DiffPair<R1, R2> {
 }
 
 impl<R1: Monoid, R2: Monoid> Monoid for DiffPair<R1, R2> {
-	#[inline(always)] fn is_zero(&self) -> bool { self.element1.is_zero() && self.element2.is_zero() }
-	#[inline(always)] fn zero() -> Self { DiffPair { element1: R1::zero(), element2: R2::zero() } }
+	#[inline(always)] fn zero() -> Self {
+		DiffPair {
+			element1: R1::zero(),
+			element2: R2::zero(),
+		}
+	}
 }
 
 impl<R1: AddAssign, R2: AddAssign> AddAssign<DiffPair<R1, R2>> for DiffPair<R1, R2> {

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -6,7 +6,7 @@
 //! dataflow collections would then track for each record the total of counts and heights, which allows
 //! us to track something like the average.
 
-use std::ops::{Add, Sub, Neg, Mul};
+use std::ops::{Add, AddAssign, Sub, Neg, Mul};
 
 use ::Data;
 
@@ -18,7 +18,7 @@ pub use self::Abelian as Diff;
 /// and almost certainly use commutativity somewhere (it isn't clear if it is a requirement, as it isn't
 /// clear that there are semantics other than "we accumulate your differences"; I suspect we don't always
 /// accumulate them in the right order, so commutativity is important until we conclude otherwise).
-pub trait Monoid : Add<Self, Output=Self> + ::std::marker::Sized + Data + Copy {
+pub trait Monoid : Add<Self, Output=Self> + AddAssign + ::std::marker::Sized + Data + Clone {
 	/// Returns true if the element is the additive identity.
 	///
 	/// This is primarily used by differential dataflow to know when it is safe to delete and update.
@@ -92,6 +92,13 @@ impl<R1: Add, R2: Add> Add<DiffPair<R1, R2>> for DiffPair<R1, R2> {
 			element1: self.element1 + rhs.element1,
 			element2: self.element2 + rhs.element2,
 		}
+	}
+}
+
+impl<R1: AddAssign, R2: AddAssign> AddAssign<DiffPair<R1, R2>> for DiffPair<R1, R2> {
+	#[inline(always)] fn add_assign(&mut self, rhs: Self) {
+		self.element1 += rhs.element1;
+		self.element2 += rhs.element2;
 	}
 }
 

--- a/src/operators/arrange.rs
+++ b/src/operators/arrange.rs
@@ -639,8 +639,8 @@ impl<G: Scope, K, V, R, T> Arranged<G, K, V, R, T> where G::Timestamp: Lattice+O
                                     if !active.is_empty() && active[0].1.less_than(&time) {
                                         ::trace::consolidate(&mut working2, 0);
                                         while !active.is_empty() && active[0].1.less_than(&time) {
-                                            for &(ref val, count) in working2.iter() {
-                                                session.give((key.clone(), val.clone(), active[0].1.clone(), count));
+                                            for &(ref val, ref count) in working2.iter() {
+                                                session.give((key.clone(), val.clone(), active[0].1.clone(), count.clone()));
                                             }
                                             active = &active[1..];
                                         }
@@ -650,9 +650,8 @@ impl<G: Scope, K, V, R, T> Arranged<G, K, V, R, T> where G::Timestamp: Lattice+O
                                 if !active.is_empty() {
                                     ::trace::consolidate(&mut working2, 0);
                                     while !active.is_empty() {
-                                        for &(ref val, count) in working2.iter() {
-                                            let count: R = count;
-                                            session.give((key.clone(), val.clone(), active[0].1.clone(), count));
+                                        for &(ref val, ref count) in working2.iter() {
+                                            session.give((key.clone(), val.clone(), active[0].1.clone(), count.clone()));
                                         }
                                         active = &active[1..];
                                     }

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -110,8 +110,8 @@ where
                         vector.sort_unstable_by(|x,y| (&x.0, &x.1).cmp(&(&y.0, &y.1)));
                         for index in 1 .. vector.len() {
                             if vector[index].0 == vector[index - 1].0 && vector[index].1 == vector[index - 1].1 {
-                                vector[index].2 = vector[index].2 + vector[index - 1].2;
-                                vector[index - 1].2 = R::zero();
+                                let prev = ::std::mem::replace(&mut vector[index - 1].2, R::zero());
+                                vector[index].2 += prev;
                             }
                         }
                         vector.retain(|x| !x.2.is_zero());

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -87,17 +87,17 @@ where
 
                         trace_cursor.seek_key(&trace_storage, key);
                         if trace_cursor.key_valid(&trace_storage) && trace_cursor.key(&trace_storage) == key {
-                            trace_cursor.map_times(&trace_storage, |_, diff| count = count + diff);
+                            trace_cursor.map_times(&trace_storage, |_, diff| count += diff);
                         }
 
                         batch_cursor.map_times(&batch, |time, diff| {
 
                             if !count.is_zero() {
-                                session.give(((key.clone(), count), time.clone(), -1));
+                                session.give(((key.clone(), count.clone()), time.clone(), -1));
                             }
-                            count = count + diff;
+                            count += diff;
                             if !count.is_zero() {
-                                session.give(((key.clone(), count), time.clone(), 1));
+                                session.give(((key.clone(), count.clone()), time.clone(), 1));
                             }
 
                         });

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -346,7 +346,7 @@ impl<G, K, V, R1, T1> JoinCore<G, K, V, R1> for Arranged<G,K,V,R1,T1>
                         for batch1 in input1_buffer.drain(..) {
                             let (trace2_cursor, trace2_storage) = trace2.cursor_through(&acknowledged2[..]).unwrap();
                             let batch1_cursor = batch1.cursor();
-                            todo1.push(Deferred::new(trace2_cursor, trace2_storage, batch1_cursor, batch1.clone(), capability.clone(), |r2,r1| *r1 * *r2));
+                            todo1.push(Deferred::new(trace2_cursor, trace2_storage, batch1_cursor, batch1.clone(), capability.clone(), |r2,r1| (r1.clone()) * (r2.clone())));
                             debug_assert!(batch1.description().lower() == &acknowledged1[..]);
                             acknowledged1 = batch1.description().upper().to_vec();
                         }
@@ -361,7 +361,7 @@ impl<G, K, V, R1, T1> JoinCore<G, K, V, R1> for Arranged<G,K,V,R1,T1>
                         for batch2 in input2_buffer.drain(..) {
                             let (trace1_cursor, trace1_storage) = trace1.cursor_through(&acknowledged1[..]).unwrap();
                             let batch2_cursor = batch2.cursor();
-                            todo2.push(Deferred::new(trace1_cursor, trace1_storage, batch2_cursor, batch2.clone(), capability.clone(), |r1,r2| *r1 * *r2));
+                            todo2.push(Deferred::new(trace1_cursor, trace1_storage, batch2_cursor, batch2.clone(), capability.clone(), |r1,r2| (r1.clone()) * (r2.clone())));
                             debug_assert!(batch2.description().lower() == &acknowledged2[..]);
                             acknowledged2 = batch2.description().upper().to_vec();
                         }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -76,7 +76,7 @@ impl<'a, V:'a, T, R> EditList<'a, V, T, R> where T: Ord+Clone, R: Monoid {
             let lower = if index == 0 { 0 } else { self.values[index-1].1 };
             let upper = self.values[index].1;
             for edit in lower .. upper {
-                logic(&self.values[index].0, &self.edits[edit].0, self.edits[edit].1);
+                logic(&self.values[index].0, &self.edits[edit].0, self.edits[edit].1.clone());
             }
         }
     }
@@ -173,7 +173,7 @@ where
     fn time(&self) -> Option<&T> { self.replay.history.last().map(|x| &x.0) }
     fn meet(&self) -> Option<&T> { self.replay.history.last().map(|x| &x.1) }
     fn edit(&self) -> Option<(&V, &T, R)> {
-        self.replay.history.last().map(|&(ref t, _, v, e)| (self.replay.edits.values[v].0, t, self.replay.edits.edits[e].1))
+        self.replay.history.last().map(|&(ref t, _, v, e)| (self.replay.edits.values[v].0, t, self.replay.edits.edits[e].1.clone()))
     }
 
     fn buffer(&self) -> &[((&'storage V, T), R)] {
@@ -182,7 +182,7 @@ where
 
     fn step(&mut self) {
         let (time, _, value_index, edit_offset) = self.replay.history.pop().unwrap();
-        self.replay.buffer.push(((self.replay.edits.values[value_index].0, time), self.replay.edits.edits[edit_offset].1));
+        self.replay.buffer.push(((self.replay.edits.values[value_index].0, time), self.replay.edits.edits[edit_offset].1.clone()));
     }
     fn step_while_time_is(&mut self, time: &T) -> bool {
         let mut found = false;

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -106,15 +106,15 @@ where
                         // Compute the multiplicity of this key before the current batch.
                         trace_cursor.seek_key(&trace_storage, key);
                         if trace_cursor.key_valid(&trace_storage) && trace_cursor.key(&trace_storage) == key {
-                            trace_cursor.map_times(&trace_storage, |_, diff| count = count + diff);
+                            trace_cursor.map_times(&trace_storage, |_, diff| count += diff);
                         }
 
                         // Apply `thresh` both before and after `diff` is applied to `count`.
                         // If the result is non-zero, send it along.
                         batch_cursor.map_times(&batch, |time, diff| {
-                            let old_weight = if count.is_zero() { R2::zero() } else { thresh(key, count) };
-                            count = count + diff;
-                            let new_weight = if count.is_zero() { R2::zero() } else { thresh(key, count) };
+                            let old_weight = if count.is_zero() { R2::zero() } else { thresh(key, count.clone()) };
+                            count += diff;
+                            let new_weight = if count.is_zero() { R2::zero() } else { thresh(key, count.clone()) };
                             let difference = new_weight - old_weight;
                             if !difference.is_zero() {
                                 session.give((key.clone(), time.clone(), difference));

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -112,10 +112,15 @@ where
                         // Apply `thresh` both before and after `diff` is applied to `count`.
                         // If the result is non-zero, send it along.
                         batch_cursor.map_times(&batch, |time, diff| {
+
+                            // Determine old and new weights.
+                            // If a count is zero, the weight must be zero.
                             let old_weight = if count.is_zero() { R2::zero() } else { thresh(key, count.clone()) };
                             count += diff;
                             let new_weight = if count.is_zero() { R2::zero() } else { thresh(key, count.clone()) };
-                            let difference = new_weight - old_weight;
+
+                            let mut difference = -old_weight;
+                            difference += new_weight;
                             if !difference.is_zero() {
                                 session.give((key.clone(), time.clone(), difference));
                             }

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -281,11 +281,11 @@ impl<D: Ord, T: Ord, R: Monoid> MergeSorter<D, T, R> {
                     Ordering::Less    => { unsafe { push_unchecked(&mut result, head1.pop()); } }
                     Ordering::Greater => { unsafe { push_unchecked(&mut result, head2.pop()); } }
                     Ordering::Equal   => {
-                        let (data1, time1, diff1) = head1.pop();
+                        let (data1, time1, mut diff1) = head1.pop();
                         let (_data2, _time2, diff2) = head2.pop();
-                        let diff = diff1 + diff2;
-                        if !diff.is_zero() {
-                            unsafe { push_unchecked(&mut result, (data1, time1, diff)); }
+                        diff1 += diff2;
+                        if !diff1.is_zero() {
+                            unsafe { push_unchecked(&mut result, (data1, time1, diff1)); }
                         }
                     }
                 }

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -208,8 +208,8 @@ impl<D: Ord, T: Ord, R: Monoid> MergeSorter<D, T, R> {
             batch.sort_unstable_by(|x,y| (&x.0, &x.1).cmp(&(&y.0, &y.1)));
             for index in 1 .. batch.len() {
                 if batch[index].0 == batch[index - 1].0 && batch[index].1 == batch[index - 1].1 {
-                    batch[index].2 = batch[index].2 + batch[index - 1].2;
-                    batch[index - 1].2 = R::zero();
+                    let prev = ::std::mem::replace(&mut batch[index - 1].2, R::zero());
+                    batch[index].2 += prev;
                 }
             }
             batch.retain(|x| !x.2.is_zero());

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -111,8 +111,8 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fm
 
 			for index in lower .. (upper - 1) {
 				if updates[index].0 == updates[index+1].0 {
-					updates[index+1].1 = updates[index+1].1 + updates[index].1;
-					updates[index].1 = R::zero();
+					let prev = ::std::mem::replace(&mut updates[index].1, R::zero());
+					updates[index+1].1 += prev;
 				}
 			}
 
@@ -268,7 +268,7 @@ where K: Ord+Clone, V: Ord+Clone, T: Lattice+Ord+Clone, R: Monoid {
 	fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
 		self.cursor.child.child.rewind(&storage.layer.vals.vals);
 		while self.cursor.child.child.valid(&storage.layer.vals.vals) {
-			logic(&self.cursor.child.child.key(&storage.layer.vals.vals).0, self.cursor.child.child.key(&storage.layer.vals.vals).1);
+			logic(&self.cursor.child.child.key(&storage.layer.vals.vals).0, self.cursor.child.child.key(&storage.layer.vals.vals).1.clone());
 			self.cursor.child.child.step(&storage.layer.vals.vals);
 		}
 	}
@@ -393,8 +393,8 @@ where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Monoid {
 
 			for index in lower .. (upper - 1) {
 				if updates[index].0 == updates[index+1].0 {
-					updates[index+1].1 = updates[index].1 + updates[index+1].1;
-					updates[index].1 = R::zero();
+					let prev = ::std::mem::replace(&mut updates[index].1, R::zero());
+					updates[index + 1].1 += prev;
 				}
 			}
 
@@ -522,7 +522,7 @@ impl<K: Ord+Clone, T: Lattice+Ord+Clone, R: Monoid> Cursor<K, (), T, R> for OrdK
 	fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
 		self.cursor.child.rewind(&storage.layer.vals);
 		while self.cursor.child.valid(&storage.layer.vals) {
-			logic(&self.cursor.child.key(&storage.layer.vals).0, self.cursor.child.key(&storage.layer.vals).1);
+			logic(&self.cursor.child.key(&storage.layer.vals).0, self.cursor.child.key(&storage.layer.vals).1.clone());
 			self.cursor.child.step(&storage.layer.vals);
 		}
 	}

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -67,7 +67,7 @@ impl<K: Ord+Clone, R: Monoid+Clone> MergeBuilder for OrderedLeafBuilder<K, R> {
                 }
                 ::std::cmp::Ordering::Equal => {
 
-                    let sum = trie1.vals[lower1].1 + trie2.vals[lower2].1;
+                    let sum = trie1.vals[lower1].1.clone() + trie2.vals[lower2].1.clone();
                     if !sum.is_zero() {
                         self.vals.push((trie1.vals[lower1].0.clone(), sum));
                     }

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -67,7 +67,8 @@ impl<K: Ord+Clone, R: Monoid+Clone> MergeBuilder for OrderedLeafBuilder<K, R> {
                 }
                 ::std::cmp::Ordering::Equal => {
 
-                    let sum = trie1.vals[lower1].1.clone() + trie2.vals[lower2].1.clone();
+                    let mut sum = trie1.vals[lower1].1.clone();
+                    sum += trie2.vals[lower2].1.clone();
                     if !sum.is_zero() {
                         self.vals.push((trie1.vals[lower1].0.clone(), sum));
                     }

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -462,8 +462,8 @@ pub fn consolidate_by<T: Eq+Clone, L: Fn(&T, &T)->::std::cmp::Ordering, R: Monoi
 	vec[off..].sort_by(|x,y| cmp(&x.0, &y.0));
 	for index in (off + 1) .. vec.len() {
 		if vec[index].0 == vec[index - 1].0 {
-			vec[index].1 = vec[index].1 + vec[index - 1].1;
-			vec[index - 1].1 = R::zero();
+			let prev = ::std::mem::replace(&mut vec[index - 1].1, R::zero());
+			vec[index].1 += prev;
 		}
 	}
 	let mut cursor = off;


### PR DESCRIPTION
This PR removes various constraints from `Monoid`, and consequently from `Abelian` as well.

The new constraints are

```rust
pub trait Monoid : AddAssign + ::std::marker::Sized + Data + Clone
```

which replaces `Add` with `AddAssign` (based on actual use in the code, ability to re-use resources) and replaces `Copy` with `Clone`. The current implementation is fairly clone-eager, and should probably be revised in various places, and perhaps also require `AddAssign<&Self>`.

The `Abelian` requirements were relaxed to not include `Sub`, instead just using `Neg` everywhere.

@eoxxs