### PR TITLE
Diff AddAssign

### DIFF
--- a/examples/monoid-bfs.rs
+++ b/examples/monoid-bfs.rs
@@ -31,8 +31,8 @@ pub struct MinSum {
 use std::ops::{AddAssign, Mul};
 use differential_dataflow::difference::Monoid;
 
-impl AddAssign<Self> for MinSum {
-    fn add_assign(&mut self, rhs: Self) {
+impl<'a> AddAssign<&'a Self> for MinSum {
+    fn add_assign(&mut self, rhs: &'a Self) {
         self.value = std::cmp::min(self.value, rhs.value);
     }
 }

--- a/src/algorithms/identifiers.rs
+++ b/src/algorithms/identifiers.rs
@@ -28,7 +28,7 @@ pub trait Identifiers<G: Scope, D: Data, R: Abelian> {
     ///              .identifiers()
     ///              // assert no conflicts
     ///              .map(|(data, id)| id)
-    ///              .threshold(|_id,cnt| if cnt > 1 { 1 } else { 0 })
+    ///              .threshold(|_id,cnt| if cnt > &1 { 1 } else { 0 })
     ///              .assert_empty();
     ///     });
     /// }
@@ -134,7 +134,7 @@ mod tests {
                 .concat(&init)
                 .map(|(round, num)| { (num, (round + num) / 10) })
                 .map(|(_data, id)| id)
-                .threshold(|_id,cnt| if cnt > 1 { 1 } else { 0 })
+                .threshold(|_id,cnt| if cnt > &1 { 1 } else { 0 })
                 .assert_empty();
         });
     }

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -18,7 +18,7 @@ pub use self::Abelian as Diff;
 /// and almost certainly use commutativity somewhere (it isn't clear if it is a requirement, as it isn't
 /// clear that there are semantics other than "we accumulate your differences"; I suspect we don't always
 /// accumulate them in the right order, so commutativity is important until we conclude otherwise).
-pub trait Monoid : AddAssign + ::std::marker::Sized + Data + Clone {
+pub trait Monoid : for<'a> AddAssign<&'a Self> + ::std::marker::Sized + Data + Clone {
 	/// Returns true if the element is the additive identity.
 	///
 	/// This is primarily used by differential dataflow to know when it is safe to delete and update.
@@ -86,10 +86,10 @@ impl<R1: Monoid, R2: Monoid> Monoid for DiffPair<R1, R2> {
 	}
 }
 
-impl<R1: AddAssign, R2: AddAssign> AddAssign<DiffPair<R1, R2>> for DiffPair<R1, R2> {
-	#[inline(always)] fn add_assign(&mut self, rhs: Self) {
-		self.element1 += rhs.element1;
-		self.element2 += rhs.element2;
+impl<'a, R1: AddAssign<&'a R1>, R2: AddAssign<&'a R2>> AddAssign<&'a DiffPair<R1, R2>> for DiffPair<R1, R2> {
+	#[inline(always)] fn add_assign(&mut self, rhs: &'a Self) {
+		self.element1 += &rhs.element1;
+		self.element2 += &rhs.element2;
 	}
 }
 
@@ -125,57 +125,57 @@ impl<T: Copy, R1: Mul<T>, R2: Mul<T>> Mul<T> for DiffPair<R1,R2> {
 // 	}
 // }
 
-/// A variable number of accumulable updates.
-#[derive(Abomonation, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
-pub struct DiffVector<R> {
-	buffer: Vec<R>,
-}
+// /// A variable number of accumulable updates.
+// #[derive(Abomonation, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+// pub struct DiffVector<R> {
+// 	buffer: Vec<R>,
+// }
 
-impl<R: Monoid> Monoid for DiffVector<R> {
-	#[inline(always)] fn is_zero(&self) -> bool {
-		self.buffer.iter().all(|x| x.is_zero())
-	}
-	#[inline(always)] fn zero() -> Self {
-		Self { buffer: Vec::new() }
-	}
-}
+// impl<R: Monoid> Monoid for DiffVector<R> {
+// 	#[inline(always)] fn is_zero(&self) -> bool {
+// 		self.buffer.iter().all(|x| x.is_zero())
+// 	}
+// 	#[inline(always)] fn zero() -> Self {
+// 		Self { buffer: Vec::new() }
+// 	}
+// }
 
-impl<R: AddAssign> AddAssign<DiffVector<R>> for DiffVector<R> {
-	#[inline(always)]
-	fn add_assign(&mut self, mut rhs: Self) {
+// impl<R: AddAssign> AddAssign<DiffVector<R>> for DiffVector<R> {
+// 	#[inline(always)]
+// 	fn add_assign(&mut self, mut rhs: Self) {
 
-		// Swap arguments if other is longer.
-		if self.buffer.len() < rhs.buffer.len() {
-			::std::mem::swap(self, &mut rhs);
-		}
+// 		// Swap arguments if other is longer.
+// 		if self.buffer.len() < rhs.buffer.len() {
+// 			::std::mem::swap(self, &mut rhs);
+// 		}
 
-		// As other is not longer, apply updates without tests.
-		for (index, update) in rhs.buffer.into_iter().enumerate() {
-			self.buffer[index] += update;
-		}
-	}
-}
+// 		// As other is not longer, apply updates without tests.
+// 		for (index, update) in rhs.buffer.into_iter().enumerate() {
+// 			self.buffer[index] += update;
+// 		}
+// 	}
+// }
 
-impl<R: Neg<Output=R>+Clone> Neg for DiffVector<R> {
-	type Output = DiffVector<<R as Neg>::Output>;
-	#[inline(always)]
-	fn neg(mut self) -> Self::Output {
-		for update in self.buffer.iter_mut() {
-			*update = -update.clone();
-		}
-		self
-	}
-}
+// impl<R: Neg<Output=R>+Clone> Neg for DiffVector<R> {
+// 	type Output = DiffVector<<R as Neg>::Output>;
+// 	#[inline(always)]
+// 	fn neg(mut self) -> Self::Output {
+// 		for update in self.buffer.iter_mut() {
+// 			*update = -update.clone();
+// 		}
+// 		self
+// 	}
+// }
 
-impl<T: Copy, R: Mul<T>> Mul<T> for DiffVector<R> {
-	type Output = DiffVector<<R as Mul<T>>::Output>;
-	fn mul(self, other: T) -> Self::Output {
-		let buffer =
-		self.buffer
-			.into_iter()
-			.map(|x| x * other)
-			.collect();
+// impl<T: Copy, R: Mul<T>> Mul<T> for DiffVector<R> {
+// 	type Output = DiffVector<<R as Mul<T>>::Output>;
+// 	fn mul(self, other: T) -> Self::Output {
+// 		let buffer =
+// 		self.buffer
+// 			.into_iter()
+// 			.map(|x| x * other)
+// 			.collect();
 
-		DiffVector { buffer }
-	}
-}
+// 		DiffVector { buffer }
+// 	}
+// }

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -21,9 +21,10 @@ pub use self::Abelian as Diff;
 pub trait Monoid : for<'a> AddAssign<&'a Self> + ::std::marker::Sized + Data + Clone {
 	/// Returns true if the element is the additive identity.
 	///
-	/// This is primarily used by differential dataflow to know when it is safe to delete and update.
+	/// This is primarily used by differential dataflow to know when it is safe to delete an update.
 	/// When a difference accumulates to zero, the difference has no effect on any accumulation and can
 	/// be removed.
+	#[inline(always)]
 	fn is_zero(&self) -> bool { self.eq(&Self::zero()) }
 	/// The additive identity.
 	///

--- a/src/operators/arrange.rs
+++ b/src/operators/arrange.rs
@@ -630,7 +630,7 @@ impl<G: Scope, K, V, R, T> Arranged<G, K, V, R, T> where G::Timestamp: Lattice+O
                                 let mut active = &active[active_finger .. same_key];
 
                                 while let Some(val) = cursor.get_val(&storage) {
-                                    cursor.map_times(&storage, |t,d| working.push((t.clone(), val.clone(), d)));
+                                    cursor.map_times(&storage, |t,d| working.push((t.clone(), val.clone(), d.clone())));
                                     cursor.step_val(&storage);
                                 }
 

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -111,7 +111,7 @@ where
                         for index in 1 .. vector.len() {
                             if vector[index].0 == vector[index - 1].0 && vector[index].1 == vector[index - 1].1 {
                                 let prev = ::std::mem::replace(&mut vector[index - 1].2, R::zero());
-                                vector[index].2 += prev;
+                                vector[index].2 += &prev;
                             }
                         }
                         vector.retain(|x| !x.2.is_zero());

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -87,7 +87,7 @@ where
 
                         trace_cursor.seek_key(&trace_storage, key);
                         if trace_cursor.key_valid(&trace_storage) && trace_cursor.key(&trace_storage) == key {
-                            trace_cursor.map_times(&trace_storage, |_, diff| count += diff);
+                            trace_cursor.map_times(&trace_storage, |_, diff| count += &diff);
                         }
 
                         batch_cursor.map_times(&batch, |time, diff| {
@@ -95,7 +95,7 @@ where
                             if !count.is_zero() {
                                 session.give(((key.clone(), count.clone()), time.clone(), -1));
                             }
-                            count += diff;
+                            count += &diff;
                             if !count.is_zero() {
                                 session.give(((key.clone(), count.clone()), time.clone(), 1));
                             }

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -87,7 +87,7 @@ where
 
                         trace_cursor.seek_key(&trace_storage, key);
                         if trace_cursor.key_valid(&trace_storage) && trace_cursor.key(&trace_storage) == key {
-                            trace_cursor.map_times(&trace_storage, |_, diff| count += &diff);
+                            trace_cursor.map_times(&trace_storage, |_, diff| count += diff);
                         }
 
                         batch_cursor.map_times(&batch, |time, diff| {
@@ -95,7 +95,7 @@ where
                             if !count.is_zero() {
                                 session.give(((key.clone(), count.clone()), time.clone(), -1));
                             }
-                            count += &diff;
+                            count += diff;
                             if !count.is_zero() {
                                 session.give(((key.clone(), count.clone()), time.clone(), 1));
                             }

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -116,7 +116,7 @@ pub trait Threshold<G: Scope, K: Data, R1: Monoid> where G::Timestamp: Lattice+O
     ///     });
     /// }
     /// ```
-    fn threshold<R2: Abelian, F: Fn(&K, R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2>;
+    fn threshold<R2: Abelian, F: Fn(&K, &R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2>;
     /// Reduces the collection to one occurrence of each distinct element.
     ///
     /// # Examples
@@ -144,9 +144,9 @@ pub trait Threshold<G: Scope, K: Data, R1: Monoid> where G::Timestamp: Lattice+O
 
 impl<G: Scope, K: Data+Hashable, R1: Monoid> Threshold<G, K, R1> for Collection<G, K, R1>
 where G::Timestamp: Lattice+Ord {
-    fn threshold<R2: Abelian, F: Fn(&K,R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
+    fn threshold<R2: Abelian, F: Fn(&K,&R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
         self.arrange_by_self()
-            .group_arranged::<_,_,DefaultKeyTrace<_,_,_>,_>(move |k,s,t| t.push(((), thresh(k, s[0].1.clone()))))
+            .group_arranged::<_,_,DefaultKeyTrace<_,_,_>,_>(move |k,s,t| t.push(((), thresh(k, &s[0].1))))
             .as_collection(|k,_| k.clone())
     }
 }
@@ -156,8 +156,8 @@ where
     G::Timestamp: Lattice+Ord,
     T1: TraceReader<K, (), G::Timestamp, R1>+Clone+'static,
     T1::Batch: BatchReader<K, (), G::Timestamp, R1> {
-    fn threshold<R2: Abelian, F: Fn(&K,R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
-        self.group_arranged::<_,_,DefaultKeyTrace<_,_,_>,_>(move |k,s,t| t.push(((), thresh(k, s[0].1.clone()))))
+    fn threshold<R2: Abelian, F: Fn(&K,&R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
+        self.group_arranged::<_,_,DefaultKeyTrace<_,_,_>,_>(move |k,s,t| t.push(((), thresh(k, &s[0].1))))
             .as_collection(|k,_| k.clone())
     }
 }

--- a/src/operators/group.rs
+++ b/src/operators/group.rs
@@ -608,7 +608,7 @@ fn consolidate<T: Ord, R: Monoid>(list: &mut Vec<(T, R)>) {
     for index in 1 .. list.len() {
         if list[index].0 == list[index-1].0 {
             let prev = ::std::mem::replace(&mut list[index-1].1, R::zero());
-            list[index].1 += prev;
+            list[index].1 += &prev;
         }
     }
     list.retain(|x| !x.1.is_zero());
@@ -625,7 +625,7 @@ pub fn consolidate_from<T: Ord+Clone, R: Monoid>(vec: &mut Vec<(T, R)>, off: usi
     for index in (off + 1) .. vec.len() {
         if vec[index].0 == vec[index - 1].0 {
             let prev = ::std::mem::replace(&mut vec[index-1].1, R::zero());
-            vec[index].1 += prev;
+            vec[index].1 += &prev;
         }
     }
 

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -44,7 +44,7 @@ impl<'a, V:'a, T, R> EditList<'a, V, T, R> where T: Ord+Clone, R: Monoid {
     where K: Eq, V: Clone, C: Cursor<K, V, T, R>, L: Fn(&T)->T {
         self.clear();
         while cursor.val_valid(storage) {
-            cursor.map_times(storage, |time1, diff1| self.push(logic(time1), diff1));
+            cursor.map_times(storage, |time1, diff1| self.push(logic(time1), diff1.clone()));
             self.seal(cursor.val(storage));
             cursor.step_val(storage);
         }

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -38,7 +38,7 @@ pub trait ThresholdTotal<G: Scope, K: Data, R: Monoid> where G::Timestamp: Total
     ///     });
     /// }
     /// ```
-    fn threshold_total<R2: Abelian, F: Fn(&K,R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2>;
+    fn threshold_total<R2: Abelian, F: Fn(&K,&R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2>;
     /// Reduces the collection to one occurrence of each distinct element.
     ///
     /// This reduction only tests whether the weight associated with a record is non-zero, and otherwise
@@ -70,7 +70,7 @@ pub trait ThresholdTotal<G: Scope, K: Data, R: Monoid> where G::Timestamp: Total
 
 impl<G: Scope, K: Data+Hashable, R: Monoid> ThresholdTotal<G, K, R> for Collection<G, K, R>
 where G::Timestamp: TotalOrder+Lattice+Ord {
-    fn threshold_total<R2: Abelian, F: Fn(&K,R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
+    fn threshold_total<R2: Abelian, F: Fn(&K,&R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
         self.arrange_by_self()
             .threshold_total(thresh)
     }
@@ -82,7 +82,7 @@ where
     T1: TraceReader<K, (), G::Timestamp, R>+Clone+'static,
     T1::Batch: BatchReader<K, (), G::Timestamp, R> {
 
-    fn threshold_total<R2: Abelian, F:Fn(&K,R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
+    fn threshold_total<R2: Abelian, F:Fn(&K,&R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
 
         let mut trace = self.trace.clone();
         let mut buffer = Vec::new();
@@ -115,9 +115,9 @@ where
 
                             // Determine old and new weights.
                             // If a count is zero, the weight must be zero.
-                            let old_weight = if count.is_zero() { R2::zero() } else { thresh(key, count.clone()) };
+                            let old_weight = if count.is_zero() { R2::zero() } else { thresh(key, &count) };
                             count += diff;
-                            let new_weight = if count.is_zero() { R2::zero() } else { thresh(key, count.clone()) };
+                            let new_weight = if count.is_zero() { R2::zero() } else { thresh(key, &count) };
 
                             let mut difference = -old_weight;
                             difference += &new_weight;

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -106,7 +106,7 @@ where
                         // Compute the multiplicity of this key before the current batch.
                         trace_cursor.seek_key(&trace_storage, key);
                         if trace_cursor.key_valid(&trace_storage) && trace_cursor.key(&trace_storage) == key {
-                            trace_cursor.map_times(&trace_storage, |_, diff| count += diff);
+                            trace_cursor.map_times(&trace_storage, |_, diff| count += &diff);
                         }
 
                         // Apply `thresh` both before and after `diff` is applied to `count`.
@@ -116,11 +116,11 @@ where
                             // Determine old and new weights.
                             // If a count is zero, the weight must be zero.
                             let old_weight = if count.is_zero() { R2::zero() } else { thresh(key, count.clone()) };
-                            count += diff;
+                            count += &diff;
                             let new_weight = if count.is_zero() { R2::zero() } else { thresh(key, count.clone()) };
 
                             let mut difference = -old_weight;
-                            difference += new_weight;
+                            difference += &new_weight;
                             if !difference.is_zero() {
                                 session.give((key.clone(), time.clone(), difference));
                             }

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -106,7 +106,7 @@ where
                         // Compute the multiplicity of this key before the current batch.
                         trace_cursor.seek_key(&trace_storage, key);
                         if trace_cursor.key_valid(&trace_storage) && trace_cursor.key(&trace_storage) == key {
-                            trace_cursor.map_times(&trace_storage, |_, diff| count += &diff);
+                            trace_cursor.map_times(&trace_storage, |_, diff| count += diff);
                         }
 
                         // Apply `thresh` both before and after `diff` is applied to `count`.
@@ -116,7 +116,7 @@ where
                             // Determine old and new weights.
                             // If a count is zero, the weight must be zero.
                             let old_weight = if count.is_zero() { R2::zero() } else { thresh(key, count.clone()) };
-                            count += &diff;
+                            count += diff;
                             let new_weight = if count.is_zero() { R2::zero() } else { thresh(key, count.clone()) };
 
                             let mut difference = -old_weight;

--- a/src/trace/cursor/cursor_list.rs
+++ b/src/trace/cursor/cursor_list.rs
@@ -115,7 +115,7 @@ where
         self.cursors[self.min_val[0]].val(&storage[self.min_val[0]])
     }
     #[inline(always)]
-    fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         for &index in self.min_val.iter() {
             self.cursors[index].map_times(&storage[index], |t,d| logic(t,d));
         }

--- a/src/trace/cursor/cursor_pair.rs
+++ b/src/trace/cursor/cursor_pair.rs
@@ -15,7 +15,7 @@ pub struct CursorPair<C1, C2> {
     val_order: Ordering,    // Invalid vals are `Greater` than all other vals. `Equal` implies both valid.
 }
 
-impl<K, V, T, R, C1, C2> Cursor<K, V, T, R> for CursorPair<C1, C2> 
+impl<K, V, T, R, C1, C2> Cursor<K, V, T, R> for CursorPair<C1, C2>
 where
     K: Ord,
     V: Ord,
@@ -25,14 +25,14 @@ where
     type Storage = (C1::Storage, C2::Storage);
 
     // validation methods
-    fn key_valid(&self, storage: &Self::Storage) -> bool { 
+    fn key_valid(&self, storage: &Self::Storage) -> bool {
         match self.key_order {
             Ordering::Less => self.cursor1.key_valid(&storage.0),
             Ordering::Equal => true,
             Ordering::Greater => self.cursor2.key_valid(&storage.1),
         }
     }
-    fn val_valid(&self, storage: &Self::Storage) -> bool { 
+    fn val_valid(&self, storage: &Self::Storage) -> bool {
         match (self.key_order, self.val_order) {
             (Ordering::Less, _) => self.cursor1.val_valid(&storage.0),
             (Ordering::Greater, _) => self.cursor2.val_valid(&storage.1),
@@ -42,7 +42,7 @@ where
         }
     }
 
-    // accessors 
+    // accessors
     fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K {
         match self.key_order {
             Ordering::Less => self.cursor1.key(&storage.0),
@@ -57,7 +57,7 @@ where
             self.cursor2.val(&storage.1)
         }
     }
-    fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         if self.key_order == Ordering::Less || (self.key_order == Ordering::Equal && self.val_order != Ordering::Greater) {
             self.cursor1.map_times(&storage.0, |t,d| logic(t,d));
         }
@@ -89,7 +89,7 @@ where
             (true, true) => self.cursor1.key(&storage.0).cmp(self.cursor2.key(&storage.1)),
         };
     }
-    
+
     // value methods
     fn step_val(&mut self, storage: &Self::Storage) {
         match self.key_order {
@@ -123,11 +123,11 @@ where
     }
 
     // rewinding methods
-    fn rewind_keys(&mut self, storage: &Self::Storage) { 
+    fn rewind_keys(&mut self, storage: &Self::Storage) {
         self.cursor1.rewind_keys(&storage.0);
         self.cursor2.rewind_keys(&storage.1);
     }
-    fn rewind_vals(&mut self, storage: &Self::Storage) { 
+    fn rewind_vals(&mut self, storage: &Self::Storage) {
         if self.key_order != Ordering::Greater { self.cursor1.rewind_vals(&storage.0); }
         if self.key_order != Ordering::Less { self.cursor2.rewind_vals(&storage.1); }
     }

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -42,7 +42,7 @@ pub trait Cursor<K, V, T, R> {
 
 	/// Applies `logic` to each pair of time and difference. Intended for mutation of the
 	/// closure's scope.
-	fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, logic: L);
+	fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, logic: L);
 
 	/// Advances the cursor to the next key. Indicates if the key is valid.
 	fn step_key(&mut self, storage: &Self::Storage);
@@ -71,7 +71,7 @@ pub trait CursorDebug<K: Clone, V: Clone, T: Clone, R: Clone> : Cursor<K, V, T, 
 			while self.val_valid(storage) {
 				let mut kv_out = Vec::new();
 				self.map_times(storage, |ts, r| {
-					kv_out.push((ts.clone(), r));
+					kv_out.push((ts.clone(), r.clone()));
 				});
 				out.push(((self.key(storage).clone(), self.val(storage).clone()), kv_out));
 				self.step_val(storage);

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -209,7 +209,7 @@ impl<D: Ord, T: Ord, R: Monoid> MergeSorter<D, T, R> {
             for index in 1 .. batch.len() {
                 if batch[index].0 == batch[index - 1].0 && batch[index].1 == batch[index - 1].1 {
                     let prev = ::std::mem::replace(&mut batch[index - 1].2, R::zero());
-                    batch[index].2 += prev;
+                    batch[index].2 += &prev;
                 }
             }
             batch.retain(|x| !x.2.is_zero());
@@ -283,7 +283,7 @@ impl<D: Ord, T: Ord, R: Monoid> MergeSorter<D, T, R> {
                     Ordering::Equal   => {
                         let (data1, time1, mut diff1) = head1.pop();
                         let (_data2, _time2, diff2) = head2.pop();
-                        diff1 += diff2;
+                        diff1 += &diff2;
                         if !diff1.is_zero() {
                             unsafe { push_unchecked(&mut result, (data1, time1, diff1)); }
                         }

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -265,10 +265,10 @@ where K: Ord+Clone, V: Ord+Clone, T: Lattice+Ord+Clone, R: Monoid {
 
 	fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { &self.cursor.key(&storage.layer) }
 	fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { &self.cursor.child.key(&storage.layer.vals) }
-	fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+	fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
 		self.cursor.child.child.rewind(&storage.layer.vals.vals);
 		while self.cursor.child.child.valid(&storage.layer.vals.vals) {
-			logic(&self.cursor.child.child.key(&storage.layer.vals.vals).0, self.cursor.child.child.key(&storage.layer.vals.vals).1.clone());
+			logic(&self.cursor.child.child.key(&storage.layer.vals.vals).0, &self.cursor.child.child.key(&storage.layer.vals.vals).1);
 			self.cursor.child.child.step(&storage.layer.vals.vals);
 		}
 	}
@@ -519,10 +519,10 @@ impl<K: Ord+Clone, T: Lattice+Ord+Clone, R: Monoid> Cursor<K, (), T, R> for OrdK
 
 	fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { &self.cursor.key(&storage.layer) }
 	fn val<'a>(&self, _storage: &'a Self::Storage) -> &'a () { unsafe { ::std::mem::transmute(&self.empty) } }
-	fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+	fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
 		self.cursor.child.rewind(&storage.layer.vals);
 		while self.cursor.child.valid(&storage.layer.vals) {
-			logic(&self.cursor.child.key(&storage.layer.vals).0, self.cursor.child.key(&storage.layer.vals).1.clone());
+			logic(&self.cursor.child.key(&storage.layer.vals).0, &self.cursor.child.key(&storage.layer.vals).1);
 			self.cursor.child.step(&storage.layer.vals);
 		}
 	}

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -112,7 +112,7 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fm
 			for index in lower .. (upper - 1) {
 				if updates[index].0 == updates[index+1].0 {
 					let prev = ::std::mem::replace(&mut updates[index].1, R::zero());
-					updates[index+1].1 += prev;
+					updates[index+1].1 += &prev;
 				}
 			}
 
@@ -394,7 +394,7 @@ where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Monoid {
 			for index in lower .. (upper - 1) {
 				if updates[index].0 == updates[index+1].0 {
 					let prev = ::std::mem::replace(&mut updates[index].1, R::zero());
-					updates[index + 1].1 += prev;
+					updates[index + 1].1 += &prev;
 				}
 			}
 

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -68,7 +68,7 @@ impl<K: Ord+Clone, R: Monoid+Clone> MergeBuilder for OrderedLeafBuilder<K, R> {
                 ::std::cmp::Ordering::Equal => {
 
                     let mut sum = trie1.vals[lower1].1.clone();
-                    sum += trie2.vals[lower2].1.clone();
+                    sum += &trie2.vals[lower2].1;
                     if !sum.is_zero() {
                         self.vals.push((trie1.vals[lower1].0.clone(), sum));
                     }

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -463,7 +463,7 @@ pub fn consolidate_by<T: Eq+Clone, L: Fn(&T, &T)->::std::cmp::Ordering, R: Monoi
 	for index in (off + 1) .. vec.len() {
 		if vec[index].0 == vec[index - 1].0 {
 			let prev = ::std::mem::replace(&mut vec[index - 1].1, R::zero());
-			vec[index].1 += prev;
+			vec[index].1 += &prev;
 		}
 	}
 	let mut cursor = off;

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -272,7 +272,7 @@ pub mod rc_blanket_impls {
 	    #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
 
 	    #[inline(always)]
-	    fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, logic: L) {
+	    fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, logic: L) {
 	    	self.cursor.map_times(storage, logic)
 	    }
 
@@ -378,7 +378,7 @@ pub mod abomonated_blanket_impls {
 	    #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
 
 	    #[inline(always)]
-	    fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, logic: L) {
+	    fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, logic: L) {
 	    	self.cursor.map_times(storage, logic)
 	    }
 

--- a/src/trace/wrappers/enter.rs
+++ b/src/trace/wrappers/enter.rs
@@ -188,7 +188,7 @@ where
     #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
 
     #[inline(always)]
-    fn map_times<L: FnMut(&TInner, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<L: FnMut(&TInner, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         self.cursor.map_times(storage, |time, diff| {
             logic(&TInner::to_inner(time.clone()), diff)
         })
@@ -235,7 +235,7 @@ where
     #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(&storage.batch) }
 
     #[inline(always)]
-    fn map_times<L: FnMut(&TInner, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<L: FnMut(&TInner, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         self.cursor.map_times(&storage.batch, |time, diff| {
             logic(&TInner::to_inner(time.clone()), diff)
         })

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -203,7 +203,7 @@ where
     #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
 
     #[inline(always)]
-    fn map_times<L: FnMut(&TInner, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<L: FnMut(&TInner, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         let logic2 = &self.logic;
@@ -256,7 +256,7 @@ where
     #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(&storage.batch) }
 
     #[inline(always)]
-    fn map_times<L: FnMut(&TInner, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<L: FnMut(&TInner, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         let logic2 = &self.logic;

--- a/src/trace/wrappers/filter.rs
+++ b/src/trace/wrappers/filter.rs
@@ -152,7 +152,7 @@ where
     #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
 
     #[inline(always)]
-    fn map_times<L: FnMut(&T,R)>(&mut self, storage: &Self::Storage, logic: L) {
+    fn map_times<L: FnMut(&T,&R)>(&mut self, storage: &Self::Storage, logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         if (self.logic)(key, val) {
@@ -203,7 +203,7 @@ where
     #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(&storage.batch) }
 
     #[inline(always)]
-    fn map_times<L: FnMut(&T,R)>(&mut self, storage: &Self::Storage, logic: L) {
+    fn map_times<L: FnMut(&T,&R)>(&mut self, storage: &Self::Storage, logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         if (self.logic)(key, val) {

--- a/src/trace/wrappers/freeze.rs
+++ b/src/trace/wrappers/freeze.rs
@@ -210,7 +210,7 @@ where
     #[inline(always)] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
     #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
 
-    #[inline(always)] fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    #[inline(always)] fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let func = &self.func;
         self.cursor.map_times(storage, |time, diff| {
             if let Some(time) = func(time) {
@@ -260,7 +260,7 @@ where
     #[inline(always)] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(&storage.batch) }
     #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(&storage.batch) }
 
-    #[inline(always)] fn map_times<L: FnMut(&T, R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    #[inline(always)] fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let func = &self.func;
         self.cursor.map_times(&storage.batch, |time, diff| {
             if let Some(time) = func(time) {


### PR DESCRIPTION
This PR adjusts trait requirements in `difference.rs` to allow more efficient implementations. Specifically, the `AddAssign<Self>` requirement is replaced by `AddAssign<&Self>`, which better fits the uses of differences (available for accumulation as references, without a need to clone).