### PR TITLE
Group to Reduce

### DIFF
--- a/dogsdogsdogs/Cargo.toml
+++ b/dogsdogsdogs/Cargo.toml
@@ -9,7 +9,7 @@ git="https://github.com/frankmcsherry/graph-map.git"
 [dependencies]
 abomonation = "0.7"
 abomonation_derive = "0.3"
-timely = { git = "https://github.com/frankmcsherry/timely-dataflow" }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
 timely_sort="0.1.6"
 differential-dataflow = { path = "../" }
 serde = "1"

--- a/examples/arrange.rs
+++ b/examples/arrange.rs
@@ -10,7 +10,7 @@ use timely::order::Product;
 use differential_dataflow::input::Input;
 use differential_dataflow::AsCollection;
 use differential_dataflow::operators::arrange::ArrangeByKey;
-use differential_dataflow::operators::group::Group;
+use differential_dataflow::operators::reduce::Reduce;
 use differential_dataflow::operators::join::JoinCore;
 use differential_dataflow::operators::Iterate;
 use differential_dataflow::operators::Consolidate;
@@ -119,7 +119,7 @@ fn main() {
                 dists.arrange_by_key()
                      .join_core(&edges, |_k,l,d| Some((*d, l+1)))
                      .concat(&roots)
-                     .group(|_, s, t| t.push((*s[0].0, 1)))
+                     .reduce(|_, s, t| t.push((*s[0].0, 1)))
             })
             .map(|(_node, dist)| dist)
             .consolidate()

--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -126,6 +126,6 @@ where G::Timestamp: Lattice+Ord {
 
         inner.join_map(&edges, |_k,l,d| (*d, l+1))
              .concat(&nodes)
-             .group(|_, s, t| t.push((*s[0].0, 1)))
+             .reduce(|_, s, t| t.push((*s[0].0, 1)))
      })
 }

--- a/examples/monoid-bfs.rs
+++ b/examples/monoid-bfs.rs
@@ -143,7 +143,7 @@ where G::Timestamp: Lattice+Ord {
     roots.scope().iterative::<u32,_,_>(|scope| {
 
         use differential_dataflow::operators::iterate::MonoidVariable;
-        use differential_dataflow::operators::group::GroupArranged;
+        use differential_dataflow::operators::reduce::ReduceCore;
         use differential_dataflow::trace::implementations::ord::OrdKeySpine as DefaultKeyTrace;
 
 
@@ -159,7 +159,7 @@ where G::Timestamp: Lattice+Ord {
             .join_map(&edges, |_k,&(),d| *d)
             .concat(&roots)
             .map(|x| (x,()))
-            .group_solve::<_,_,DefaultKeyTrace<_,_,_>,_>(|_key, input, output, updates| {
+            .reduce_core::<_,_,DefaultKeyTrace<_,_,_>,_>(|_key, input, output, updates| {
                 if output.is_empty() || input[0].1 < output[0].1 {
                     updates.push(((), input[0].1));
                 }

--- a/examples/stackoverflow.rs
+++ b/examples/stackoverflow.rs
@@ -122,6 +122,6 @@ where G::Timestamp: Lattice+Ord {
 
         inner.join_map(&edges, |_k,l,d| (*d, l+1))
              .concat(&nodes)
-             .group(|_, s, t| t.push((*s[0].0, 1)))
+             .reduce(|_, s, t| t.push((*s[0].0, 1)))
      })
 }

--- a/experiments/Cargo.toml
+++ b/experiments/Cargo.toml
@@ -9,6 +9,6 @@ rand="0.3.13"
 abomonation = "0.7"
 abomonation_derive = "0.3"
 #timely = "0.7"
-timely = { git = "https://github.com/frankmcsherry/timely-dataflow" }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
 differential-dataflow = { path = "../" }
 graph_map = { git = "https://github.com/frankmcsherry/graph-map" }

--- a/experiments/src/bin/attend.rs
+++ b/experiments/src/bin/attend.rs
@@ -32,7 +32,7 @@ fn main() {
                     graph.enter(&attend.scope())
                          .semijoin(attend)
                          .map(|(_,y)| y)
-                         .threshold_total(|_,w| if w >= 3 { 1 } else { 0 })
+                         .threshold_total(|_,w| if w >= &3 { 1 } else { 0 })
                          .concat(&organizers.enter(&attend.scope()))
                          .consolidate()
                 })

--- a/experiments/src/bin/deals.rs
+++ b/experiments/src/bin/deals.rs
@@ -88,8 +88,7 @@ fn main() {
     }).unwrap();
 }
 
-use timely::progress::nested::product::Product;
-// use timely::progress::timestamp::RootTimestamp;
+use timely::order::Product;
 
 fn _trim_and_flip<G: Scope>(graph: &Collection<G, Edge>) -> Collection<G, Edge>
 where G::Timestamp: Lattice+Ord+Hash {
@@ -138,7 +137,7 @@ where G::Timestamp: Lattice+Ord+Hash {
 
              inner.join_map(&edges, |_k,l,d| (*d,*l))
                   .concat(&nodes)
-                  .group(|_, s, t| t.push((*s[0].0, 1)))
+                  .reduce(|_, s, t| t.push((*s[0].0, 1)))
 
          })
 }

--- a/experiments/src/bin/graphs-interactive-alt.rs
+++ b/experiments/src/bin/graphs-interactive-alt.rs
@@ -7,7 +7,7 @@ use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle;
-use timely::progress::nested::product::Product;
+use timely::order::Product;
 
 use differential_dataflow::input::Input;
 use differential_dataflow::Collection;
@@ -289,7 +289,7 @@ where G::Timestamp: Lattice+Ord {
 
     forward
         .join_map(&reverse, |_,&(source, dist1),&(target, dist2)| ((source, target), dist1 + dist2))
-        .group(|_st,input,output| output.push((*input[0].0,1)))
+        .reduce(|_st,input,output| output.push((*input[0].0,1)))
 }
 
 // returns pairs (n, s) indicating node n can be reached from a root in s steps.
@@ -321,7 +321,7 @@ where G::Timestamp: Lattice+Ord {
         let reached =
         forward
             .join_map(&reverse, |_, &(src,d1), &(dst,d2)| ((src, dst), d1 + d2))
-            .group(|_key, s, t| t.push((*s[0].0, 1)))
+            .reduce(|_key, s, t| t.push((*s[0].0, 1)))
             .semijoin(&goals);
 
         let active =
@@ -341,7 +341,7 @@ where G::Timestamp: Lattice+Ord {
             .join_core(&forward_graph, |_med, &(src, dist), &next| Some((next, (src, dist+1))))
             .concat(&forward)
             .map(|(next, (src, dist))| ((next, src), dist))
-            .group(|_key, s, t| t.push((*s[0].0, 1)))
+            .reduce(|_key, s, t| t.push((*s[0].0, 1)))
             .map(|((next, src), dist)| (next, (src, dist)));
 
         forward.set(&forward_next);
@@ -356,7 +356,7 @@ where G::Timestamp: Lattice+Ord {
             .join_core(&reverse_graph, |_med, &(rev, dist), &next| Some((next, (rev, dist+1))))
             .concat(&reverse)
             .map(|(next, (rev, dist))| ((next, rev), dist))
-            .group(|_key, s, t| t.push((*s[0].0, 1)))
+            .reduce(|_key, s, t| t.push((*s[0].0, 1)))
             .map(|((next,rev), dist)| (next, (rev, dist)));
 
         reverse.set(&reverse_next);
@@ -392,6 +392,6 @@ where G::Timestamp: Lattice {
 
             nodes
                 .concat(&prop)
-                .group(|_, s, t| { t.push((*s[0].0, 1)); })
+                .reduce(|_, s, t| { t.push((*s[0].0, 1)); })
         })
 }

--- a/experiments/src/bin/graphs-interactive-neu-zwei.rs
+++ b/experiments/src/bin/graphs-interactive-neu-zwei.rs
@@ -261,7 +261,7 @@ where G::Timestamp: Lattice+Ord {
 
     forward
         .join_map(&reverse, |_,&(source, dist1),&(target, dist2)| ((source, target), dist1 + dist2))
-        .group(|_st,input,output| output.push((*input[0].0,1)))
+        .reduce(|_st,input,output| output.push((*input[0].0,1)))
 }
 
 // // returns pairs (n, s) indicating node n can be reached from a root in s steps.
@@ -294,7 +294,7 @@ where G::Timestamp: Lattice+Ord {
 //         let reached =
 //         forward
 //             .join_map(&reverse, |_, &(src,d1), &(dst,d2)| ((src, dst), d1 + d2))
-//             .group(|_key, s, t| t.push((*s[0].0, 1)))
+//             .reduce(|_key, s, t| t.push((*s[0].0, 1)))
 //             .semijoin(&goals);
 
 //         let active =
@@ -314,7 +314,7 @@ where G::Timestamp: Lattice+Ord {
 //             .join_core(&forward_graph, |_med, &(src, dist), &next| Some((next, (src, dist+1))))
 //             .concat(&forward)
 //             .map(|(next, (src, dist))| ((next, src), dist))
-//             .group(|_key, s, t| t.push((*s[0].0, 1)))
+//             .reduce(|_key, s, t| t.push((*s[0].0, 1)))
 //             .map(|((next, src), dist)| (next, (src, dist)));
 
 //         forward.set(&forward_next);
@@ -329,7 +329,7 @@ where G::Timestamp: Lattice+Ord {
 //             .join_core(&reverse_graph, |_med, &(rev, dist), &next| Some((next, (rev, dist+1))))
 //             .concat(&reverse)
 //             .map(|(next, (rev, dist))| ((next, rev), dist))
-//             .group(|_key, s, t| t.push((*s[0].0, 1)))
+//             .reduce(|_key, s, t| t.push((*s[0].0, 1)))
 //             .map(|((next,rev), dist)| (next, (rev, dist)));
 
 //         reverse.set(&reverse_next);

--- a/experiments/src/bin/graphs-interactive.rs
+++ b/experiments/src/bin/graphs-interactive.rs
@@ -7,7 +7,7 @@ use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle;
-use timely::progress::nested::product::Product;
+use timely::order::Product;
 
 use differential_dataflow::input::Input;
 use differential_dataflow::Collection;
@@ -230,7 +230,7 @@ where G::Timestamp: Lattice+Ord {
 
     forward
         .join_map(&reverse, |_,&(source, dist1),&(target, dist2)| ((source, target), dist1 + dist2))
-        .group(|_st,input,output| output.push((*input[0].0,1)))
+        .reduce(|_st,input,output| output.push((*input[0].0,1)))
 }
 
 // returns pairs (n, s) indicating node n can be reached from a root in s steps.
@@ -262,7 +262,7 @@ where G::Timestamp: Lattice+Ord {
         let reached =
         forward
             .join_map(&reverse, |_, &(src,d1), &(dst,d2)| ((src, dst), d1 + d2))
-            .group(|_key, s, t| t.push((*s[0].0, 1)))
+            .reduce(|_key, s, t| t.push((*s[0].0, 1)))
             .semijoin(&goals);
 
         let active =
@@ -282,7 +282,7 @@ where G::Timestamp: Lattice+Ord {
             .join_core(&forward_graph, |_med, &(src, dist), &next| Some((next, (src, dist+1))))
             .concat(&forward)
             .map(|(next, (src, dist))| ((next, src), dist))
-            .group(|_key, s, t| t.push((*s[0].0, 1)))
+            .reduce(|_key, s, t| t.push((*s[0].0, 1)))
             .map(|((next, src), dist)| (next, (src, dist)));
 
         forward.set(&forward_next);
@@ -297,7 +297,7 @@ where G::Timestamp: Lattice+Ord {
             .join_core(&reverse_graph, |_med, &(rev, dist), &next| Some((next, (rev, dist+1))))
             .concat(&reverse)
             .map(|(next, (rev, dist))| ((next, rev), dist))
-            .group(|_key, s, t| t.push((*s[0].0, 1)))
+            .reduce(|_key, s, t| t.push((*s[0].0, 1)))
             .map(|((next,rev), dist)| (next, (rev, dist)));
 
         reverse.set(&reverse_next);

--- a/experiments/src/bin/graphs.rs
+++ b/experiments/src/bin/graphs.rs
@@ -137,7 +137,7 @@ fn bfs<G: Scope<Timestamp = ()>> (
 
         graph.join_map(&inner, |_src,&dest,&dist| (dest, dist+1))
              .concat(&roots)
-             .group(|_key, input, output| output.push((*input[0].0,1)))
+             .reduce(|_key, input, output| output.push((*input[0].0,1)))
     })
 }
 

--- a/experiments/src/bin/graspan-interactive.rs
+++ b/experiments/src/bin/graspan-interactive.rs
@@ -11,7 +11,6 @@ use differential_dataflow::input::Input;
 // use differential_dataflow::trace::Trace;
 // use differential_dataflow::trace::implementations::ord::OrdValSpine;
 use differential_dataflow::operators::*;
-// use differential_dataflow::operators::group::GroupArranged;
 use differential_dataflow::operators::arrange::ArrangeByKey;
 
 fn main() {

--- a/experiments/src/bin/graspan.rs
+++ b/experiments/src/bin/graspan.rs
@@ -10,7 +10,6 @@ use differential_dataflow::input::Input;
 // use differential_dataflow::trace::Trace;
 // use differential_dataflow::trace::implementations::ord::OrdValSpine;
 use differential_dataflow::operators::*;
-// use differential_dataflow::operators::group::GroupArranged;
 use differential_dataflow::operators::arrange::ArrangeByKey;
 
 fn main() {

--- a/experiments/src/bin/graspan2.rs
+++ b/experiments/src/bin/graspan2.rs
@@ -6,14 +6,13 @@ use std::io::{BufRead, BufReader};
 use std::fs::File;
 
 use timely::dataflow::Scope;
-use timely::progress::nested::product::Product;
+use timely::order::Product;
 
 use differential_dataflow::operators::iterate::Variable;
 
 use differential_dataflow::Collection;
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::*;
-// use differential_dataflow::operators::iterate::CoreVariable;
 use differential_dataflow::operators::arrange::ArrangeByKey;
 
 type Iter = u64;

--- a/src/algorithms/graphs/bfs.rs
+++ b/src/algorithms/graphs/bfs.rs
@@ -26,6 +26,6 @@ where
 
         inner.join_map(&edges, |_k,l,d| (d.clone(), l+1))
              .concat(&nodes)
-             .group(|_, s, t| t.push((s[0].0.clone(), 1)))
+             .reduce(|_, s, t| t.push((s[0].0.clone(), 1)))
      })
 }

--- a/src/algorithms/graphs/bijkstra.rs
+++ b/src/algorithms/graphs/bijkstra.rs
@@ -47,7 +47,7 @@ where
         let reached =
         forward
             .join_map(&reverse, |_, (src,d1), (dst,d2)| ((src.clone(), dst.clone()), *d1 + *d2))
-            .group(|_key, s, t| t.push((s[0].0.clone(), 1)));
+            .reduce(|_key, s, t| t.push((s[0].0.clone(), 1)));
 
         let active =
         reached
@@ -67,7 +67,7 @@ where
             .join_map(&edges, |_med, (src, dist), next| (next.clone(), (src.clone(), *dist+1)))
             .concat(&forward)
             .map(|(next, (src, dist))| ((next, src), dist))
-            .group(|_key, s, t| t.push((s[0].0.clone(), 1)))
+            .reduce(|_key, s, t| t.push((s[0].0.clone(), 1)))
             .map(|((next, src), dist)| (next, (src, dist)));
 
         forward.set(&forward_next);
@@ -82,7 +82,7 @@ where
             .join_map(&edges.map(|(x,y)| (y,x)), |_med, (rev, dist), next| (next.clone(), (rev.clone(), *dist+1)))
             .concat(&reverse)
             .map(|(next, (rev, dist))| ((next, rev), dist))
-            .group(|_key, s, t| t.push((s[0].0.clone(), 1)))
+            .reduce(|_key, s, t| t.push((s[0].0.clone(), 1)))
             .map(|((next,rev), dist)| (next, (rev, dist)));
 
         reverse.set(&reverse_next);

--- a/src/algorithms/graphs/propagate.rs
+++ b/src/algorithms/graphs/propagate.rs
@@ -23,7 +23,7 @@ where
 
              inner.join_map(&edges, |_k,l,d| (d.clone(),l.clone()))
                   .concat(&nodes)
-                  .group(|_, s, t| t.push((s[0].0.clone(), 1)))
+                  .reduce(|_, s, t| t.push((s[0].0.clone(), 1)))
 
          })
 }
@@ -44,7 +44,7 @@ where
 
              inner.join_map(&edges, |_k,l,d| (d.clone(),l.clone()))
                   .concat(&nodes)
-                  .group(|_, s, t| t.push((s[0].0.clone(), 1)))
+                  .reduce(|_, s, t| t.push((s[0].0.clone(), 1)))
 
          })
 }

--- a/src/algorithms/graphs/sequential.rs
+++ b/src/algorithms/graphs/sequential.rs
@@ -88,7 +88,7 @@ where
             messages
                 // .concat(&old_messages)  // /-- possibly too clever: None if any inputs None.
                 // .antijoin(&incomplete)
-                .group(move |k, vs, t| t.push((Some(logic(k,vs)),1)))
+                .reduce(move |k, vs, t| t.push((Some(logic(k,vs)),1)))
                 .concat(&incomplete.map(|x| (x, None)))
         })
 }

--- a/src/algorithms/identifiers.rs
+++ b/src/algorithms/identifiers.rs
@@ -100,7 +100,7 @@ mod tests {
         // there are collisions, everyone gets a unique identifier.
 
         use ::input::Input;
-        use ::operators::{Threshold, Group};
+        use ::operators::{Threshold, Reduce};
         use ::operators::iterate::Iterate;
 
         ::timely::example(|scope| {

--- a/src/algorithms/identifiers.rs
+++ b/src/algorithms/identifiers.rs
@@ -53,11 +53,11 @@ where
         // with the lower round, breaking ties by record), and indicate
         // that the losers should increment their round and try again.
         //
-        // Non-obviously, this happens via a `group` operator that yields
+        // Non-obviously, this happens via a `reduce` operator that yields
         // additions and subtractions of losers, rather than reproducing
         // the winners. This is done under the premise that losers are
         // very rare, and maintaining winners in both the input and output
-        // of `group` is an unneccesary duplication.
+        // of `reduce` is an unneccesary duplication.
 
         use collection::AsCollection;
 
@@ -68,7 +68,7 @@ where
                 init.enter(&diff.scope())
                     .concat(&diff)
                     .map(|pair| (pair.hashed(), pair))
-                    .group(|_hash, input, output| {
+                    .reduce(|_hash, input, output| {
                         // keep round-positive records as changes.
                         let ((round, record), count) = &input[0];
                         if *round > 0 {
@@ -116,7 +116,7 @@ mod tests {
                     init.enter(&diff.scope())
                         .concat(&diff)
                         .map(|(round, num)| ((round + num) / 10, (round, num)))
-                        .group(|_hash, input, output| {
+                        .reduce(|_hash, input, output| {
                             // keep round-positive records as changes.
                             let ((round, record), count) = &input[0];
                             if *round > 0 {

--- a/src/operators/arrange.rs
+++ b/src/operators/arrange.rs
@@ -243,7 +243,7 @@ where T: Lattice+Ord+Clone+'static, Tr: TraceReader<K,V,T,R> {
     /// use timely::Configuration;
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::arrange::ArrangeBySelf;
-    /// use differential_dataflow::operators::group::Group;
+    /// use differential_dataflow::operators::reduce::Reduce;
     /// use differential_dataflow::trace::Trace;
     /// use differential_dataflow::trace::implementations::ord::OrdValSpine;
     /// use differential_dataflow::hashable::OrdWrapper;
@@ -266,7 +266,7 @@ where T: Lattice+Ord+Clone+'static, Tr: TraceReader<K,V,T,R> {
     ///         // create a second dataflow
     ///         worker.dataflow(move |scope| {
     ///             trace.import(scope)
-    ///                  .group(move |_key, src, dst| dst.push((*src[0].0, 1)));
+    ///                  .reduce(move |_key, src, dst| dst.push((*src[0].0, 1)));
     ///         });
     ///
     ///     }).unwrap();

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -4,7 +4,7 @@
 //! operators have specialized implementations to make them work efficiently, and are in addition
 //! to several operations defined directly on the `Collection` type (e.g. `map` and `filter`).
 
-pub use self::group::{Group, Threshold, Count, consolidate_from};
+pub use self::reduce::{Reduce, Threshold, Count, consolidate_from};
 pub use self::consolidate::Consolidate;
 pub use self::iterate::Iterate;
 pub use self::join::{Join, JoinCore};
@@ -12,13 +12,12 @@ pub use self::count::CountTotal;
 pub use self::threshold::ThresholdTotal;
 
 pub mod arrange;
-pub mod group;
+pub mod reduce;
 pub mod consolidate;
 pub mod iterate;
 pub mod join;
 pub mod count;
 pub mod threshold;
-// pub mod min;
 
 use ::difference::Monoid;
 use lattice::Lattice;

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -32,9 +32,9 @@ pub trait Reduce<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestamp: Latt
     /// Input data must be structured as `(key, val)` pairs.
     /// The user-supplied reduction function takes as arguments
     ///
-    ///     1. a reference to the key,
-    ///     2. a reference to the slice of values and their accumulated updates,
-    ///     3. a mutuable reference to a vector to populate with output values and accumulated updates.
+    /// 1. a reference to the key,
+    /// 2. a reference to the slice of values and their accumulated updates,
+    /// 3. a mutuable reference to a vector to populate with output values and accumulated updates.
     ///
     /// The user logic is only invoked for non-empty input collections, and it is safe to assume that the
     /// slice of input values is non-empty. The values are presented in sorted order, as defined by their
@@ -227,7 +227,7 @@ pub trait ReduceCore<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestamp: 
     /// extern crate differential_dataflow;
     ///
     /// use differential_dataflow::input::Input;
-    /// use differential_dataflow::operators::group::ReduceCore;
+    /// use differential_dataflow::operators::reduce::ReduceCore;
     /// use differential_dataflow::trace::Trace;
     /// use differential_dataflow::trace::implementations::ord::OrdValSpine;
     /// use differential_dataflow::hashable::OrdWrapper;
@@ -235,7 +235,6 @@ pub trait ReduceCore<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestamp: 
     /// fn main() {
     ///     ::timely::example(|scope| {
     ///
-    ///         // wrap and order input, then group manually.
     ///         let trace =
     ///         scope.new_collection_from(1 .. 10u32).1
     ///              .map(|x| (x, x))
@@ -265,7 +264,7 @@ pub trait ReduceCore<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestamp: 
 
     /// Solves for output updates when presented with inputs and would-be outputs.
     ///
-    /// Unlike `group_arranged`, this method may be called with an empty `input`,
+    /// Unlike `reduce_arranged`, this method may be called with an empty `input`,
     /// and it may not be safe to index into the first element.
     /// At least one of the two collections will be non-empty.
     fn reduce_core<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -1,17 +1,9 @@
-//! Group records by a key, and apply a reduction function.
+//! Applies a reduction function on records grouped by key.
 //!
-//! The `group` operators act on data that can be viewed as pairs `(key, val)`. They group records
-//! with the same key, and apply user supplied functions to the key and a list of values, which are
-//! expected to populate a list of output values.
-//!
-//! Several variants of `group` exist which allow more precise control over how grouping is done.
-//! For example, the `_by` suffixed variants take arbitrary data, but require a key-value selector
-//! to be applied to each record. The `_u` suffixed variants use unsigned integers as keys, and
-//! will use a dense array rather than a `HashMap` to store their keys.
-//!
-//! The list of values are presented as an iterator which internally merges sorted lists of values.
-//! This ordering can be exploited in several cases to avoid computation when only the first few
-//! elements are required.
+//! The `reduce` operator acts on `(key, val)` data.
+//! Records with the same key are grouped together, and a user-supplied reduction function is applied
+//! to the key and the list of values.
+//! The function is expected to populate a list of output values.
 
 use hashable::Hashable;
 use ::{Data, Collection};
@@ -33,9 +25,20 @@ use trace::implementations::ord::OrdKeySpine as DefaultKeyTrace;
 
 use trace::TraceReader;
 
-/// Extension trait for the `group` differential dataflow method.
-pub trait Group<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestamp: Lattice+Ord {
-    /// Groups records by their first field, and applies reduction logic to the associated values.
+/// Extension trait for the `reduce` differential dataflow method.
+pub trait Reduce<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestamp: Lattice+Ord {
+    /// Applies a reduction function on records grouped by key.
+    ///
+    /// Input data must be structured as `(key, val)` pairs.
+    /// The user-supplied reduction function takes as arguments
+    ///
+    ///     1. a reference to the key,
+    ///     2. a reference to the slice of values and their accumulated updates,
+    ///     3. a mutuable reference to a vector to populate with output values and accumulated updates.
+    ///
+    /// The user logic is only invoked for non-empty input collections, and it is safe to assume that the
+    /// slice of input values is non-empty. The values are presented in sorted order, as defined by their
+    /// `Ord` implementations.
     ///
     /// # Examples
     ///
@@ -44,24 +47,24 @@ pub trait Group<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestamp: Latti
     /// extern crate differential_dataflow;
     ///
     /// use differential_dataflow::input::Input;
-    /// use differential_dataflow::operators::Group;
+    /// use differential_dataflow::operators::Reduce;
     ///
     /// fn main() {
     ///     ::timely::example(|scope| {
-    ///         // report the first value for each group
+    ///         // report the smallest value for each group
     ///         scope.new_collection_from(1 .. 10).1
     ///              .map(|x| (x / 3, x))
-    ///              .group(|_key, src, dst| {
-    ///                  dst.push((*src[0].0, 1))
+    ///              .reduce(|_key, input, output| {
+    ///                  output.push((*input[0].0, 1))
     ///              });
     ///     });
     /// }
     /// ```
-    fn group<L, V2: Data, R2: Abelian>(&self, logic: L) -> Collection<G, (K, V2), R2>
+    fn reduce<L, V2: Data, R2: Abelian>(&self, logic: L) -> Collection<G, (K, V2), R2>
     where L: Fn(&K, &[(&V, R)], &mut Vec<(V2, R2)>)+'static;
 }
 
-impl<G, K, V, R> Group<G, K, V, R> for Collection<G, (K, V), R>
+impl<G, K, V, R> Reduce<G, K, V, R> for Collection<G, (K, V), R>
     where
         G: Scope,
         G::Timestamp: Lattice+Ord,
@@ -69,28 +72,28 @@ impl<G, K, V, R> Group<G, K, V, R> for Collection<G, (K, V), R>
         V: Data,
         R: Monoid,
  {
-    fn group<L, V2: Data, R2: Abelian>(&self, logic: L) -> Collection<G, (K, V2), R2>
+    fn reduce<L, V2: Data, R2: Abelian>(&self, logic: L) -> Collection<G, (K, V2), R2>
         where L: Fn(&K, &[(&V, R)], &mut Vec<(V2, R2)>)+'static {
         self.arrange_by_key()
-            .group_arranged::<_,_,DefaultValTrace<_,_,_,_>,_>(logic)
+            .reduce_abelian::<_,_,DefaultValTrace<_,_,_,_>,_>(logic)
             .as_collection(|k,v| (k.clone(), v.clone()))
     }
 }
 
-impl<G: Scope, K: Data, V: Data, T1, R: Monoid> Group<G, K, V, R> for Arranged<G, K, V, R, T1>
+impl<G: Scope, K: Data, V: Data, T1, R: Monoid> Reduce<G, K, V, R> for Arranged<G, K, V, R, T1>
 where
     G::Timestamp: Lattice+Ord,
     T1: TraceReader<K, V, G::Timestamp, R>+Clone+'static,
     T1::Batch: BatchReader<K, V, G::Timestamp, R>
 {
-    fn group<L, V2: Data, R2: Abelian>(&self, logic: L) -> Collection<G, (K, V2), R2>
+    fn reduce<L, V2: Data, R2: Abelian>(&self, logic: L) -> Collection<G, (K, V2), R2>
         where L: Fn(&K, &[(&V, R)], &mut Vec<(V2, R2)>)+'static {
-        self.group_arranged::<_,_,DefaultValTrace<_,_,_,_>,_>(logic)
+        self.reduce_abelian::<_,_,DefaultValTrace<_,_,_,_>,_>(logic)
             .as_collection(|k,v| (k.clone(), v.clone()))
     }
 }
 
-/// Extension trait for the `distinct` differential dataflow method.
+/// Extension trait for the `threshold` and `distinct` differential dataflow methods.
 pub trait Threshold<G: Scope, K: Data, R1: Monoid> where G::Timestamp: Lattice+Ord {
     /// Transforms the multiplicity of records.
     ///
@@ -146,7 +149,7 @@ impl<G: Scope, K: Data+Hashable, R1: Monoid> Threshold<G, K, R1> for Collection<
 where G::Timestamp: Lattice+Ord {
     fn threshold<R2: Abelian, F: Fn(&K,R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
         self.arrange_by_self()
-            .group_arranged::<_,_,DefaultKeyTrace<_,_,_>,_>(move |k,s,t| t.push(((), thresh(k, s[0].1.clone()))))
+            .reduce_abelian::<_,_,DefaultKeyTrace<_,_,_>,_>(move |k,s,t| t.push(((), thresh(k, s[0].1.clone()))))
             .as_collection(|k,_| k.clone())
     }
 }
@@ -157,7 +160,7 @@ where
     T1: TraceReader<K, (), G::Timestamp, R1>+Clone+'static,
     T1::Batch: BatchReader<K, (), G::Timestamp, R1> {
     fn threshold<R2: Abelian, F: Fn(&K,R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
-        self.group_arranged::<_,_,DefaultKeyTrace<_,_,_>,_>(move |k,s,t| t.push(((), thresh(k, s[0].1.clone()))))
+        self.reduce_abelian::<_,_,DefaultKeyTrace<_,_,_>,_>(move |k,s,t| t.push(((), thresh(k, s[0].1.clone()))))
             .as_collection(|k,_| k.clone())
     }
 }
@@ -193,7 +196,7 @@ where
 {
     fn count(&self) -> Collection<G, (K, R), isize> {
         self.arrange_by_self()
-            .group_arranged::<_,_,DefaultValTrace<_,_,_,_>,_>(|_k,s,t| t.push((s[0].1.clone(), 1)))
+            .reduce_abelian::<_,_,DefaultValTrace<_,_,_,_>,_>(|_k,s,t| t.push((s[0].1.clone(), 1)))
             .as_collection(|k,c| (k.clone(), c.clone()))
     }
 }
@@ -205,13 +208,13 @@ where
     T1::Batch: BatchReader<K, (), G::Timestamp, R>
 {
     fn count(&self) -> Collection<G, (K, R), isize> {
-        self.group_arranged::<_,_,DefaultValTrace<_,_,_,_>,_>(|_k,s,t| t.push((s[0].1.clone(), 1)))
+        self.reduce_abelian::<_,_,DefaultValTrace<_,_,_,_>,_>(|_k,s,t| t.push((s[0].1.clone(), 1)))
             .as_collection(|k,c| (k.clone(), c.clone()))
     }
 }
 
 /// Extension trait for the `group_arranged` differential dataflow method.
-pub trait GroupArranged<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestamp: Lattice+Ord {
+pub trait ReduceCore<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestamp: Lattice+Ord {
     /// Applies `group` to arranged data, and returns an arrangement of output data.
     ///
     /// This method is used by the more ergonomic `group`, `distinct`, and `count` methods, although
@@ -224,7 +227,7 @@ pub trait GroupArranged<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestam
     /// extern crate differential_dataflow;
     ///
     /// use differential_dataflow::input::Input;
-    /// use differential_dataflow::operators::group::GroupArranged;
+    /// use differential_dataflow::operators::group::ReduceCore;
     /// use differential_dataflow::trace::Trace;
     /// use differential_dataflow::trace::implementations::ord::OrdValSpine;
     /// use differential_dataflow::hashable::OrdWrapper;
@@ -236,14 +239,14 @@ pub trait GroupArranged<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestam
     ///         let trace =
     ///         scope.new_collection_from(1 .. 10u32).1
     ///              .map(|x| (x, x))
-    ///              .group_arranged::<_,_,OrdValSpine<_,_,_,_>,_>(
+    ///              .reduce_abelian::<_,_,OrdValSpine<_,_,_,_>,_>(
     ///                  move |_key, src, dst| dst.push((*src[0].0, 1))
     ///              )
     ///              .trace;
     ///     });
     /// }
     /// ```
-    fn group_arranged<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>
+    fn reduce_abelian<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>
         where
             V2: Data,
             R2: Abelian,
@@ -251,7 +254,7 @@ pub trait GroupArranged<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestam
             T2::Batch: Batch<K, V2, G::Timestamp, R2>,
             L: Fn(&K, &[(&V, R)], &mut Vec<(V2, R2)>)+'static,
         {
-            self.group_solve(move |key, input, output, change| {
+            self.reduce_core(move |key, input, output, change| {
                 if !input.is_empty() {
                     logic(key, input, change);
                 }
@@ -265,7 +268,7 @@ pub trait GroupArranged<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestam
     /// Unlike `group_arranged`, this method may be called with an empty `input`,
     /// and it may not be safe to index into the first element.
     /// At least one of the two collections will be non-empty.
-    fn group_solve<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>
+    fn reduce_core<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>
         where
             V2: Data,
             R2: Monoid,
@@ -275,7 +278,7 @@ pub trait GroupArranged<G: Scope, K: Data, V: Data, R: Monoid> where G::Timestam
             ;
 }
 
-impl<G, K, V, R> GroupArranged<G, K, V, R> for Collection<G, (K, V), R>
+impl<G, K, V, R> ReduceCore<G, K, V, R> for Collection<G, (K, V), R>
 where
     G: Scope,
     G::Timestamp: Lattice+Ord,
@@ -283,7 +286,7 @@ where
     V: Data,
     R: Monoid,
 {
-    fn group_solve<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>
+    fn reduce_core<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>
         where
             V2: Data,
             R2: Monoid,
@@ -292,17 +295,17 @@ where
             L: Fn(&K, &[(&V, R)], &mut Vec<(V2,R2)>, &mut Vec<(V2, R2)>)+'static
     {
         self.arrange_by_key()
-            .group_solve(logic)
+            .reduce_core(logic)
     }
 }
 
-impl<G: Scope, K: Data, V: Data, T1, R: Monoid> GroupArranged<G, K, V, R> for Arranged<G, K, V, R, T1>
+impl<G: Scope, K: Data, V: Data, T1, R: Monoid> ReduceCore<G, K, V, R> for Arranged<G, K, V, R, T1>
 where
     G::Timestamp: Lattice+Ord,
     T1: TraceReader<K, V, G::Timestamp, R>+Clone+'static,
     T1::Batch: BatchReader<K, V, G::Timestamp, R> {
 
-    fn group_solve<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>
+    fn reduce_core<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>
         where
             V2: Data,
             R2: Monoid,
@@ -316,7 +319,7 @@ where
         let stream = {
 
             let result_trace = &mut result_trace;
-            self.stream.unary_frontier(Pipeline, "Group", move |_capability, operator_info| {
+            self.stream.unary_frontier(Pipeline, "Reduce", move |_capability, operator_info| {
 
                 let logger = {
                     let scope = self.stream.scope();
@@ -359,7 +362,7 @@ where
 
                 move |input, output| {
 
-                    // The `group` operator receives fully formed batches, which each serve as an indication
+                    // The `reduce` operator receives fully formed batches, which each serve as an indication
                     // that the frontier has advanced to the upper bound of their description.
                     //
                     // Although we could act on each individually, several may have been sent, and it makes

--- a/tests/bfs.rs
+++ b/tests/bfs.rs
@@ -217,6 +217,6 @@ where G::Timestamp: Lattice+Ord {
 
         inner.join_map(&edges, |_k,l,d| (*d, l+1))
              .concat(&nodes)
-             .group(|_, s, t| t.push((*s[0].0, 1)))
+             .reduce(|_, s, t| t.push((*s[0].0, 1)))
      })
 }

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -8,7 +8,7 @@ use timely::dataflow::operators::capture::Extract;
 use differential_dataflow::input::InputSession;
 use differential_dataflow::collection::AsCollection;
 use differential_dataflow::operators::arrange::{ArrangeByKey, ArrangeBySelf};
-use differential_dataflow::operators::group::Group;
+use differential_dataflow::operators::reduce::Reduce;
 use differential_dataflow::trace::TraceReader;
 use itertools::Itertools;
 
@@ -61,7 +61,7 @@ fn test_import() {
                 ::std::mem::drop(trace);
                 let captured =
                 imported
-                    .group(|_k, s, t| t.push((s.iter().map(|&(_, w)| w).sum(), 1i64)))
+                    .reduce(|_k, s, t| t.push((s.iter().map(|&(_, w)| w).sum(), 1i64)))
                     .inner
                     .exchange(|_| 0)
                     .capture();
@@ -131,7 +131,7 @@ fn test_import_completed_dataflow() {
                 ::std::mem::drop(trace);
                 let stream =
                 imported
-                    .group(|_k, s, t| t.push((s.iter().map(|&(_, w)| w).sum(), 1i64)))
+                    .reduce(|_k, s, t| t.push((s.iter().map(|&(_, w)| w).sum(), 1i64)))
                     .inner
                     .exchange(|_| 0);
                 let probe = stream.probe();

--- a/tests/reduce.rs
+++ b/tests/reduce.rs
@@ -4,10 +4,10 @@ extern crate differential_dataflow;
 use timely::dataflow::operators::{ToStream, Capture, Map};
 use timely::dataflow::operators::capture::Extract;
 use differential_dataflow::AsCollection;
-use differential_dataflow::operators::{Group, Count};
+use differential_dataflow::operators::{Reduce, Count};
 
 #[test]
-fn group() {
+fn reduce() {
 
     let data = timely::example(|scope| {
 
@@ -16,7 +16,7 @@ fn group() {
                         .to_stream(scope)
                         .as_collection();
 
-        col1.group(|_,s,t| t.push((*s[0].0, s.len() as isize))).inner.capture()
+        col1.reduce(|_,s,t| t.push((*s[0].0, s.len() as isize))).inner.capture()
     });
 
     let extracted = data.extract();
@@ -25,7 +25,7 @@ fn group() {
 }
 
 #[test]
-fn group_scaling() {
+fn reduce_scaling() {
 
     let data = timely::example(|scope| {
 

--- a/tests/scc.rs
+++ b/tests/scc.rs
@@ -254,7 +254,7 @@ where G::Timestamp: Lattice+Ord+Hash {
 
              inner.join_map(&edges, |_k,l,d| (*d,*l))
                   .concat(&nodes)
-                  .group(|_, s, t| t.push((*s[0].0, 1)))
+                  .reduce(|_, s, t| t.push((*s[0].0, 1)))
 
          })
 }

--- a/tpchlike/src/queries/query02.rs
+++ b/tpchlike/src/queries/query02.rs
@@ -102,7 +102,7 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
         .semijoin(&suppliers.map(|x| x.0))
         .map(|(supp, (part, supply_cost))| (part, (supply_cost, supp)))
         .semijoin(&parts.map(|x| x.0))
-        .group(|_x, s, t| {
+        .reduce(|_x, s, t| {
             let minimum = (s[0].0).0;
             t.extend(s.iter().take_while(|x| (x.0).0 == minimum).map(|&(&x,w)| (x,w)));
         });

--- a/tpchlike/src/queries/query11.rs
+++ b/tpchlike/src/queries/query11.rs
@@ -46,7 +46,7 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
     source.len() >= query.len() && &source[..query.len()] == query
 }
 
-pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
+pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp>
 where G::Timestamp: Lattice+TotalOrder+Ord {
 
     let nations =
@@ -67,7 +67,7 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
         .explode(|x| Some(((x.supp_key, x.part_key), (x.supplycost as isize) * (x.availqty as isize))))
         .semijoin(&suppliers)
         .map(|(_, part_key)| ((), part_key))
-        .group(|_part_key, s, t| {
+        .reduce(|_part_key, s, t| {
             let threshold: isize = s.iter().map(|x| x.1 as isize).sum::<isize>() / 10000;
             t.extend(s.iter().filter(|x| x.1 > threshold).map(|&(&a,b)| (a, b)));
         })

--- a/tpchlike/src/queries/query15.rs
+++ b/tpchlike/src/queries/query15.rs
@@ -49,11 +49,11 @@ use ::types::create_date;
 // drop view revenue:s;
 // :n -1
 
-pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
+pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp>
 where G::Timestamp: Lattice+TotalOrder+Ord {
 
     // revenue by supplier
-    let revenue = 
+    let revenue =
         collections
             .lineitems()
             .explode(|item|
@@ -68,22 +68,22 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
         revenue
             // do a hierarchical min, to improve update perf.
             .map(|key| ((key % 1000) as u16, key))
-            .group(|_k, s, t| {
+            .reduce(|_k, s, t| {
                 let max = s.iter().map(|x| x.1).max().unwrap();
                 t.extend(s.iter().filter(|x| x.1 == max).map(|&(&a,b)| (a,b)));
             })
             .map(|(_,key)| ((key % 100) as u8, key))
-            .group(|_k, s, t| {
+            .reduce(|_k, s, t| {
                 let max = s.iter().map(|x| x.1).max().unwrap();
                 t.extend(s.iter().filter(|x| x.1 == max).map(|&(&a,b)| (a,b)));
             })
             .map(|(_,key)| ((key % 10) as u8, key))
-            .group(|_k, s, t| {
+            .reduce(|_k, s, t| {
                 let max = s.iter().map(|x| x.1).max().unwrap();
                 t.extend(s.iter().filter(|x| x.1 == max).map(|&(&a,b)| (a,b)));
             })
             .map(|(_,key)| ((), key))
-            .group(|_k, s, t| {
+            .reduce(|_k, s, t| {
                 let max = s.iter().map(|x| x.1).max().unwrap();
                 t.extend(s.iter().filter(|x| x.1 == max).map(|&(&a,b)| (a,b)));
             })

--- a/tpchlike/src/queries/query17.rs
+++ b/tpchlike/src/queries/query17.rs
@@ -32,10 +32,10 @@ use ::Collections;
 //   );
 // :n -1
 
-pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
+pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp>
 where G::Timestamp: Lattice+TotalOrder+Ord {
 
-    let parts = 
+    let parts =
     collections
         .parts()   // We fluff out search strings to have the right lengths. \\
         .flat_map(|x|  {
@@ -49,7 +49,7 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
         .lineitems()
         .map(|x| (x.part_key, (x.quantity, x.extended_price)))
         .semijoin(&parts)
-        .group(|_k, s, t| {
+        .reduce(|_k, s, t| {
 
             // determine the total and count of quantity.
             let total: i64 = s.iter().map(|x| (x.0).0 * (x.1 as i64)).sum();

--- a/tpchlike/src/queries/query20.rs
+++ b/tpchlike/src/queries/query20.rs
@@ -3,7 +3,7 @@ use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::operators::*;
-use differential_dataflow::operators::group::GroupArranged;
+use differential_dataflow::operators::reduce::ReduceCore;
 use differential_dataflow::trace::implementations::ord::OrdValSpine as DefaultValTrace;
 use differential_dataflow::lattice::Lattice;
 
@@ -62,7 +62,7 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
 pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp>
 where G::Timestamp: Lattice+TotalOrder+Ord {
 
-    println!("TODO: Q20 uses a `group_arranged` to get an arrangement, but could use `count_total`");
+    println!("TODO: Q20 uses a `reduce_abelian` to get an arrangement, but could use `count_total`");
 
     let partkeys = collections.parts.filter(|p| p.name.as_bytes() == b"forest").map(|p| p.part_key);
 
@@ -77,7 +77,7 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
         )
         .semijoin(&partkeys)
         .explode(|l| Some(((((l.0 as u64) << 32) + (l.1).0 as u64, ()), (l.1).1 as isize)))
-        .group_arranged::<_,_,DefaultValTrace<_,_,_,_>,_>(|_k,s,t| t.push((s[0].1, 1)));
+        .reduce_abelian::<_,_,DefaultValTrace<_,_,_,_>,_>(|_k,s,t| t.push((s[0].1, 1)));
 
     let suppliers =
     collections

--- a/tpchlike/src/queries/query21.rs
+++ b/tpchlike/src/queries/query21.rs
@@ -60,7 +60,7 @@ fn starts_with(source: &[u8], query: &[u8]) -> bool {
     source.len() >= query.len() && &source[..query.len()] == query
 }
 
-pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp> 
+pub fn query<G: Scope>(collections: &mut Collections<G>) -> ProbeHandle<G::Timestamp>
 where G::Timestamp: Lattice+TotalOrder+Ord {
 
     let orders =
@@ -81,14 +81,14 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     let lateitems = lineitems.filter(|l| (l.1).1);
     let lateorders = lateitems.map(|l| l.0).distinct_total();
 
-    let problems = 
+    let problems =
     lineitems
         .map(|(order_key, (_supp_key, is_late))| (order_key, is_late))
         .semijoin(&lateorders)    //- on_time and late, but just one late -\\
-        .group(|_order_key, s, t| if s.len() == 2 && s[1].1 == 1 { t.push(((), 1)); })
+        .reduce(|_order_key, s, t| if s.len() == 2 && s[1].1 == 1 { t.push(((), 1)); })
         .map(|(order_key, _)| order_key);
 
-    let latesupps = 
+    let latesupps =
     lateitems
         .semijoin(&problems)
         .map(|(_order_key, (supp_key, _))| supp_key);

--- a/tpchlike/src/queries/query22.rs
+++ b/tpchlike/src/queries/query22.rs
@@ -4,7 +4,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 
 use differential_dataflow::operators::*;
 use differential_dataflow::difference::DiffPair;
-use differential_dataflow::operators::group::GroupArranged;
+use differential_dataflow::operators::reduce::ReduceCore;
 use differential_dataflow::operators::ThresholdTotal;
 use differential_dataflow::lattice::Lattice;
 
@@ -80,7 +80,7 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
     let averages =
     customers
         .explode(|(cc, acctbal, _)| Some(((cc, ()), DiffPair::new(acctbal as isize, 1))))
-        .group_arranged::<_,_,DefaultValTrace<_,_,_,_>,_>(|_k,s,t| t.push((s[0].1, 1)));
+        .reduce_abelian::<_,_,DefaultValTrace<_,_,_,_>,_>(|_k,s,t| t.push((s[0].1, 1)));
 
     customers
         .map(|(cc, acct, key)| (key, (cc, acct)))


### PR DESCRIPTION
This PR changes the `group` module and operator to `reduce`, as well as normalizing other aspects of method naming. This change is mostly to line up with existing use of `reduce` from MapReduce, which is for many users a common reference point and from which `group` has limited difference. Historically, LINQ had a `GroupBy` method that performed approximately the same logic, and the `group` named derived from this lineage. Going forward, probably best to stick with what everyone else already uses.