### PR TITLE
Remove `Lattice::maximum()`

### DIFF
--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -87,7 +87,7 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fm
 
 		// 1. For each (time, diff) pair, advance the time.
 		for i in time_start .. layer.vals.vals.vals.len() {
-			layer.vals.vals.vals[i].0 = layer.vals.vals.vals[i].0.advance_by(frontier);
+			layer.vals.vals.vals[i].0.advance_by(frontier);
 		}
 
 		// 2. For each `(val, off)` pair, sort the range, compact, and rewrite `off`.
@@ -366,7 +366,7 @@ where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Monoid {
 
 		// 1. For each (time, diff) pair, advance the time.
 		for i in time_start .. layer.vals.vals.len() {
-			layer.vals.vals[i].0 = layer.vals.vals[i].0.advance_by(frontier);
+			layer.vals.vals[i].0.advance_by(frontier);
 		}
 		// for time_diff in self.layer.vals.vals.iter_mut() {
 		// 	time_diff.0 = time_diff.0.advance_by(frontier);


### PR DESCRIPTION
This PR removes the `maximum()` method from the `Lattice` trait, enabling a larger class of timestamps appropriate for differential dataflow. Previously, `maximum()` was used in only two places:

1. In `reduce.rs` where it simplified the maintenance of the running `meet`. Where we previously started from `maximum()` and went down, we now use `Option<T>` like we probably should have done from the start.

2. In `Lattice::advance_by()` we used `maximum()` as the return value for an empty frontier. The result should be an `Option<T>` but we are a bit too lazy to do that right now (the result is only optional with an empty input frontier, which can be observed by the caller and probably shouldn't result in a call.

The advantage of this relaxation is that we can use timestamp types without a largest element. The specific example that precipitated this was `Vec<T> where T: Lattice`.