### PR TITLE
Unmanaged arrangements

### DIFF
--- a/tests/import.rs
+++ b/tests/import.rs
@@ -266,7 +266,7 @@ fn test_import_unmanaged() {
                     .exchange(|_| 0)
                     .capture();
 
-                ::std::mem::forget(imported.killswitch);
+                ::std::boxed::Box::leak(::std::boxed::Box::new(imported.killswitch));
                 
                 (captured,)
             });


### PR DESCRIPTION
This isn't ready for prime-time yet, but I could use some feedback. 
If the general approach seems sane, I can clean things up.

For one, I haven't actually integrated this with declarative, to see whether it actually solves the unregistering problem and leads to a proper cleanup. Will check that now.

The other thing is that now `import_named` and `import_unmanaged` do mostly the same things. I think the former could be reduced to the latter + `Box::leak(killswitch)` but I'm not sure.
Other than that, current arrangement API is unaffected by these additions.