### PR TITLE
Monoid for worst case optimal joins

### DIFF
--- a/dogsdogsdogs/src/altneu.rs
+++ b/dogsdogsdogs/src/altneu.rs
@@ -75,7 +75,6 @@ impl<T: Timestamp> Refines<T> for AltNeu<T> {
 use differential_dataflow::lattice::Lattice;
 impl<T: Lattice> Lattice for AltNeu<T> {
     fn minimum() -> Self { AltNeu::alt(T::minimum()) }
-    fn maximum() -> Self { AltNeu::neu(T::maximum()) }
     fn join(&self, other: &Self) -> Self {
         let time = self.time.join(&other.time);
         let mut neu = false;

--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -151,13 +151,15 @@ where
 
     pub fn index<G: Scope<Timestamp = T>>(collection: &Collection<G, (K, V), R>) -> Self {
         // We need to count the number of (k, v) pairs and not rely on the given Monoid R and its binary addition operation.
-        let counts = collection
+        // counts and validate can share the base arrangement
+        let arranged = collection.arrange_by_self();
+        let counts = arranged
             .distinct()
             .map(|(k, _v)| k)
             .arrange_by_self()
             .trace;
         let propose = collection.arrange_by_key().trace;
-        let validate = collection.arrange_by_self().trace;
+        let validate = arranged.trace;
 
         CollectionIndex {
             count_trace: counts,

--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -365,7 +365,7 @@ where
                                 if cursor.get_key(&storage) == Some(&key) {
                                     while let Some(value) = cursor.get_val(&storage) {
                                         let mut count = R::zero();
-                                        cursor.map_times(&storage, |t, d| if t.less_equal(time) { count = count + d; });
+                                        cursor.map_times(&storage, |t, d| if t.less_equal(time) { count += d; });
                                         // assert!(count >= 0);
                                         if count > R::zero() {
                                             session.give(((prefix.clone(), value.clone()), time.clone(), diff.clone()));
@@ -459,7 +459,7 @@ where
                                 cursor.seek_key(&storage, &key);
                                 if cursor.get_key(&storage) == Some(&key) {
                                     let mut count = R::zero();
-                                    cursor.map_times(&storage, |t, d| if t.less_equal(time) { count = count + d; });
+                                    cursor.map_times(&storage, |t, d| if t.less_equal(time) { count += d; });
                                     // assert!(count >= 0);
                                     if count > R::zero(){
                                         session.give((prefix.clone(), time.clone(), diff.clone()));

--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -280,7 +280,7 @@ where
                             }
                         }
 
-                        prefixes.retain(|ptd| ptd.2 != R::zero());
+                        prefixes.retain(|ptd| !ptd.2.is_zero());
                     }
                 }
             }
@@ -360,9 +360,9 @@ where
                                     while let Some(value) = cursor.get_val(&storage) {
                                         let mut count = R::zero();
                                         cursor.map_times(&storage, |t, d| if t.less_equal(time) { count += d; });
-                                        // assert!(count >= 0);
-                                        if count > R::zero() {
-                                            session.give(((prefix.clone(), value.clone()), time.clone(), diff.clone() * count));
+                                        let prod = count * diff.clone();
+                                        if !prod.is_zero() {
+                                            session.give(((prefix.clone(), value.clone()), time.clone(), prod));
                                         }
                                         cursor.step_val(&storage);
                                     }
@@ -372,7 +372,7 @@ where
                             }
                         }
 
-                        prefixes.retain(|ptd| ptd.2 != R::zero());
+                        prefixes.retain(|ptd| !ptd.2.is_zero());
                     }
                 }
             }
@@ -454,16 +454,16 @@ where
                                 if cursor.get_key(&storage) == Some(&key) {
                                     let mut count = R::zero();
                                     cursor.map_times(&storage, |t, d| if t.less_equal(time) { count += d; });
-                                    // assert!(count >= 0);
-                                    if count > R::zero(){
-                                        session.give((prefix.clone(), time.clone(), diff.clone() * count));
+                                    let prod = count * diff.clone();
+                                    if !prod.is_zero(){
+                                        session.give((prefix.clone(), time.clone(), prod));
                                     }
                                 }
                                 *diff = R::zero();
                             }
                         }
 
-                        prefixes.retain(|ptd| ptd.2 != R::zero());
+                        prefixes.retain(|ptd| !ptd.2.is_zero());
                     }
                 }
             }

--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -362,7 +362,7 @@ where
                                         cursor.map_times(&storage, |t, d| if t.less_equal(time) { count += d; });
                                         // assert!(count >= 0);
                                         if count > R::zero() {
-                                            session.give(((prefix.clone(), value.clone()), time.clone(), diff.clone()));
+                                            session.give(((prefix.clone(), value.clone()), time.clone(), diff.clone() * count));
                                         }
                                         cursor.step_val(&storage);
                                     }
@@ -456,7 +456,7 @@ where
                                     cursor.map_times(&storage, |t, d| if t.less_equal(time) { count += d; });
                                     // assert!(count >= 0);
                                     if count > R::zero(){
-                                        session.give((prefix.clone(), time.clone(), diff.clone()));
+                                        session.give((prefix.clone(), time.clone(), diff.clone() * count));
                                     }
                                 }
                                 *diff = R::zero();

--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -149,7 +149,7 @@ where
 {
 
     pub fn index<G: Scope<Timestamp = T>>(collection: &Collection<G, (K, V), R>) -> Self {
-        // We need to count the number of (k, v) pairs and not rely on the given Monoid R and use its binary addition operation later.
+        // We need to count the number of (k, v) pairs and not rely on the given Monoid R and its binary addition operation.
         // We assume that input collections are distinct (k, v) pairs.
         let counts = collection
             .inner


### PR DESCRIPTION
Most of it is straight forward type changing, but theres the part about correctly counting the occurrences of tuples whilst proposing the extensions.

If we have a `Max` monoid "counting" would result in prefixed proposing potentially more results than they prior "counted". 

Assuming that the indexed collections are distinct (key, value) pairs we can count +1 if the diff is positive and -1 if negative. Thats why we need a `is_inverse()` method in the diff trait. The count trace should contain `isize` diffs. Or maybe I am mistaken here?

It feels like there is a more elegant way though instead of using is_inverse ...