### PR TITLE
Import unset

### DIFF
--- a/src/operators/arrange.rs
+++ b/src/operators/arrange.rs
@@ -313,9 +313,8 @@ where
                 if let Some(ref mut capabilities) = *capabilities {
 
                     let mut borrow = queue.1.borrow_mut();
-                    while let Some((frontier, sent)) = borrow.pop_front() {
+                    for (frontier, sent) in borrow.drain(..) {
 
-                        // if data are associated, send em!
                         if let Some((time, batch)) = sent {
                             let delayed = capabilities.delayed(&time);
                             output.session(&delayed).give(batch);


### PR DESCRIPTION
This PR steals from #146 (with permission) to introduce a method `import_core` that returns in addition to an arrangement a `ShutdownButton` (name pending) with a single method `push()` that causes the imported arrangement to cease producing output batches. This is meant to allow clean shutdown of dataflow graphs without requiring the termination of the input arrangements on which they depend.

The PR also uses `CapabilitySet<T>` from timely dataflow, which tidies up the implementation quite a bit!

cc @comnik @utaal 