### PR TITLE
Replace #[inline(always)] with #[inline].

### DIFF
--- a/src/difference.rs
+++ b/src/difference.rs
@@ -24,7 +24,7 @@ pub trait Monoid : for<'a> AddAssign<&'a Self> + ::std::marker::Sized + Data + C
 	/// This is primarily used by differential dataflow to know when it is safe to delete an update.
 	/// When a difference accumulates to zero, the difference has no effect on any accumulation and can
 	/// be removed.
-	#[inline(always)]
+	#[inline]
 	fn is_zero(&self) -> bool { self.eq(&Self::zero()) }
 	/// The additive identity.
 	///
@@ -43,15 +43,15 @@ pub trait Abelian : Monoid + Neg<Output=Self> { }
 impl<T: Monoid + Neg<Output=Self>> Abelian for T { }
 
 impl Monoid for isize {
-	#[inline(always)] fn zero() -> Self { 0 }
+	#[inline] fn zero() -> Self { 0 }
 }
 
 impl Monoid for i64 {
-	#[inline(always)] fn zero() -> Self { 0 }
+	#[inline] fn zero() -> Self { 0 }
 }
 
 impl Monoid for i32 {
-	#[inline(always)] fn zero() -> Self { 0 }
+	#[inline] fn zero() -> Self { 0 }
 }
 
 /// The difference defined by a pair of difference elements.
@@ -70,7 +70,7 @@ pub struct DiffPair<R1, R2> {
 
 impl<R1, R2> DiffPair<R1, R2> {
 	/// Creates a new Diff pair from two elements.
-	#[inline(always)] pub fn new(elt1: R1, elt2: R2) -> Self {
+	#[inline] pub fn new(elt1: R1, elt2: R2) -> Self {
 		DiffPair {
 			element1: elt1,
 			element2: elt2,
@@ -79,7 +79,7 @@ impl<R1, R2> DiffPair<R1, R2> {
 }
 
 impl<R1: Monoid, R2: Monoid> Monoid for DiffPair<R1, R2> {
-	#[inline(always)] fn zero() -> Self {
+	#[inline] fn zero() -> Self {
 		DiffPair {
 			element1: R1::zero(),
 			element2: R2::zero(),
@@ -88,7 +88,7 @@ impl<R1: Monoid, R2: Monoid> Monoid for DiffPair<R1, R2> {
 }
 
 impl<'a, R1: AddAssign<&'a R1>, R2: AddAssign<&'a R2>> AddAssign<&'a DiffPair<R1, R2>> for DiffPair<R1, R2> {
-	#[inline(always)] fn add_assign(&mut self, rhs: &'a Self) {
+	#[inline] fn add_assign(&mut self, rhs: &'a Self) {
 		self.element1 += &rhs.element1;
 		self.element2 += &rhs.element2;
 	}
@@ -96,7 +96,7 @@ impl<'a, R1: AddAssign<&'a R1>, R2: AddAssign<&'a R2>> AddAssign<&'a DiffPair<R1
 
 impl<R1: Neg, R2: Neg> Neg for DiffPair<R1, R2> {
 	type Output = DiffPair<<R1 as Neg>::Output, <R2 as Neg>::Output>;
-	#[inline(always)] fn neg(self) -> Self::Output {
+	#[inline] fn neg(self) -> Self::Output {
 		DiffPair {
 			element1: -self.element1,
 			element2: -self.element2,
@@ -133,16 +133,16 @@ pub struct DiffVector<R> {
 }
 
 impl<R: Monoid> Monoid for DiffVector<R> {
-	#[inline(always)] fn is_zero(&self) -> bool {
+	#[inline] fn is_zero(&self) -> bool {
 		self.buffer.iter().all(|x| x.is_zero())
 	}
-	#[inline(always)] fn zero() -> Self {
+	#[inline] fn zero() -> Self {
 		Self { buffer: Vec::new() }
 	}
 }
 
 impl<'a, R: AddAssign<&'a R>+Clone> AddAssign<&'a DiffVector<R>> for DiffVector<R> {
-	#[inline(always)]
+	#[inline]
 	fn add_assign(&mut self, rhs: &'a Self) {
 
 		// Ensure sufficient length to receive addition.
@@ -160,7 +160,7 @@ impl<'a, R: AddAssign<&'a R>+Clone> AddAssign<&'a DiffVector<R>> for DiffVector<
 
 impl<R: Neg<Output=R>+Clone> Neg for DiffVector<R> {
 	type Output = DiffVector<<R as Neg>::Output>;
-	#[inline(always)]
+	#[inline]
 	fn neg(mut self) -> Self::Output {
 		for update in self.buffer.iter_mut() {
 			*update = -update.clone();

--- a/src/hashable.rs
+++ b/src/hashable.rs
@@ -101,13 +101,13 @@ pub struct OrdWrapper<T: Ord+Hashable> {
 }
 
 impl<T: Ord+Hashable> PartialOrd for OrdWrapper<T> {
-    #[inline(always)]
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
         (self.item.hashed(), &self.item).partial_cmp(&(other.item.hashed(), &other.item))
     }
 }
 impl<T: Ord+Hashable> Ord for OrdWrapper<T> {
-    #[inline(always)]
+    #[inline]
     fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
         (self.item.hashed(), &self.item).cmp(&(other.item.hashed(), &other.item))
     }
@@ -134,18 +134,18 @@ pub struct HashableWrapper<T: Hashable> {
 
 impl<T: Hashable> Hashable for HashableWrapper<T> {
     type Output = T::Output;
-    #[inline(always)]
+    #[inline]
     fn hashed(&self) -> T::Output { self.hash }
 }
 
 impl<T: Hashable> Deref for HashableWrapper<T> {
     type Target = T;
-    #[inline(always)]
+    #[inline]
     fn deref(&self) -> &T { &self.item }
 }
 
 impl<T: Hashable> From<T> for HashableWrapper<T> {
-    #[inline(always)]
+    #[inline]
     fn from(item: T) -> HashableWrapper<T> {
         HashableWrapper {
             hash: item.hashed(),
@@ -163,17 +163,17 @@ pub struct UnsignedWrapper<T: Unsigned+Copy> {
 
 impl<T: Unsigned+Copy> Hashable for UnsignedWrapper<T> {
     type Output = T;
-    #[inline(always)]
+    #[inline]
     fn hashed(&self) -> Self::Output { self.item }
 }
 
 impl<T: Unsigned+Copy> Deref for UnsignedWrapper<T> {
     type Target = T;
-    #[inline(always)]
+    #[inline]
     fn deref(&self) -> &T { &self.item }
 }
 
 impl<T: Unsigned+Copy> From<T> for UnsignedWrapper<T> {
-    #[inline(always)]
+    #[inline]
     fn from(item: T) -> Self { UnsignedWrapper { item } }
 }

--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -149,7 +149,7 @@ pub trait Lattice : PartialOrder {
     /// assert_eq!(advanced, Product::new(4, 7));
     /// # }
     /// ```
-    #[inline(always)]
+    #[inline]
     fn advance_by(&mut self, frontier: &[Self]) where Self: Sized {
         if let Some(first) = frontier.get(0) {
             let mut result = self.join(first);
@@ -164,16 +164,16 @@ pub trait Lattice : PartialOrder {
 use timely::order::Product;
 
 impl<T1: Lattice, T2: Lattice> Lattice for Product<T1, T2> {
-    #[inline(always)]
+    #[inline]
     fn minimum() -> Self { Product::new(T1::minimum(), T2::minimum()) }
-    #[inline(always)]
+    #[inline]
     fn join(&self, other: &Product<T1, T2>) -> Product<T1, T2> {
         Product {
             outer: self.outer.join(&other.outer),
             inner: self.inner.join(&other.inner),
         }
     }
-    #[inline(always)]
+    #[inline]
     fn meet(&self, other: &Product<T1, T2>) -> Product<T1, T2> {
         Product {
             outer: self.outer.meet(&other.outer),
@@ -185,9 +185,9 @@ impl<T1: Lattice, T2: Lattice> Lattice for Product<T1, T2> {
 macro_rules! implement_lattice {
     ($index_type:ty, $minimum:expr) => (
         impl Lattice for $index_type {
-            #[inline(always)] fn minimum() -> Self { $minimum }
-            #[inline(always)] fn join(&self, other: &Self) -> Self { ::std::cmp::max(*self, *other) }
-            #[inline(always)] fn meet(&self, other: &Self) -> Self { ::std::cmp::min(*self, *other) }
+            #[inline] fn minimum() -> Self { $minimum }
+            #[inline] fn join(&self, other: &Self) -> Self { ::std::cmp::max(*self, *other) }
+            #[inline] fn meet(&self, other: &Self) -> Self { ::std::cmp::min(*self, *other) }
         }
     )
 }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -31,7 +31,7 @@ struct EditList<'a, V: 'a, T, R> {
 
 impl<'a, V:'a, T, R> EditList<'a, V, T, R> where T: Ord+Clone, R: Monoid {
     /// Creates an empty list of edits.
-    #[inline(always)]
+    #[inline]
     fn new() -> Self {
         EditList {
             values: Vec::new(),
@@ -49,20 +49,20 @@ impl<'a, V:'a, T, R> EditList<'a, V, T, R> where T: Ord+Clone, R: Monoid {
         }
     }
     /// Clears the list of edits.
-    #[inline(always)]
+    #[inline]
     fn clear(&mut self) {
         self.values.clear();
         self.edits.clear();
     }
     fn len(&self) -> usize { self.edits.len() }
     /// Inserts a new edit for an as-yet undetermined value.
-    #[inline(always)]
+    #[inline]
     fn push(&mut self, time: T, diff: R) {
         // TODO: Could attempt "insertion-sort" like behavior here, where we collapse if possible.
         self.edits.push((time, diff));
     }
     /// Associates all edits pushed since the previous `seal_value` call with `value`.
-    #[inline(always)]
+    #[inline]
     fn seal(&mut self, value: &'a V) {
         let prev = self.values.last().map(|x| x.1).unwrap_or(0);
         consolidate_from(&mut self.edits, prev);

--- a/src/trace/cursor/cursor_list.rs
+++ b/src/trace/cursor/cursor_list.rs
@@ -95,26 +95,26 @@ where
     type Storage = Vec<C::Storage>;
 
     // validation methods
-    #[inline(always)]
+    #[inline]
     fn key_valid(&self, _storage: &Self::Storage) -> bool { !self.min_key.is_empty() }
-    #[inline(always)]
+    #[inline]
     fn val_valid(&self, _storage: &Self::Storage) -> bool { !self.min_val.is_empty() }
 
     // accessors
-    #[inline(always)]
+    #[inline]
     fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K {
         debug_assert!(self.key_valid(storage));
         debug_assert!(self.cursors[self.min_key[0]].key_valid(&storage[self.min_key[0]]));
         self.cursors[self.min_key[0]].key(&storage[self.min_key[0]])
     }
-    #[inline(always)]
+    #[inline]
     fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V {
         debug_assert!(self.key_valid(storage));
         debug_assert!(self.val_valid(storage));
         debug_assert!(self.cursors[self.min_val[0]].val_valid(&storage[self.min_val[0]]));
         self.cursors[self.min_val[0]].val(&storage[self.min_val[0]])
     }
-    #[inline(always)]
+    #[inline]
     fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         for &index in self.min_val.iter() {
             self.cursors[index].map_times(&storage[index], |t,d| logic(t,d));
@@ -122,14 +122,14 @@ where
     }
 
     // key methods
-    #[inline(always)]
+    #[inline]
     fn step_key(&mut self, storage: &Self::Storage) {
         for &index in self.min_key.iter() {
             self.cursors[index].step_key(&storage[index]);
         }
         self.minimize_keys(storage);
     }
-    #[inline(always)]
+    #[inline]
     fn seek_key(&mut self, storage: &Self::Storage, key: &K) {
         for index in 0 .. self.cursors.len() {
             self.cursors[index].seek_key(&storage[index], key);
@@ -138,14 +138,14 @@ where
     }
 
     // value methods
-    #[inline(always)]
+    #[inline]
     fn step_val(&mut self, storage: &Self::Storage) {
         for &index in self.min_val.iter() {
             self.cursors[index].step_val(&storage[index]);
         }
         self.minimize_vals(storage);
     }
-    #[inline(always)]
+    #[inline]
     fn seek_val(&mut self, storage: &Self::Storage, val: &V) {
         for &index in self.min_key.iter() {
             self.cursors[index].seek_val(&storage[index], val);
@@ -154,14 +154,14 @@ where
     }
 
     // rewinding methods
-    #[inline(always)]
+    #[inline]
     fn rewind_keys(&mut self, storage: &Self::Storage) {
         for index in 0 .. self.cursors.len() {
             self.cursors[index].rewind_keys(&storage[index]);
         }
         self.minimize_keys(storage);
     }
-    #[inline(always)]
+    #[inline]
     fn rewind_vals(&mut self, storage: &Self::Storage) {
         for &index in self.min_key.iter() {
             self.cursors[index].rewind_vals(&storage[index]);

--- a/src/trace/implementations/graph.rs
+++ b/src/trace/implementations/graph.rs
@@ -214,7 +214,7 @@ impl<N> Builder<Node, N, Product<RootTimestamp,()>, isize, GraphBatch<N>> for Gr
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn push(&mut self, (key, val, _time, _diff): (Node, N, Product<RootTimestamp,()>, isize)) {
         while self.nodes.len() <= (key as usize) / self.peers {
             self.keys.push((self.peers * self.nodes.len() + self.index) as Node);

--- a/src/trace/implementations/hash.rs
+++ b/src/trace/implementations/hash.rs
@@ -129,7 +129,7 @@ where K: Clone+Default+HashOrdered+'static, V: Ord+Clone+'static, T: Lattice+Ord
 		} 
 	}
 
-	#[inline(always)]
+	#[inline]
 	fn push(&mut self, (key, val, time, diff): (K, V, T, R)) {
 		self.builder.push_tuple((key, (val, (time, diff))));
 	}
@@ -252,7 +252,7 @@ where K: Clone+Default+HashOrdered+'static, T: Lattice+Ord+Clone+Default+'static
 		} 
 	}
 
-	#[inline(always)]
+	#[inline]
 	fn push(&mut self, (key, _, time, diff): (K, (), T, R)) {
 		self.builder.push_tuple((key, (time, diff)));
 	}

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -117,30 +117,30 @@ pub struct VecQueue<T> {
 }
 
 impl<T> VecQueue<T> {
-    #[inline(always)]
+    #[inline]
     pub fn new() -> Self { VecQueue::from(Vec::new()) }
-    #[inline(always)]
+    #[inline]
     pub fn pop(&mut self) -> T {
         debug_assert!(self.head < self.tail);
         self.head += 1;
         unsafe { ::std::ptr::read(self.list.as_mut_ptr().offset((self.head as isize) - 1)) }
     }
-    #[inline(always)]
+    #[inline]
     pub fn peek(&self) -> &T {
         debug_assert!(self.head < self.tail);
         unsafe { self.list.get_unchecked(self.head) }
     }
-    #[inline(always)]
+    #[inline]
     pub fn _peek_tail(&self) -> &T {
         debug_assert!(self.head < self.tail);
         unsafe { self.list.get_unchecked(self.tail-1) }
     }
-    #[inline(always)]
+    #[inline]
     pub fn _slice(&self) -> &[T] {
         debug_assert!(self.head < self.tail);
         unsafe { from_raw_parts(self.list.get_unchecked(self.head), self.tail - self.head) }
     }
-    #[inline(always)]
+    #[inline]
     pub fn from(mut list: Vec<T>) -> Self {
         let tail = list.len();
         unsafe { list.set_len(0); }
@@ -151,18 +151,18 @@ impl<T> VecQueue<T> {
         }
     }
     // could leak, if self.head != self.tail.
-    #[inline(always)]
+    #[inline]
     pub fn done(self) -> Vec<T> {
         debug_assert!(self.head == self.tail);
         self.list
     }
-    #[inline(always)]
+    #[inline]
     pub fn len(&self) -> usize { self.tail - self.head }
-    #[inline(always)]
+    #[inline]
     pub fn is_empty(&self) -> bool { self.head == self.tail }
 }
 
-#[inline(always)]
+#[inline]
 unsafe fn push_unchecked<T>(vec: &mut Vec<T>, element: T) {
     debug_assert!(vec.len() < vec.capacity());
     let len = vec.len();
@@ -339,7 +339,7 @@ impl<D: Ord, T: Ord, R: Monoid> MergeSorter<D, T, R> {
 /// stays false once it becomes false, a joint property of the predicate
 /// and the slice. This allows `advance` to use exponential search to
 /// count the number of elements in time logarithmic in the result.
-#[inline(always)]
+#[inline]
 pub fn _advance<T, F: Fn(&T)->bool>(slice: &[T], function: F) -> usize {
 
 	// start with no advance

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -302,7 +302,7 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fm
 		}
 	}
 
-	#[inline(always)]
+	#[inline]
 	fn push(&mut self, (key, val, time, diff): (K, V, T, R)) {
 		self.builder.push_tuple((key, (val, (time, diff))));
 	}
@@ -557,7 +557,7 @@ where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Monoid {
 		}
 	}
 
-	#[inline(always)]
+	#[inline]
 	fn push(&mut self, (key, _, time, diff): (K, (), T, R)) {
 		self.builder.push_tuple((key, (time, diff)));
 	}

--- a/src/trace/implementations/vec.rs
+++ b/src/trace/implementations/vec.rs
@@ -250,7 +250,7 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fm
 	fn new() -> Self { VecBuilder { list: Vec::new() } }
 	fn with_capacity(cap: usize) -> Self { VecBuilder { list: Vec::with_capacity(cap) } }
 
-	#[inline(always)]
+	#[inline]
 	fn push(&mut self, (key, val, time, diff): (K, V, T, R)) { self.list.push((key,val,time,diff)); }
 
 	#[inline(never)]

--- a/src/trace/layers/hashed.rs
+++ b/src/trace/layers/hashed.rs
@@ -126,11 +126,11 @@ pub struct HashedBuilder<K: HashOrdered, L> {
 
 impl<K: HashOrdered+Clone+Default, L> HashedBuilder<K, L> {
 
-	#[inline(always)]
+	#[inline]
 	fn _lower(&self, index: usize) -> usize {
 		self.keys[index].get_lower()
 	}
-	#[inline(always)]
+	#[inline]
 	fn _upper(&self, index: usize) -> usize {
 		self.keys[index].get_upper()
 	}
@@ -319,7 +319,7 @@ impl<K: HashOrdered+Clone+Default, L: TupleBuilder> TupleBuilder for HashedBuild
 			vals: L::with_capacity(cap),
 		} 
 	}
-	#[inline(always)]
+	#[inline]
 	fn push_tuple(&mut self, (key, val): (K, L::Item)) {
 
 		// we build up self.temp, and rely on self.boundary() to drain self.temp.

--- a/src/trace/layers/ordered.rs
+++ b/src/trace/layers/ordered.rs
@@ -86,7 +86,7 @@ impl<K: Ord+Clone, L: MergeBuilder> MergeBuilder for OrderedBuilder<K, L> {
 			vals: L::with_capacity(&other1.vals, &other2.vals),
 		}
 	}
-	#[inline(always)]
+	#[inline]
 	fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
 		debug_assert!(lower < upper);
 		let other_basis = other.offs[lower];
@@ -171,7 +171,7 @@ impl<K: Ord+Clone, L: TupleBuilder> TupleBuilder for OrderedBuilder<K, L> {
 			vals: L::with_capacity(cap),
 		}
 	}
-	#[inline(always)]
+	#[inline]
 	fn push_tuple(&mut self, (key, val): (K, L::Item)) {
 
 		// if first element, prior element finish, or different element, need to push and maybe punctuate.

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -44,7 +44,7 @@ impl<K: Ord+Clone, R: Monoid+Clone> MergeBuilder for OrderedLeafBuilder<K, R> {
             vals: Vec::with_capacity(<OrderedLeaf<K, R> as Trie>::keys(other1) + <OrderedLeaf<K, R> as Trie>::keys(other2)),
         }
     }
-    #[inline(always)]
+    #[inline]
     fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
         self.vals.extend_from_slice(&other.vals[lower .. upper]);
     }
@@ -96,7 +96,7 @@ impl<K: Ord+Clone, R: Monoid+Clone> TupleBuilder for OrderedLeafBuilder<K, R> {
     type Item = (K, R);
     fn new() -> Self { OrderedLeafBuilder { vals: Vec::new() } }
     fn with_capacity(cap: usize) -> Self { OrderedLeafBuilder { vals: Vec::with_capacity(cap) } }
-    #[inline(always)] fn push_tuple(&mut self, tuple: (K, R)) { self.vals.push(tuple) }
+    #[inline] fn push_tuple(&mut self, tuple: (K, R)) { self.vals.push(tuple) }
 }
 
 /// A cursor for walking through an unordered sequence of values.

--- a/src/trace/layers/unordered.rs
+++ b/src/trace/layers/unordered.rs
@@ -62,7 +62,7 @@ impl<K: Clone> TupleBuilder for UnorderedBuilder<K> {
 	type Item = K;
 	fn new() -> Self { UnorderedBuilder { vals: Vec::new() } }
 	fn with_capacity(cap: usize) -> Self { UnorderedBuilder { vals: Vec::with_capacity(cap) } }
-	#[inline(always)] fn push_tuple(&mut self, tuple: K) { self.vals.push(tuple) }
+	#[inline] fn push_tuple(&mut self, tuple: K) { self.vals.push(tuple) }
 }
 
 /// A cursor for walking through an unordered sequence of values.

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -265,25 +265,25 @@ pub mod rc_blanket_impls {
 
 	    type Storage = Rc<B>;
 
-	    #[inline(always)] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
-	    #[inline(always)] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
+	    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
+	    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
 
-	    #[inline(always)] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
-	    #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
+	    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
+	    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
 
-	    #[inline(always)]
+	    #[inline]
 	    fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, logic: L) {
 	    	self.cursor.map_times(storage, logic)
 	    }
 
-	    #[inline(always)] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-	    #[inline(always)] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(storage, key) }
+	    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
+	    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(storage, key) }
 
-	    #[inline(always)] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
-	    #[inline(always)] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(storage, val) }
+	    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
+	    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(storage, val) }
 
-	    #[inline(always)] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
-	    #[inline(always)] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
+	    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
+	    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
 	}
 
 	/// An immutable collection of updates.
@@ -371,25 +371,25 @@ pub mod abomonated_blanket_impls {
 
 	    type Storage = Abomonated<B, Vec<u8>>;
 
-	    #[inline(always)] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
-	    #[inline(always)] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
+	    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
+	    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
 
-	    #[inline(always)] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
-	    #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
+	    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
+	    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
 
-	    #[inline(always)]
+	    #[inline]
 	    fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, logic: L) {
 	    	self.cursor.map_times(storage, logic)
 	    }
 
-	    #[inline(always)] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-	    #[inline(always)] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(storage, key) }
+	    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
+	    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(storage, key) }
 
-	    #[inline(always)] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
-	    #[inline(always)] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(storage, val) }
+	    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
+	    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(storage, val) }
 
-	    #[inline(always)] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
-	    #[inline(always)] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
+	    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
+	    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
 	}
 
 	/// An immutable collection of updates.

--- a/src/trace/wrappers/enter.rs
+++ b/src/trace/wrappers/enter.rs
@@ -181,27 +181,27 @@ where
 {
     type Storage = C::Storage;
 
-    #[inline(always)] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
-    #[inline(always)] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
+    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
+    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
 
-    #[inline(always)] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
-    #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
+    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
+    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
 
-    #[inline(always)]
+    #[inline]
     fn map_times<L: FnMut(&TInner, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         self.cursor.map_times(storage, |time, diff| {
             logic(&TInner::to_inner(time.clone()), diff)
         })
     }
 
-    #[inline(always)] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-    #[inline(always)] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(storage, key) }
+    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(storage, key) }
 
-    #[inline(always)] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
-    #[inline(always)] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(storage, val) }
+    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(storage, val) }
 
-    #[inline(always)] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
-    #[inline(always)] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
+    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
+    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
 }
 
 
@@ -228,25 +228,25 @@ where
 {
     type Storage = BatchEnter<K, V, T, R, B, TInner>;
 
-    #[inline(always)] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }
-    #[inline(always)] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(&storage.batch) }
+    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }
+    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(&storage.batch) }
 
-    #[inline(always)] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(&storage.batch) }
-    #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(&storage.batch) }
+    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(&storage.batch) }
+    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(&storage.batch) }
 
-    #[inline(always)]
+    #[inline]
     fn map_times<L: FnMut(&TInner, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         self.cursor.map_times(&storage.batch, |time, diff| {
             logic(&TInner::to_inner(time.clone()), diff)
         })
     }
 
-    #[inline(always)] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
-    #[inline(always)] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(&storage.batch, key) }
+    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(&storage.batch, key) }
 
-    #[inline(always)] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
-    #[inline(always)] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(&storage.batch, val) }
+    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(&storage.batch, val) }
 
-    #[inline(always)] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
-    #[inline(always)] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }
+    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
+    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }
 }

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -196,13 +196,13 @@ where
 {
     type Storage = C::Storage;
 
-    #[inline(always)] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
-    #[inline(always)] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
+    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
+    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
 
-    #[inline(always)] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
-    #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
+    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
+    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
 
-    #[inline(always)]
+    #[inline]
     fn map_times<L: FnMut(&TInner, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
@@ -212,14 +212,14 @@ where
         })
     }
 
-    #[inline(always)] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-    #[inline(always)] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(storage, key) }
+    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(storage, key) }
 
-    #[inline(always)] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
-    #[inline(always)] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(storage, val) }
+    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(storage, val) }
 
-    #[inline(always)] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
-    #[inline(always)] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
+    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
+    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
 }
 
 
@@ -249,13 +249,13 @@ where
 {
     type Storage = BatchEnter<K, V, T, R, B, TInner, F>;
 
-    #[inline(always)] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }
-    #[inline(always)] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(&storage.batch) }
+    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }
+    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(&storage.batch) }
 
-    #[inline(always)] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(&storage.batch) }
-    #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(&storage.batch) }
+    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(&storage.batch) }
+    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(&storage.batch) }
 
-    #[inline(always)]
+    #[inline]
     fn map_times<L: FnMut(&TInner, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
@@ -265,12 +265,12 @@ where
         })
     }
 
-    #[inline(always)] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
-    #[inline(always)] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(&storage.batch, key) }
+    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(&storage.batch, key) }
 
-    #[inline(always)] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
-    #[inline(always)] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(&storage.batch, val) }
+    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(&storage.batch, val) }
 
-    #[inline(always)] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
-    #[inline(always)] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }
+    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
+    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }
 }

--- a/src/trace/wrappers/filter.rs
+++ b/src/trace/wrappers/filter.rs
@@ -145,13 +145,13 @@ where
 {
     type Storage = C::Storage;
 
-    #[inline(always)] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
-    #[inline(always)] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
+    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
+    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
 
-    #[inline(always)] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
-    #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
+    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
+    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
 
-    #[inline(always)]
+    #[inline]
     fn map_times<L: FnMut(&T,&R)>(&mut self, storage: &Self::Storage, logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
@@ -160,14 +160,14 @@ where
         }
     }
 
-    #[inline(always)] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-    #[inline(always)] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(storage, key) }
+    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(storage, key) }
 
-    #[inline(always)] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
-    #[inline(always)] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(storage, val) }
+    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(storage, val) }
 
-    #[inline(always)] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
-    #[inline(always)] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
+    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
+    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
 }
 
 
@@ -196,13 +196,13 @@ where
 {
     type Storage = BatchFilter<K, V, T, R, B, F>;
 
-    #[inline(always)] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }
-    #[inline(always)] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(&storage.batch) }
+    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }
+    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(&storage.batch) }
 
-    #[inline(always)] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(&storage.batch) }
-    #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(&storage.batch) }
+    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(&storage.batch) }
+    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(&storage.batch) }
 
-    #[inline(always)]
+    #[inline]
     fn map_times<L: FnMut(&T,&R)>(&mut self, storage: &Self::Storage, logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
@@ -211,12 +211,12 @@ where
         }
     }
 
-    #[inline(always)] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
-    #[inline(always)] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(&storage.batch, key) }
+    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(&storage.batch, key) }
 
-    #[inline(always)] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
-    #[inline(always)] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(&storage.batch, val) }
+    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(&storage.batch, val) }
 
-    #[inline(always)] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
-    #[inline(always)] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }
+    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
+    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }
 }

--- a/src/trace/wrappers/freeze.rs
+++ b/src/trace/wrappers/freeze.rs
@@ -204,13 +204,13 @@ where
 
     type Storage = C::Storage;
 
-    #[inline(always)] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
-    #[inline(always)] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
+    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
+    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
 
-    #[inline(always)] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
-    #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
+    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
+    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
 
-    #[inline(always)] fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    #[inline] fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let func = &self.func;
         self.cursor.map_times(storage, |time, diff| {
             if let Some(time) = func(time) {
@@ -219,14 +219,14 @@ where
         })
     }
 
-    #[inline(always)] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-    #[inline(always)] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(storage, key) }
+    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(storage, key) }
 
-    #[inline(always)] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
-    #[inline(always)] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(storage, val) }
+    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(storage, val) }
 
-    #[inline(always)] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
-    #[inline(always)] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
+    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
+    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
 }
 
 
@@ -254,13 +254,13 @@ where
 
     type Storage = BatchFreeze<K, V, T, R, B, F>;
 
-    #[inline(always)] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }
-    #[inline(always)] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(&storage.batch) }
+    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }
+    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(&storage.batch) }
 
-    #[inline(always)] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(&storage.batch) }
-    #[inline(always)] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(&storage.batch) }
+    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(&storage.batch) }
+    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(&storage.batch) }
 
-    #[inline(always)] fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    #[inline] fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let func = &self.func;
         self.cursor.map_times(&storage.batch, |time, diff| {
             if let Some(time) = func(time) {
@@ -269,12 +269,12 @@ where
         })
     }
 
-    #[inline(always)] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
-    #[inline(always)] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(&storage.batch, key) }
+    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(&storage.batch, key) }
 
-    #[inline(always)] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
-    #[inline(always)] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(&storage.batch, val) }
+    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(&storage.batch, val) }
 
-    #[inline(always)] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
-    #[inline(always)] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }
+    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
+    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }
 }

--- a/tpchlike/src/types.rs
+++ b/tpchlike/src/types.rs
@@ -5,7 +5,7 @@ use abomonation::Abomonation;
 
 pub type Date = u32;
 
-#[inline(always)]
+#[inline]
 pub fn create_date(year: u16, month: u8, day: u8) -> u32 {
     ((year as u32) << 16) + ((month as u32) << 8) + (day as u32)
 }


### PR DESCRIPTION
As a maintainer of another high-performance Rust project (Rust FlatBuffers), I've learned that forcing the compiler to inline can be problematic. The Rust toolchain (LLVM in particular) can make better decisions than we can (usually) when deciding when and what to inline. This PR switches all #[inline(always)] attributes to #[inline], in accordance with Rust best practices.

See also https://github.com/TimelyDataflow/timely-dataflow/pull/247