### PR TITLE
Mdbook updates

### DIFF
--- a/mdbook/src/chapter_0/chapter_0_0.md
+++ b/mdbook/src/chapter_0/chapter_0_0.md
@@ -25,6 +25,13 @@ Instead, edit your `Cargo.toml` file, which tells Rust about your dependencies, 
         differential-dataflow = "0.7"
         Echidnatron%
 
-You should only need to add those last two lines there, which bring in dependencies on both [timely dataflow](https://github.com/frankmcsherry/timely-dataflow) and [differential dataflow](https://github.com/frankmcsherry/differential-dataflow). We will be using both of those.
+You should only need to add those last two lines there, which bring in dependencies on both [timely dataflow](https://github.com/TimelyDataflow/timely-dataflow) and [differential dataflow](https://github.com/TimelyDataflow/differential-dataflow). We will be using both of those.
 
-You should now be ready to go. Code examples should mostly work, and you should complain (or file an issue) if they do not!
+If you would like to point at the most current code release, hosted on github, you can replace the dependencies with:
+
+        [dependencies]
+        timely = { git = "https://github.com/TimelyDataflow/timely" }
+        differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow" }
+
+
+You should now be ready to go. Code examples should mostly work, and you should complain (or [file an issue](https://github.com/TimelyDataflow/differential-dataflow/issues)) if they do not!

--- a/mdbook/src/chapter_0/chapter_0_1.md
+++ b/mdbook/src/chapter_0/chapter_0_1.md
@@ -58,9 +58,7 @@ We want to report each pair `(m2, p)`, and we happen to also produce as evidence
 When we execute this program we get to see the skip-level reports for the small binary tree we loaded as input:
 
         Echidnatron% cargo run -- 10
-           Compiling differential-dataflow v0.6.0 (file:///Users/mcsherry/Projects/differential-dataflow)
-            Finished dev [unoptimized + debuginfo] target(s) in 7.17s
-             Running `target/debug/examples/hello`
+             Running `target/debug/my_project`
         ((0, 0, 0), (Root, 0), 1)
         ((0, 0, 1), (Root, 0), 1)
         ((1, 0, 2), (Root, 0), 1)

--- a/mdbook/src/chapter_0/chapter_0_1.md
+++ b/mdbook/src/chapter_0/chapter_0_1.md
@@ -2,7 +2,7 @@
 
 You write differential dataflow programs against apparently static input collections, with operations that look a bit like database (SQL) or big data (MapReduce) idioms. This is actually a bit of a trick, because you will have the ablity to change the input data, but we'll pretend we don't know that yet.
 
-Let's write a program with one input: a collection `manages` of pairs `(manager, person)` describing people and their direct reports. Our program will determine for each person their manager's manager. If you are familiar with SQL, this is an "equijoin", and we will write exactly that in differential dataflow.
+Let's write a program with one input: a collection `manages` of pairs `(manager, person)` describing people and their direct reports. Our program will determine for each person their manager's manager (where the boss manages the boss's own self). If you are familiar with SQL, this is an "equijoin", and we will write exactly that in differential dataflow.
 
 If you are following along at home, put this in your `src/main.rs` file.
 
@@ -34,9 +34,12 @@ If you are following along at home, put this in your `src/main.rs` file.
                     .inspect(|x| println!("{:?}", x));
             });
 
+            // Read a size for our organization from the arguments.
+            let size = std::env::args().nth(1).unwrap().parse().unwrap();
+
             // Load input (a binary tree).
             input.advance_to(0);
-            for person in 0 .. 10 {
+            for person in 0 .. size {
                 input.insert((person/2, person));
             }
 
@@ -54,7 +57,7 @@ We want to report each pair `(m2, p)`, and we happen to also produce as evidence
 
 When we execute this program we get to see the skip-level reports for the small binary tree we loaded as input:
 
-        Echidnatron% cargo run --example hello
+        Echidnatron% cargo run -- 10
            Compiling differential-dataflow v0.6.0 (file:///Users/mcsherry/Projects/differential-dataflow)
             Finished dev [unoptimized + debuginfo] target(s) in 7.17s
              Running `target/debug/examples/hello`

--- a/mdbook/src/chapter_0/chapter_0_2.md
+++ b/mdbook/src/chapter_0/chapter_0_2.md
@@ -7,7 +7,7 @@ Our organization has gone from one where each manager has at most two reports, t
 The only change we'll make is to add the following just after we load up our initial org chart:
 
 ```rust,no_run
-    for person in 1 .. 10 {
+    for person in 1 .. size {
         input.advance_to(person);
         input.remove((person/2, person));
         input.insert((person/3, person));

--- a/mdbook/src/chapter_0/chapter_0_2.md
+++ b/mdbook/src/chapter_0/chapter_0_2.md
@@ -33,10 +33,8 @@ This removes the prior management relation, and introduces a new one where the p
 
 We do this for each of the non-boss employees and get to see a bunch of outputs.
 
-        Echidnatron% cargo run --example hello
-           Compiling differential-dataflow v0.6.0 (file:///Users/mcsherry/Projects/differential-dataflow)
-            Finished dev [unoptimized + debuginfo] target(s) in 7.42s
-             Running `target/debug/examples/hello`
+        Echidnatron% cargo run -- 10
+             Running `target/debug/my_project`
         ((0, 0, 0), (Root, 0), 1)
         ((0, 0, 1), (Root, 0), 1)
         ((0, 0, 2), (Root, 2), 1)

--- a/mdbook/src/chapter_0/chapter_0_3.md
+++ b/mdbook/src/chapter_0/chapter_0_3.md
@@ -6,19 +6,21 @@ We are going to make our example program a bit more exciting, in a few different
 
 Ten people is a pretty small organization. Let's do ten million instead.
 
-We are going to have to turn off the output printing here. We'll also break it down two ways, just loading up the initial computation, and then doing that plus all of the changes to the reporting structure. We haven't learned how to interactively load all of the input and await results yet (in just a moment), so we will only see elapsed times measuring the throughput, not the latency.
+We are going to have to turn off the output printing here, so comment out the `inspect()` line (but keep the semicolon). Also, we'll need to add the `--release` flag to our command line, so that we optimize our binary and don't try running debug code for millions of steps.
 
-First producing the collection of skip-level management.
+We'll break down the results of our modified computation two ways, just loading up the initial computation, and then doing that plus all of the changes to the reporting structure. We haven't learned how to interactively load all of the input and await results yet (in just a moment), so we will only see elapsed times measuring the throughput, not the latency.
 
-    Echidnatron% time cargo run --release --example hello 10000000
+First, if we just produce the collection of skip-level management (with the step two code from before):
+
+    Echidnatron% time cargo run --release -- 10000000
     cargo run --release --example hello 10000000 -w1  2.74s user 1.00s system 98% cpu 3.786 total
     Echidnatron%
 
 Four seconds. We have no clue if this is a good or bad time.
 
-Second we produce the skip-level management and then modify it 10 million times.
+Second, if we produce the skip-level management and then modify it 10 million times (including the step two code from before):
 
-    Echidnatron% time cargo run --release --example hello 10000000
+    Echidnatron% time cargo run --release -- 10000000
     cargo run --release --example hello 10000000  10.64s user 2.22s system 99% cpu 12.939 total
     Echidnatron%
 
@@ -43,13 +45,13 @@ We can also make the same changes to the code that supplies the change, where ea
 
 I'm on a laptop with two cores. Let's load the data again, without modifying it, but let's use two worker threads (with the `-w2` argument)
 
-    Echidnatron% time cargo run --release --example hello 10000000 -w2
+    Echidnatron% time cargo run --release -- 10000000 -w2
     cargo run --release --example hello 10000000 -w2  3.34s user 1.27s system 191% cpu 2.402 total
     Echidnatron%
 
 Now let's try loading and doing ten million modifications, but with two worker threads.
 
-    Echidnatron% time cargo run --release --example hello 10000000 -w2
+    Echidnatron% time cargo run --release -- 10000000 -w2
     cargo run --release --example hello 10000000 -w2  13.06s user 3.14s system 196% cpu 8.261 total
     Echidnatron%
 

--- a/mdbook/src/chapter_2/chapter_2_3.md
+++ b/mdbook/src/chapter_2/chapter_2_3.md
@@ -11,3 +11,10 @@ For example, we might form the symmetric "management relation" by concatenating 
 ```
 
 This collection likely has at most one copy of each record, unless perhaps any manager manages itself. In fact, zero manages itself, and the element `(0, 0)` would have count two.
+
+Importantly, `concat` doesn't do the hard work of ensuring that there is only one physical of each element. If we inspect the output of the `concat` above, we might see
+
+        ((0,0), (Root, 0), 1)
+        ((0,0), (Root, 0), 1)
+
+Although these are two updates to the same element at the same time, `concat` is a bit lazy (read: efficient) and doesn't do the hard work until we ask it. For that, we'll need the `consolidate` operator.

--- a/mdbook/src/chapter_2/chapter_2_4.md
+++ b/mdbook/src/chapter_2/chapter_2_4.md
@@ -1,6 +1,10 @@
 ## The Consolidate Operator
 
-The `consolidate` operator takes an input collection, and does nothing to the collection except ensure that each element occurs with only one count. As an example, if we were to inspect
+The `consolidate` operator takes an input collection, and does nothing other than possibly changing its physical representation. It leaves the same sets of elements at the same times with the same logical counts.
+
+What `consolidate` does do is ensure that each element at each time has at most one physical tuple. Generally, we might have multiple updates to the same element at the same time, expressed as independent updates. The `consolidate` operator adds all of these updates together before moving the udpate along.
+
+As an example, if we were to inspect
 
 ```rust,no_run
     manages
@@ -14,4 +18,18 @@ we might see two copies of the same element:
         ((0,0), (Root, 0), 1)
         ((0,0), (Root, 0), 1)
 
-This is because for reasons of efficiency, operators like `map` and `concat` do not work too hard to "consolidate" the changes that they produce. This is rarely a problem, but it can nonetheless be helpful to consolidate a collection before inspecting it, to ensure that you see the most concise version.
+However, by introducing `consolidate`
+
+```rust,no_run
+    manages
+        .map(|(m2, m1)| (m1, m2))
+        .concat(&manages)
+        .consolidate()
+        .inspect(|x| println!("{:?}", x));
+```
+
+we are guaranteed to see at most one `(0,0)` update at each time:
+
+        ((0,0), (Root, 0), 2)
+
+The `consolidate` operator is mostly useful before `inspect`ing data, but it can also be important for efficiency; knowing when to spend the additional computation to consolidate the representation of your data is an advanced topic!

--- a/mdbook/src/chapter_2/chapter_2_6.md
+++ b/mdbook/src/chapter_2/chapter_2_6.md
@@ -1,12 +1,12 @@
-## The Group Operator
+## The Reduce Operator
 
-The `group` operator takes an input collection whose records have a `(key, value)` structure, and it applies a user-supplied closure to each group of values with the same key.
+The `reduce` operator takes an input collection whose records have a `(key, value)` structure, and it applies a user-supplied reduction closure to each group of values with the same key.
 
 For example, to produce for each manager their managee with the lowest identifier, we might write
 
 ```rust,no_run
     manages
-        .group(|_key, input, output| {
+        .reduce(|_key, input, output| {
             let mut min_index = 0;
 
             // Each element of input is a `(&Value, Count)`
@@ -39,7 +39,7 @@ Speaking of which ...
 
 ### Count
 
-The convenience method `count` wraps the `group` operator, and performs the common operation much more easily. The count operator takes arbitrary input collections, and produces a collection as output whose records are pairs of input records and their accumulated count.
+The convenience method `count` wraps the `reduce` operator, and performs the common operation much more easily. The count operator takes arbitrary input collections, and produces a collection as output whose records are pairs of input records and their accumulated count.
 
 ### Distinct
 

--- a/mdbook/src/chapter_2/chapter_2_6.md
+++ b/mdbook/src/chapter_2/chapter_2_6.md
@@ -43,7 +43,7 @@ The convenience method `count` wraps the `reduce` operator, and performs the com
 
 ### Distinct
 
-The `distinct` operator is another convenience operator, and it takes any input collection to one in which each input record occurs exactly once. The distinct operator is a great way to recover set semantics despite differential dataflow's native multiset semantics.
+The `distinct` operator is another convenience operator, and it takes any input collection to one in which each input record occurs at most once. The distinct operator is a great way to recover set semantics despite differential dataflow's native multiset semantics.
 
 ### Threshold
 

--- a/mdbook/src/chapter_5/chapter_5_1.md
+++ b/mdbook/src/chapter_5/chapter_5_1.md
@@ -2,7 +2,7 @@
 
 Imagine you have collection that describes a relation among people, perhaps "x knows y", and you would like to query the "friends of friends" relation: for a given person x, who are the people known by friends of x?
 
-Let's first build this naively, starting from two inputs: `knows` containing the pairs of the relation and `query` containing pairs `(query_id, source)` that allow us to interactively interrogate the data.
+Let's first build this naively, starting from two inputs: `knows` containing the pairs of the relation and `query` containing pairs `(source, query_id)` that allow us to interactively interrogate the data.
 
 ```rust
 extern crate timely;

--- a/mdbook/src/chapter_a/chapter_a_1.md
+++ b/mdbook/src/chapter_a/chapter_a_1.md
@@ -2,22 +2,24 @@
 
 Ten people was a pretty small organization. Let's do ten million instead.
 
-We are going to have to turn off the output printing here. We'll also break it down two ways, just loading up the initial computation, and then doing that plus all of the changes to the reporting structure. We haven't learned how to interactively load all of the input and await results yet (in just a moment), so we will only see elapsed times measuring the throughput, not the latency.
+We are going to have to turn off the output printing here (comment out the `inspect`, but save the semicolon). We'll also need to add the `--release` flag to our command line, to avoid waiting forever.
 
-First, we produce the skip-level management.
+We'll break down our computation two ways, first just loading up the initial computation, and second doing that plus all of the changes to the reporting structure. We haven't learned how to interactively load all of the input and await results yet (in just a moment), so we will only see elapsed times measuring the throughput, not the latency.
+
+First, we produce the skip-level management (with the "change its input" code commented out).
 
 ```ignore
-        Echidnatron% time cargo run --release --example hello 10000000
+        Echidnatron% time cargo run --release -- 10000000
         cargo run --release --example hello 10000000 -w1  2.74s user 1.00s system 98% cpu 3.786 total
         Echidnatron%
 ```
 
 Four seconds. We have no clue if this is a good or bad time.
 
-Second, we produce the skip-level management and then modify it 10 million times.
+Second, we produce the skip-level management and then modify it 10 million times (as in "change its input").
 
 ```ignore
-        Echidnatron% time cargo run --release --example hello 10000000
+        Echidnatron% time cargo run --release -- 10000000
         cargo run --release --example hello 10000000  10.64s user 2.22s system 99% cpu 12.939 total
         Echidnatron%
 ```

--- a/mdbook/src/chapter_a/chapter_a_1.md
+++ b/mdbook/src/chapter_a/chapter_a_1.md
@@ -10,7 +10,9 @@ First, we produce the skip-level management (with the "change its input" code co
 
 ```ignore
         Echidnatron% time cargo run --release -- 10000000
-        cargo run --release --example hello 10000000 -w1  2.74s user 1.00s system 98% cpu 3.786 total
+            Finished release [optimized] target(s) in 0.24s
+             Running `target/release/my_project 10000000`
+        cargo run --release my_project 10000000 -w1  2.74s user 1.00s system 98% cpu 3.786 total
         Echidnatron%
 ```
 
@@ -20,7 +22,9 @@ Second, we produce the skip-level management and then modify it 10 million times
 
 ```ignore
         Echidnatron% time cargo run --release -- 10000000
-        cargo run --release --example hello 10000000  10.64s user 2.22s system 99% cpu 12.939 total
+            Finished release [optimized] target(s) in 0.24s
+             Running `target/release/my_project 10000000`
+        cargo run --release my_project 10000000  10.64s user 2.22s system 99% cpu 12.939 total
         Echidnatron%
 ```
 

--- a/mdbook/src/chapter_a/chapter_a_2.md
+++ b/mdbook/src/chapter_a/chapter_a_2.md
@@ -37,7 +37,7 @@ We can also make the same changes to the code that supplies the change, where ea
 I'm on a laptop with two cores. Let's load the data again, without modifying it, but let's use two worker threads (with the `-w2` argument)
 
 ```ignore
-        Echidnatron% time cargo run --release --example hello 10000000 -w2
+        Echidnatron% time cargo run --release -- 10000000 -w2
         cargo run --release --example hello 10000000 -w2  3.34s user 1.27s system 191% cpu 2.402 total
         Echidnatron%
 ```
@@ -45,7 +45,7 @@ I'm on a laptop with two cores. Let's load the data again, without modifying it,
 Now let's try loading and doing ten million modifications, but with two worker threads.
 
 ```ignore
-        Echidnatron% time cargo run --release --example hello 10000000 -w2
+        Echidnatron% time cargo run --release -- 10000000 -w2
         cargo run --release --example hello 10000000 -w2  13.06s user 3.14s system 196% cpu 8.261 total
         Echidnatron%
 ```

--- a/mdbook/src/chapter_a/chapter_a_2.md
+++ b/mdbook/src/chapter_a/chapter_a_2.md
@@ -38,7 +38,9 @@ I'm on a laptop with two cores. Let's load the data again, without modifying it,
 
 ```ignore
         Echidnatron% time cargo run --release -- 10000000 -w2
-        cargo run --release --example hello 10000000 -w2  3.34s user 1.27s system 191% cpu 2.402 total
+            Finished release [optimized] target(s) in 0.24s
+             Running `target/release/my_project 10000000 -w2`
+        cargo run --release -- 10000000 -w2  3.34s user 1.27s system 191% cpu 2.402 total
         Echidnatron%
 ```
 
@@ -46,7 +48,9 @@ Now let's try loading and doing ten million modifications, but with two worker t
 
 ```ignore
         Echidnatron% time cargo run --release -- 10000000 -w2
-        cargo run --release --example hello 10000000 -w2  13.06s user 3.14s system 196% cpu 8.261 total
+            Finished release [optimized] target(s) in 0.24s
+             Running `target/release/my_project 10000000 -w2`
+        cargo run --release -- 10000000 -w2  13.06s user 3.14s system 196% cpu 8.261 total
         Echidnatron%
 ```
 

--- a/mdbook/src/chapter_a/chapter_a_3.md
+++ b/mdbook/src/chapter_a/chapter_a_3.md
@@ -55,7 +55,7 @@ We can make the same changes for the interactive loading, but we'll synchronize 
 This starts to print out a mess of data, indicating not only how long it takes to start up the computation, but also how long each individual round of updates takes.
 
 ```ignore
-        Echidnatron% cargo run --release --example hello 10000000
+        Echidnatron% cargo run --release -- 10000000
             Finished release [optimized + debuginfo] target(s) in 0.06s
              Running `target/release/examples/hello 10000000`
         4.092895186s    data loaded

--- a/mdbook/src/chapter_a/chapter_a_3.md
+++ b/mdbook/src/chapter_a/chapter_a_3.md
@@ -56,8 +56,8 @@ This starts to print out a mess of data, indicating not only how long it takes t
 
 ```ignore
         Echidnatron% cargo run --release -- 10000000
-            Finished release [optimized + debuginfo] target(s) in 0.06s
-             Running `target/release/examples/hello 10000000`
+            Finished release [optimized] target(s) in 0.24s
+             Running `target/release/my_project 10000000`
         4.092895186s    data loaded
         4.092975626s    step 1 complete
         4.093021676s    step 2 complete


### PR DESCRIPTION
Updates in response to confusions reported over in https://github.com/TimelyDataflow/timely-dataflow/issues/248. These include:

1. Making the examples run as actual binaries (as described by the text).
2. Add a size argument initially, to avoid the confusion of adding it later.
3. Elaborate on `concat` and `consolidate`.
4. Swap the order of the `query` pair for arrangements.