### PR TITLE
hack to prevent panic

### DIFF
--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -313,8 +313,8 @@ impl<G, K, V, R1, T1> JoinCore<G, K, V, R1> for Arranged<G,K,V,R1,T1>
         let mut trace2 = Some(other.trace.clone());
 
         // acknowledged frontier for each input.
-        let mut acknowledged1: Option<Vec<G::Timestamp>> = None;//vec![G::Timestamp::minimum()];
-        let mut acknowledged2: Option<Vec<G::Timestamp>> = None;//vec![G::Timestamp::minimum()];
+        let mut acknowledged1: Option<Vec<G::Timestamp>> = None;
+        let mut acknowledged2: Option<Vec<G::Timestamp>> = None;
 
         // deferred work of batches from each input.
         let mut todo1 = Vec::new();
@@ -345,6 +345,7 @@ impl<G, K, V, R1, T1> JoinCore<G, K, V, R1> for Arranged<G,K,V,R1,T1>
                         data.swap(&mut input1_buffer);
                         for batch1 in input1_buffer.drain(..) {
                             if let Some(acknowledged2) = &acknowledged2 {
+                                // TODO : cursor_through may be problematic for pre-merged traces.
                                 let (trace2_cursor, trace2_storage) = trace2.cursor_through(&acknowledged2[..]).unwrap();
                                 let batch1_cursor = batch1.cursor();
                                 todo1.push(Deferred::new(trace2_cursor, trace2_storage, batch1_cursor, batch1.clone(), capability.clone(), |r2,r1| (r1.clone()) * (r2.clone())));
@@ -362,6 +363,7 @@ impl<G, K, V, R1, T1> JoinCore<G, K, V, R1> for Arranged<G,K,V,R1,T1>
                         data.swap(&mut input2_buffer);
                         for batch2 in input2_buffer.drain(..) {
                             if let Some(acknowledged1) = &acknowledged1 {
+                                // TODO : cursor_through may be problematic for pre-merged traces.
                                 let (trace1_cursor, trace1_storage) = trace1.cursor_through(&acknowledged1[..]).unwrap();
                                 let batch2_cursor = batch2.cursor();
                                 todo2.push(Deferred::new(trace1_cursor, trace1_storage, batch2_cursor, batch2.clone(), capability.clone(), |r1,r2| (r1.clone()) * (r2.clone())));

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -313,8 +313,8 @@ impl<G, K, V, R1, T1> JoinCore<G, K, V, R1> for Arranged<G,K,V,R1,T1>
         let mut trace2 = Some(other.trace.clone());
 
         // acknowledged frontier for each input.
-        let mut acknowledged1 = vec![G::Timestamp::minimum()];
-        let mut acknowledged2 = vec![G::Timestamp::minimum()];
+        let mut acknowledged1: Option<Vec<G::Timestamp>> = None;//vec![G::Timestamp::minimum()];
+        let mut acknowledged2: Option<Vec<G::Timestamp>> = None;//vec![G::Timestamp::minimum()];
 
         // deferred work of batches from each input.
         let mut todo1 = Vec::new();
@@ -344,11 +344,13 @@ impl<G, K, V, R1, T1> JoinCore<G, K, V, R1> for Arranged<G,K,V,R1,T1>
                         let capability = capability.retain();
                         data.swap(&mut input1_buffer);
                         for batch1 in input1_buffer.drain(..) {
-                            let (trace2_cursor, trace2_storage) = trace2.cursor_through(&acknowledged2[..]).unwrap();
-                            let batch1_cursor = batch1.cursor();
-                            todo1.push(Deferred::new(trace2_cursor, trace2_storage, batch1_cursor, batch1.clone(), capability.clone(), |r2,r1| (r1.clone()) * (r2.clone())));
-                            debug_assert!(batch1.description().lower() == &acknowledged1[..]);
-                            acknowledged1 = batch1.description().upper().to_vec();
+                            if let Some(acknowledged2) = &acknowledged2 {
+                                let (trace2_cursor, trace2_storage) = trace2.cursor_through(&acknowledged2[..]).unwrap();
+                                let batch1_cursor = batch1.cursor();
+                                todo1.push(Deferred::new(trace2_cursor, trace2_storage, batch1_cursor, batch1.clone(), capability.clone(), |r2,r1| (r1.clone()) * (r2.clone())));
+                                // debug_assert!(batch1.description().lower() == &acknowledged1[..]);
+                            }
+                            acknowledged1 = Some(batch1.description().upper().to_vec());
                         }
                     }
                 });
@@ -359,11 +361,13 @@ impl<G, K, V, R1, T1> JoinCore<G, K, V, R1> for Arranged<G,K,V,R1,T1>
                         let capability = capability.retain();
                         data.swap(&mut input2_buffer);
                         for batch2 in input2_buffer.drain(..) {
-                            let (trace1_cursor, trace1_storage) = trace1.cursor_through(&acknowledged1[..]).unwrap();
-                            let batch2_cursor = batch2.cursor();
-                            todo2.push(Deferred::new(trace1_cursor, trace1_storage, batch2_cursor, batch2.clone(), capability.clone(), |r1,r2| (r1.clone()) * (r2.clone())));
-                            debug_assert!(batch2.description().lower() == &acknowledged2[..]);
-                            acknowledged2 = batch2.description().upper().to_vec();
+                            if let Some(acknowledged1) = &acknowledged1 {
+                                let (trace1_cursor, trace1_storage) = trace1.cursor_through(&acknowledged1[..]).unwrap();
+                                let batch2_cursor = batch2.cursor();
+                                todo2.push(Deferred::new(trace1_cursor, trace1_storage, batch2_cursor, batch2.clone(), capability.clone(), |r1,r2| (r1.clone()) * (r2.clone())));
+                                // debug_assert!(batch2.description().lower() == &acknowledged2[..]);
+                            }
+                            acknowledged2 = Some(batch2.description().upper().to_vec());
                         }
                     }
                 });
@@ -398,14 +402,18 @@ impl<G, K, V, R1, T1> JoinCore<G, K, V, R1> for Arranged<G,K,V,R1,T1>
                 if trace2.is_some() && input1.frontier().is_empty() { trace2 = None; }
                 if let Some(ref mut trace2) = trace2 {
                     trace2.advance_by(&input1.frontier().frontier()[..]);
-                    trace2.distinguish_since(&acknowledged2[..]);
+                    if let Some(acknowledged2) = &acknowledged2 {
+                        trace2.distinguish_since(&acknowledged2[..]);
+                    }
                 }
 
                 // shut down or advance trace1.
                 if trace1.is_some() && input2.frontier().is_empty() { trace1 = None; }
                 if let Some(ref mut trace1) = trace1 {
                     trace1.advance_by(&input2.frontier().frontier()[..]);
-                    trace1.distinguish_since(&acknowledged1[..]);
+                    if let Some(acknowledged1) = &acknowledged1 {
+                        trace1.distinguish_since(&acknowledged1[..]);
+                    }
                 }
             }
         })


### PR DESCRIPTION
This PR attempts to prevent a panic in which two already-advanced traces are joined. One will attempt to get a cursor for the other at frontier `Vec<G::Timestamp::minimum()>`, and will fail because the other trace has already been `distinguish_since`d something larger.

However, this really should have just been "nothing done, because such an early frontier means no data". So, the join operator tracks options of frontiers now, and doesn't request cursors that it can't have.

This is technically a hack because we could plausibly receive only a subset of batches in our first join execution, and this would cause a bunch of panics for similar reasons (requesting cursors up to boundaries that are no longer maintained). The longer-term fix should be to switch to a "bookmark" like implementation of `distinguish_since`.

@comnik is this anything you've seen? It was a quickly observed panic for me in `interactive`: just create two collections: put some data in and advance them a bit (to move the distinguish-since boundary past `vec![0]`) and then attempt to join them.