### PR TITLE
introduce ExchangeData

### DIFF
--- a/src/algorithms/graphs/bfs.rs
+++ b/src/algorithms/graphs/bfs.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 
 use timely::dataflow::*;
 
-use ::{Collection, Data};
+use ::{Collection, ExchangeData};
 use ::operators::*;
 use ::lattice::Lattice;
 
@@ -13,7 +13,7 @@ pub fn bfs<G, N>(edges: &Collection<G, (N,N)>, roots: &Collection<G, N>) -> Coll
 where
     G: Scope,
     G::Timestamp: Lattice+Ord,
-    N: Data+Hash,
+    N: ExchangeData+Hash,
 {
     // initialize roots as reaching themselves at distance 0
     let nodes = roots.map(|x| (x, 0));

--- a/src/algorithms/graphs/bijkstra.rs
+++ b/src/algorithms/graphs/bijkstra.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 use timely::order::Product;
 use timely::dataflow::*;
 
-use ::{Collection, Data};
+use ::{Collection, ExchangeData};
 use ::operators::*;
 use ::lattice::Lattice;
 use ::operators::iterate::Variable;
@@ -24,7 +24,7 @@ pub fn bidijkstra<G, N>(edges: &Collection<G, (N,N)>, goals: &Collection<G, (N,N
 where
     G: Scope,
     G::Timestamp: Lattice+Ord,
-    N: Data+Hash,
+    N: ExchangeData+Hash,
 {
     edges.scope().iterative::<u64,_,_>(|inner| {
 

--- a/src/algorithms/graphs/propagate.rs
+++ b/src/algorithms/graphs/propagate.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 
 use timely::dataflow::*;
 
-use ::{Collection, Data};
+use ::{Collection, ExchangeData};
 use ::operators::*;
 use ::lattice::Lattice;
 
@@ -13,8 +13,8 @@ pub fn propagate<G, N, L>(edges: &Collection<G, (N,N)>, nodes: &Collection<G,(N,
 where
     G: Scope,
     G::Timestamp: Lattice+Ord,
-    N: Data+Hash,
-    L: Data,
+    N: ExchangeData+Hash,
+    L: ExchangeData,
 {
     nodes.filter(|_| false)
          .iterate(|inner| {
@@ -33,8 +33,8 @@ pub fn propagate_at<G, N, L, F>(edges: &Collection<G, (N,N)>, nodes: &Collection
 where
     G: Scope,
     G::Timestamp: Lattice+Ord,
-    N: Data+Hash,
-    L: Data,
+    N: ExchangeData+Hash,
+    L: ExchangeData,
     F: Fn(&L)->u64+'static,
 {
     nodes.filter(|_| false)

--- a/src/algorithms/graphs/scc.rs
+++ b/src/algorithms/graphs/scc.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 
 use timely::dataflow::*;
 
-use ::{Collection, Data};
+use ::{Collection, ExchangeData};
 use ::operators::*;
 use ::lattice::Lattice;
 
@@ -16,7 +16,7 @@ pub fn trim<G, N>(graph: &Collection<G, (N,N)>) -> Collection<G, (N,N)>
 where
     G: Scope,
     G::Timestamp: Lattice+Ord,
-    N: Data+Hash,
+    N: ExchangeData+Hash,
 {
     graph.iterate(|edges| {
         // keep edges from active edge destinations.
@@ -34,7 +34,7 @@ pub fn strongly_connected<G, N>(graph: &Collection<G, (N,N)>) -> Collection<G, (
 where
     G: Scope,
     G::Timestamp: Lattice+Ord,
-    N: Data+Hash,
+    N: ExchangeData+Hash,
 {
     graph.iterate(|inner| {
         let edges = graph.enter(&inner.scope());
@@ -48,7 +48,7 @@ fn trim_edges<G, N>(cycle: &Collection<G, (N,N)>, edges: &Collection<G, (N,N)>)
 where
     G: Scope,
     G::Timestamp: Lattice+Ord,
-    N: Data+Hash,
+    N: ExchangeData+Hash,
 {
     let nodes = edges.map_in_place(|x| x.0 = x.1.clone())
                      .consolidate();

--- a/src/algorithms/graphs/sequential.rs
+++ b/src/algorithms/graphs/sequential.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 
 use timely::dataflow::*;
 
-use ::{Collection, Data};
+use ::{Collection, ExchangeData};
 use ::lattice::Lattice;
 use ::operators::*;
 use hashable::Hashable;
@@ -13,7 +13,7 @@ fn _color<G, N>(edges: &Collection<G, (N,N)>) -> Collection<G,(N,Option<u32>)>
 where
     G: Scope,
     G::Timestamp: Lattice+Ord,
-    N: Data+Hash,
+    N: ExchangeData+Hash,
 {
     // need some bogus initial values.
     let start = edges.map(|(x,_y)| (x,u32::max_value()))
@@ -48,8 +48,8 @@ pub fn sequence<G, N, V, F>(
 where
     G: Scope,
     G::Timestamp: Lattice+Hash+Ord,
-    N: Data+Hashable,
-    V: Data,
+    N: ExchangeData+Hashable,
+    V: ExchangeData,
     F: Fn(&N, &[(&V, isize)])->V+'static
 {
 

--- a/src/algorithms/identifiers.rs
+++ b/src/algorithms/identifiers.rs
@@ -2,13 +2,13 @@
 
 use timely::dataflow::Scope;
 
-use ::{Collection, Data, Hashable};
+use ::{Collection, ExchangeData, Hashable};
 use ::lattice::Lattice;
 use ::operators::*;
 use ::difference::Abelian;
 
 /// Assign unique identifiers to elements of a collection.
-pub trait Identifiers<G: Scope, D: Data, R: Abelian> {
+pub trait Identifiers<G: Scope, D: ExchangeData, R: ExchangeData+Abelian> {
     /// Assign unique identifiers to elements of a collection.
     ///
     /// # Example
@@ -40,8 +40,8 @@ impl<G, D, R> Identifiers<G, D, R> for Collection<G, D, R>
 where
     G: Scope,
     G::Timestamp: Lattice,
-    D: Data+::std::hash::Hash,
-    R: Abelian,
+    D: ExchangeData+::std::hash::Hash,
+    R: ExchangeData+Abelian,
 {
     fn identifiers(&self) -> Collection<G, (D, u64), R> {
 

--- a/src/algorithms/prefix_sum.rs
+++ b/src/algorithms/prefix_sum.rs
@@ -2,7 +2,7 @@
 
 use timely::dataflow::Scope;
 
-use ::{Collection, Data};
+use ::{Collection, ExchangeData};
 use ::lattice::Lattice;
 use ::operators::*;
 
@@ -23,8 +23,8 @@ impl<G, K, D> PrefixSum<G, K, D> for Collection<G, ((usize, K), D)>
 where
     G: Scope,
     G::Timestamp: Lattice,
-    K: Data+::std::hash::Hash,
-    D: Data+::std::hash::Hash,
+    K: ExchangeData+::std::hash::Hash,
+    D: ExchangeData+::std::hash::Hash,
 {
     fn prefix_sum<F>(&self, zero: D, combine: F) -> Self where F: Fn(&K,&D,&D)->D + 'static {
         self.prefix_sum_at(self.map(|(x,_)| x), zero, combine)
@@ -47,8 +47,8 @@ pub fn aggregate<G, K, D, F>(collection: Collection<G, ((usize, K), D)>, combine
 where
     G: Scope,
     G::Timestamp: Lattice,
-    K: Data+::std::hash::Hash,
-    D: Data+::std::hash::Hash,
+    K: ExchangeData+::std::hash::Hash,
+    D: ExchangeData+::std::hash::Hash,
     F: Fn(&K,&D,&D)->D + 'static,
 {
     // initial ranges are at each index, and with width 2^0.
@@ -83,8 +83,8 @@ pub fn broadcast<G, K, D, F>(
 where
     G: Scope,
     G::Timestamp: Lattice+Ord+::std::fmt::Debug,
-    K: Data+::std::hash::Hash,
-    D: Data+::std::hash::Hash,
+    K: ExchangeData+::std::hash::Hash,
+    D: ExchangeData+::std::hash::Hash,
     F: Fn(&K,&D,&D)->D + 'static,
 {
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -442,7 +442,8 @@ impl<G: Scope, D: Data, R: Monoid> Collection<G, D, R> where G::Timestamp: Data 
     /// }
     /// ```
     pub fn assert_empty(&self)
-    where D: ::Data+Hashable,
+    where D: ::ExchangeData+Hashable,
+          R: ::ExchangeData+Hashable,
           G::Timestamp: Lattice+Ord,
     {
         use operators::consolidate::Consolidate;
@@ -561,7 +562,8 @@ impl<G: Scope, D: Data, R: Abelian> Collection<G, D, R> where G::Timestamp: Data
     /// }
     /// ```
     pub fn assert_eq(&self, other: &Self)
-    where D: ::Data+Hashable,
+    where D: ::ExchangeData+Hashable,
+          R: ::ExchangeData+Hashable,
           G::Timestamp: Lattice+Ord
     {
         self.negate()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,13 +78,17 @@ pub use collection::{Collection, AsCollection};
 pub use hashable::Hashable;
 pub use difference::Abelian as Diff;
 
-/// A composite trait for data types usable in differential dataflow.
+/// Data type usable in differential dataflow.
 ///
 /// Most differential dataflow operators require the ability to cancel corresponding updates, and the
 /// way that they do this is by putting the data in a canonical form. The `Ord` trait allows us to sort
 /// the data, at which point we can consolidate updates for equivalent records.
-pub trait Data : timely::ExchangeData + Ord + Debug { }
-impl<T: timely::ExchangeData + Ord + Debug> Data for T { }
+pub trait Data : timely::Data + Ord + Debug { }
+impl<T: timely::Data + Ord + Debug> Data for T { }
+
+/// Data types exchangeable in differential dataflow.
+pub trait ExchangeData : timely::ExchangeData + Ord + Debug { }
+impl<T: timely::ExchangeData + Ord + Debug> ExchangeData for T { }
 
 extern crate fnv;
 extern crate timely;

--- a/src/operators/arrange.rs
+++ b/src/operators/arrange.rs
@@ -835,7 +835,9 @@ where
     /// is the correct way to determine that times in the shared trace are committed.
     fn arrange<Tr>(&self) -> Arranged<G, TraceAgent<Tr>>
     where
-        K: Hashable,
+        K: ExchangeData+Hashable,
+        V: ExchangeData,
+        R: ExchangeData,
         Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
         Tr::Batch: Batch<K, V, G::Timestamp, R>,
         Tr::Cursor: Cursor<K, V, G::Timestamp, R>,
@@ -850,7 +852,9 @@ where
     /// is the correct way to determine that times in the shared trace are committed.
     fn arrange_named<Tr>(&self, name: &str) -> Arranged<G, TraceAgent<Tr>>
     where
-        K: Hashable,
+        K: ExchangeData+Hashable,
+        V: ExchangeData,
+        R: ExchangeData,
         Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
         Tr::Batch: Batch<K, V, G::Timestamp, R>,
         Tr::Cursor: Cursor<K, V, G::Timestamp, R>,
@@ -876,7 +880,7 @@ where
 impl<G: Scope, K: ExchangeData+Hashable, V: ExchangeData, R: Monoid+ExchangeData> Arrange<G, K, V, R> for Collection<G, (K, V), R>
 where
     G::Timestamp: Lattice+Ord,
-{    
+{
     fn arrange_core<P, Tr>(&self, pact: P, name: &str) -> Arranged<G, TraceAgent<Tr>>
     where
         P: ParallelizationContract<G::Timestamp, ((K,V),G::Timestamp,R)>,

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -8,12 +8,12 @@
 
 use timely::dataflow::Scope;
 
-use ::{Collection, Data, Hashable};
+use ::{Collection, ExchangeData, Hashable};
 use ::difference::Monoid;
 use operators::arrange::ArrangeBySelf;
 
 /// An extension method for consolidating weighted streams.
-pub trait Consolidate<D: Data+Hashable> {
+pub trait Consolidate<D: ExchangeData+Hashable> {
     /// Aggregates the weights of equal records into at most one record.
     ///
     /// This method uses the type `D`'s `hashed()` method to partition the data. The data are
@@ -45,8 +45,8 @@ pub trait Consolidate<D: Data+Hashable> {
 
 impl<G: Scope, D, R> Consolidate<D> for Collection<G, D, R>
 where
-    D: Data+Hashable,
-    R: Monoid,
+    D: ExchangeData+Hashable,
+    R: ExchangeData+Monoid,
     G::Timestamp: ::lattice::Lattice+Ord,
  {
     fn consolidate(&self) -> Self {
@@ -55,7 +55,7 @@ where
 }
 
 /// An extension method for consolidating weighted streams.
-pub trait ConsolidateStream<D: Data+Hashable> {
+pub trait ConsolidateStream<D: ExchangeData+Hashable> {
     /// Aggregates the weights of equal records.
     ///
     /// Unlike `consolidate`, this method does not exchange data and does not
@@ -90,8 +90,8 @@ pub trait ConsolidateStream<D: Data+Hashable> {
 
 impl<G: Scope, D, R> ConsolidateStream<D> for Collection<G, D, R>
 where
-    D: Data+Hashable,
-    R: Monoid,
+    D: ExchangeData+Hashable,
+    R: ExchangeData+Monoid,
     G::Timestamp: ::lattice::Lattice+Ord,
  {
     fn consolidate_stream(&self) -> Self {

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -19,7 +19,7 @@ use timely::dataflow::operators::Operator;
 use timely::dataflow::channels::pact::Pipeline;
 
 use lattice::Lattice;
-use ::{Data, Collection};
+use ::{ExchangeData, Collection};
 use ::difference::Monoid;
 use hashable::Hashable;
 use collection::AsCollection;
@@ -27,7 +27,7 @@ use operators::arrange::{Arranged, ArrangeBySelf};
 use trace::{BatchReader, Cursor, TraceReader};
 
 /// Extension trait for the `count` differential dataflow method.
-pub trait CountTotal<G: Scope, K: Data, R: Monoid> where G::Timestamp: TotalOrder+Lattice+Ord {
+pub trait CountTotal<G: Scope, K: ExchangeData, R: Monoid> where G::Timestamp: TotalOrder+Lattice+Ord {
     /// Counts the number of occurrences of each element.
     ///
     /// # Examples
@@ -51,7 +51,7 @@ pub trait CountTotal<G: Scope, K: Data, R: Monoid> where G::Timestamp: TotalOrde
     fn count_total(&self) -> Collection<G, (K, R), isize>;
 }
 
-impl<G: Scope, K: Data+Hashable, R: Monoid> CountTotal<G, K, R> for Collection<G, K, R>
+impl<G: Scope, K: ExchangeData+Hashable, R: ExchangeData+Monoid> CountTotal<G, K, R> for Collection<G, K, R>
 where G::Timestamp: TotalOrder+Lattice+Ord {
     fn count_total(&self) -> Collection<G, (K, R), isize> {
         self.arrange_by_self()
@@ -59,7 +59,7 @@ where G::Timestamp: TotalOrder+Lattice+Ord {
     }
 }
 
-impl<G: Scope, K: Data, R: Monoid, T1> CountTotal<G, K, R> for Arranged<G, K, (), R, T1>
+impl<G: Scope, K: ExchangeData, R: ExchangeData+Monoid, T1> CountTotal<G, K, R> for Arranged<G, K, (), R, T1>
 where
     G::Timestamp: TotalOrder+Lattice+Ord,
     T1: TraceReader<K, (), G::Timestamp, R>+Clone+'static,

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -6,7 +6,7 @@
 //! The function is expected to populate a list of output values.
 
 use hashable::Hashable;
-use ::{Data, Collection};
+use ::{Data, ExchangeData, Collection};
 use ::difference::{Monoid, Abelian};
 
 use timely::order::PartialOrder;
@@ -68,9 +68,9 @@ impl<G, K, V, R> Reduce<G, K, V, R> for Collection<G, (K, V), R>
     where
         G: Scope,
         G::Timestamp: Lattice+Ord,
-        K: Data+Hashable,
-        V: Data,
-        R: Monoid,
+        K: ExchangeData+Hashable,
+        V: ExchangeData,
+        R: ExchangeData+Monoid,
  {
     fn reduce<L, V2: Data, R2: Abelian>(&self, logic: L) -> Collection<G, (K, V2), R2>
         where L: Fn(&K, &[(&V, R)], &mut Vec<(V2, R2)>)+'static {
@@ -145,7 +145,7 @@ pub trait Threshold<G: Scope, K: Data, R1: Monoid> where G::Timestamp: Lattice+O
     }
 }
 
-impl<G: Scope, K: Data+Hashable, R1: Monoid> Threshold<G, K, R1> for Collection<G, K, R1>
+impl<G: Scope, K: ExchangeData+Hashable, R1: ExchangeData+Monoid> Threshold<G, K, R1> for Collection<G, K, R1>
 where G::Timestamp: Lattice+Ord {
     fn threshold<R2: Abelian, F: Fn(&K,&R1)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
         self.arrange_by_self()
@@ -154,7 +154,7 @@ where G::Timestamp: Lattice+Ord {
     }
 }
 
-impl<G: Scope, K: Data, T1, R1: Monoid> Threshold<G, K, R1> for Arranged<G, K, (), R1, T1>
+impl<G: Scope, K: ExchangeData+Data, T1, R1: ExchangeData+Monoid> Threshold<G, K, R1> for Arranged<G, K, (), R1, T1>
 where
     G::Timestamp: Lattice+Ord,
     T1: TraceReader<K, (), G::Timestamp, R1>+Clone+'static,
@@ -190,7 +190,7 @@ pub trait Count<G: Scope, K: Data, R: Monoid> where G::Timestamp: Lattice+Ord {
     fn count(&self) -> Collection<G, (K, R), isize>;
 }
 
-impl<G: Scope, K: Data+Hashable, R: Monoid> Count<G, K, R> for Collection<G, K, R>
+impl<G: Scope, K: ExchangeData+Hashable, R: ExchangeData+Monoid> Count<G, K, R> for Collection<G, K, R>
 where
     G::Timestamp: Lattice+Ord,
 {
@@ -201,7 +201,7 @@ where
     }
 }
 
-impl<G: Scope, K: Data, T1, R: Monoid> Count<G, K, R> for Arranged<G, K, (), R, T1>
+impl<G: Scope, K: ExchangeData, T1, R: ExchangeData+Monoid> Count<G, K, R> for Arranged<G, K, (), R, T1>
 where
     G::Timestamp: Lattice+Ord,
     T1: TraceReader<K, (), G::Timestamp, R>+Clone+'static,
@@ -281,9 +281,9 @@ impl<G, K, V, R> ReduceCore<G, K, V, R> for Collection<G, (K, V), R>
 where
     G: Scope,
     G::Timestamp: Lattice+Ord,
-    K: Data+Hashable,
-    V: Data,
-    R: Monoid,
+    K: ExchangeData+Hashable,
+    V: ExchangeData,
+    R: ExchangeData+Monoid,
 {
     fn reduce_core<L, V2, T2, R2>(&self, logic: L) -> Arranged<G, K, V2, R2, TraceAgent<K, V2, G::Timestamp, R2, T2>>
         where

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -9,7 +9,7 @@ use timely::dataflow::operators::Operator;
 use timely::dataflow::channels::pact::Pipeline;
 
 use lattice::Lattice;
-use ::{Data, Collection};
+use ::{ExchangeData, Collection};
 use ::difference::{Monoid, Abelian};
 use hashable::Hashable;
 use collection::AsCollection;
@@ -17,7 +17,7 @@ use operators::arrange::{Arranged, ArrangeBySelf};
 use trace::{BatchReader, Cursor, TraceReader};
 
 /// Extension trait for the `distinct` differential dataflow method.
-pub trait ThresholdTotal<G: Scope, K: Data, R: Monoid> where G::Timestamp: TotalOrder+Lattice+Ord {
+pub trait ThresholdTotal<G: Scope, K: ExchangeData, R: ExchangeData+Monoid> where G::Timestamp: TotalOrder+Lattice+Ord {
     /// Reduces the collection to one occurrence of each distinct element.
     ///
     /// # Examples
@@ -68,7 +68,7 @@ pub trait ThresholdTotal<G: Scope, K: Data, R: Monoid> where G::Timestamp: Total
     }
 }
 
-impl<G: Scope, K: Data+Hashable, R: Monoid> ThresholdTotal<G, K, R> for Collection<G, K, R>
+impl<G: Scope, K: ExchangeData+Hashable, R: ExchangeData+Monoid> ThresholdTotal<G, K, R> for Collection<G, K, R>
 where G::Timestamp: TotalOrder+Lattice+Ord {
     fn threshold_total<R2: Abelian, F: Fn(&K,&R)->R2+'static>(&self, thresh: F) -> Collection<G, K, R2> {
         self.arrange_by_self()
@@ -76,7 +76,7 @@ where G::Timestamp: TotalOrder+Lattice+Ord {
     }
 }
 
-impl<G: Scope, K: Data, R: Monoid, T1> ThresholdTotal<G, K, R> for Arranged<G, K, (), R, T1>
+impl<G: Scope, K: ExchangeData, R: ExchangeData+Monoid, T1> ThresholdTotal<G, K, R> for Arranged<G, K, (), R, T1>
 where
     G::Timestamp: TotalOrder+Lattice+Ord,
     T1: TraceReader<K, (), G::Timestamp, R>+Clone+'static,

--- a/tpchlike/Cargo.toml
+++ b/tpchlike/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 
 [dependencies]
+rand = "0.6.5"
 regex = "0.2"
 timely = "0.9"
 #timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }

--- a/tpchlike/Cargo.toml
+++ b/tpchlike/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Frank McSherry <fmcsherry@me.com>"]
 
 [dependencies]
 regex = "0.2"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
+timely = "0.9"
+#timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
 differential-dataflow = { path = "../" }
 arrayvec = { git = "https://github.com/bluss/arrayvec" }
 abomonation = "0.7"

--- a/tpchlike/src/bin/arrange.rs
+++ b/tpchlike/src/bin/arrange.rs
@@ -3,6 +3,7 @@ extern crate differential_dataflow;
 extern crate core_affinity;
 extern crate tpchlike;
 
+use std::rc::Rc;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::time::Instant;
@@ -40,9 +41,11 @@ fn main() {
             let (regs_in, regs) = scope.new_input();
             let (supp_in, supp) = scope.new_input();
 
+            // let line = line.map(|(x,y,z): (LineItem, usize, isize)| (x,y+1,-z)).concat(&line);
+
             let collections = Collections::new(
                 cust.as_collection(),
-                line.as_collection(),
+                line.map(|(d,t,r)| (Rc::new(d),t,r)).as_collection(),
                 nats.as_collection(),
                 ords.as_collection(),
                 part.as_collection(),

--- a/tpchlike/src/bin/batch.rs
+++ b/tpchlike/src/bin/batch.rs
@@ -3,6 +3,7 @@ extern crate differential_dataflow;
 extern crate core_affinity;
 extern crate tpchlike;
 
+use std::rc::Rc;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::time::Instant;
@@ -40,7 +41,7 @@ fn main() {
 
             let mut collections = Collections::new(
                 cust.as_collection(),
-                line.as_collection(),
+                line.map(|(d,t,r)| (Rc::new(d),t,r)).as_collection(),
                 nats.as_collection(),
                 ords.as_collection(),
                 part.as_collection(),

--- a/tpchlike/src/bin/just-arrange.rs
+++ b/tpchlike/src/bin/just-arrange.rs
@@ -63,29 +63,6 @@ fn main() {
 
             context.index = arrange;
 
-            queries::query01::query_arranged(&mut context);
-            queries::query02::query_arranged(&mut context);
-            queries::query03::query_arranged(&mut context);
-            queries::query04::query_arranged(&mut context);
-            queries::query05::query_arranged(&mut context);
-            queries::query06::query_arranged(&mut context);
-            queries::query07::query_arranged(&mut context);
-            queries::query08::query_arranged(&mut context);
-            queries::query09::query_arranged(&mut context);
-            queries::query10::query_arranged(&mut context);
-            // queries::query11::query_arranged(&mut context);
-            queries::query12::query_arranged(&mut context);
-            queries::query13::query_arranged(&mut context);
-            queries::query14::query_arranged(&mut context);
-            queries::query15::query_arranged(&mut context);
-            queries::query16::query_arranged(&mut context);
-            queries::query17::query_arranged(&mut context);
-            queries::query18::query_arranged(&mut context);
-            queries::query19::query_arranged(&mut context);
-            // queries::query20::query_arranged(&mut context);
-            // queries::query21::query_arranged(&mut context);
-            // queries::query22::query_arranged(&mut context);
-
             // return the various input handles, and the list of probes.
             let inputs = (
                 Some(cust_in),

--- a/tpchlike/src/bin/sosp.rs
+++ b/tpchlike/src/bin/sosp.rs
@@ -1,0 +1,196 @@
+extern crate rand;
+extern crate timely;
+extern crate differential_dataflow;
+extern crate core_affinity;
+extern crate tpchlike;
+
+use std::rc::Rc;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::time::Instant;
+
+use timely::dataflow::ProbeHandle;
+use tpchlike::{Arrangements, Experiment, InputHandles, types::*, queries};
+
+fn main() {
+
+    timely::execute_from_args(std::env::args().skip(4), |worker| {
+
+        let timer = worker.timer();
+        let index = worker.index();
+        let peers = worker.peers();
+
+        let core_ids = core_affinity::get_core_ids().unwrap();
+        core_affinity::set_for_current(core_ids[index]);
+
+        let mut args = ::std::env::args();
+        args.next();
+        let prefix = args.next().unwrap();
+        let logical_batch = args.next().unwrap().parse::<usize>().expect("logical batch must be an integer");
+        let physical_batch = args.next().unwrap().parse::<usize>().expect("physical batch must be an integer");
+        let concurrent = args.next().unwrap().parse::<usize>().expect("concurrency must be an integer");
+        let arrange: bool = args.next().unwrap().parse().unwrap();
+        let seal: bool = ::std::env::args().any(|x| x == "seal-inputs");
+
+        // Build all indices, as we plan to use all of them.
+        let (mut inputs, mut probe, mut traces) = worker.dataflow::<usize,_,_>(move |scope| {
+
+            let mut inputs = InputHandles::new();
+            let mut probe = ProbeHandle::new();
+            let traces = Arrangements::new(&mut inputs, scope, &mut probe, arrange);
+
+            (inputs, probe, traces)
+        });
+
+        // customer.tbl lineitem.tbl    nation.tbl  orders.tbl  part.tbl    partsupp.tbl    region.tbl  supplier.tbl
+        let mut customers = load::<Customer>(prefix.as_str(), "customer.tbl", index, peers, logical_batch, physical_batch, 0);
+        let mut lineitems = load::<LineItem>(prefix.as_str(), "lineitem.tbl", index, peers, logical_batch, physical_batch, 1);
+        let mut nations = load::<Nation>(prefix.as_str(), "nation.tbl", index, peers, logical_batch, physical_batch, 2);
+        let mut orders = load::<Order>(prefix.as_str(), "orders.tbl", index, peers, logical_batch, physical_batch, 3);
+        let mut parts = load::<Part>(prefix.as_str(), "part.tbl", index, peers, logical_batch, physical_batch, 4);
+        let mut partsupps = load::<PartSupp>(prefix.as_str(), "partsupp.tbl", index, peers, logical_batch, physical_batch, 5);
+        let mut regions = load::<Region>(prefix.as_str(), "region.tbl", index, peers, logical_batch, physical_batch, 6);
+        let mut suppliers = load::<Supplier>(prefix.as_str(), "supplier.tbl", index, peers, logical_batch, physical_batch, 7);
+
+        println!("{:?}\tInput loaded", timer.elapsed());
+
+        // Synchronize before starting the timer.
+        let next_round = 1;
+        inputs.advance_to(next_round);
+
+        let time = next_round;
+        worker.step_while(|| probe.less_than(&time));
+
+        use rand::prelude::*;
+        let mut rng = rand::thread_rng();
+
+        let timer = Instant::now();
+        let mut experiments = Vec::<Experiment>::new();
+        let mut round = 0;
+        while customers.len() > 0 || lineitems.len() > 0 || nations.len() > 0 || orders.len() > 0 || parts.len() > 0 || partsupps.len() > 0 || regions.len() > 0 || suppliers.len() > 0 {
+
+            let this_round = 1 + 8 * round * physical_batch;
+
+            let query = rng.gen_range(0, 22);
+
+            // install new dataflows, retire old dataflow
+            worker.dataflow::<usize,_,_>(|scope| {
+
+                let mut experiment = Experiment::new(query);
+                match query {
+                     0 => queries::query01::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                     1 => queries::query02::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                     2 => queries::query03::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                     3 => queries::query04::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                     4 => queries::query05::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                     5 => queries::query06::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                     6 => queries::query07::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                     7 => queries::query08::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                     8 => queries::query09::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                     9 => queries::query10::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                    10 => queries::query11::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                    11 => queries::query12::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                    12 => queries::query13::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                    13 => queries::query14::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                    14 => queries::query15::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                    15 => queries::query16::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                    16 => queries::query17::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                    17 => queries::query18::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                    18 => queries::query19::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                    19 => queries::query20::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                    20 => queries::query21::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                    21 => queries::query22::query_arranged(scope, &mut probe, &mut experiment, &mut traces),
+                    _ => { },
+                }
+                experiment.lineitem.advance_to(this_round);
+                experiments.push(experiment);
+            });
+            if experiments.len() > concurrent {
+                experiments.remove(0).close();
+            }
+            let start = timer.elapsed();
+            worker.step_while(|| probe.less_than(&this_round));
+            let install = timer.elapsed() - start;
+
+            // catch all inputs up to the same (next) round.
+            let next_round = 1 + 8 * (round + 1) * physical_batch;
+
+            // introduce physical batch of data for each input with remaining data.
+            if let Some(mut data) = customers.pop() { inputs.customer.send_batch(&mut data); }
+            if let Some(mut data) = lineitems.pop() {
+                let mut data = data.drain(..).map(|(x,y,z)| (Rc::new(x),y,z)).collect::<Vec<_>>();
+                let mut temp = Vec::new();
+                for experiment in experiments.iter_mut() {
+                    temp.clone_from(&data);
+                    experiment.lineitem.send_batch(&mut temp);
+                    experiment.lineitem.advance_to(next_round);
+                }
+                inputs.lineitem.send_batch(&mut data);
+            }
+            if let Some(mut data) = nations.pop() { inputs.nation.send_batch(&mut data); }
+            if let Some(mut data) = orders.pop() { inputs.order.send_batch(&mut data); }
+            if let Some(mut data) = parts.pop() { inputs.part.send_batch(&mut data); }
+            if let Some(mut data) = partsupps.pop() { inputs.partsupp.send_batch(&mut data); }
+            if let Some(mut data) = regions.pop() { inputs.region.send_batch(&mut data); }
+            if let Some(mut data) = suppliers.pop() { inputs.supplier.send_batch(&mut data); }
+
+            inputs.advance_to(next_round);
+            traces.advance_by(&[next_round]);
+
+            let start = timer.elapsed();
+            worker.step_while(|| probe.less_than(&next_round));
+            let work = timer.elapsed() - start;
+
+            println!("{:?}\tround {}\tinstalled {} in {:?}\tupdated in {:?}", timer.elapsed(), round, query, install.as_nanos(), work.as_nanos());
+
+            round += 1;
+        }
+
+    }).unwrap();
+}
+
+// Returns a sequence of physical batches of ready-to-go timestamped data. Not clear that `input` can exploit the pre-arrangement yet.
+fn load<T>(prefix: &str, name: &str, index: usize, peers: usize, logical_batch: usize, physical_batch: usize, off: usize)
+    -> Vec<Vec<(T, usize, isize)>>
+where T: for<'a> From<&'a str> {
+
+    let mut result = Vec::new();
+    let mut buffer = Vec::new();
+
+    let path = format!("{}{}", prefix, name);
+
+    let items_file = File::open(&path).expect("didn't find items file");
+    let mut items_reader =  BufReader::new(items_file);
+    let mut count = 0;
+
+    let mut line = String::new();
+
+    while items_reader.read_line(&mut line).unwrap() > 0 {
+
+        if count % peers == index {
+
+            let logical = (8 * count / logical_batch) + off;
+            let physical = logical / physical_batch;
+            let round = physical / 8;
+
+            while result.len() < round {
+                result.push(buffer);
+                buffer = Vec::with_capacity(2 + logical_batch * physical_batch / peers);
+            }
+
+            let item = T::from(line.as_str());
+            buffer.push((item, logical + 1, 1));
+        }
+
+        count += 1;
+
+        line.clear();
+    }
+
+    if buffer.len() > 0 {
+        result.push(buffer);
+    }
+
+    result.reverse();
+    result
+}

--- a/tpchlike/src/bin/stream.rs
+++ b/tpchlike/src/bin/stream.rs
@@ -3,6 +3,7 @@ extern crate differential_dataflow;
 extern crate core_affinity;
 extern crate tpchlike;
 
+use std::rc::Rc;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::time::Instant;
@@ -43,7 +44,7 @@ fn main() {
 
             let mut collections = Collections::new(
                 cust.as_collection(),
-                line.as_collection(),
+                line.map(|(d,t,r)| (Rc::new(d),t,r)).as_collection(),
                 nats.as_collection(),
                 ords.as_collection(),
                 part.as_collection(),

--- a/tpchlike/src/lib.rs
+++ b/tpchlike/src/lib.rs
@@ -8,69 +8,75 @@ extern crate regex;
 use std::rc::Rc;
 
 use timely::dataflow::*;
+use timely::dataflow::operators::CapabilitySet;
 
 use differential_dataflow::Collection;
 use differential_dataflow::operators::arrange::ArrangeByKey;
+use differential_dataflow::operators::arrange::ShutdownButton;
 
 pub mod types;
 pub mod queries;
 
 pub use types::*;
 
-pub struct Context<G: Scope<Timestamp=usize>> {
-    pub index: bool,
-    pub scope: G,
-    pub probe: ProbeHandle<usize>,
-    pub collections: Collections<G>,
-    pub arrangements: Arrangements,
+pub struct InputHandles {
+    pub customer:   InputHandle<usize, (Customer, usize, isize)>,
+    pub lineitem:   InputHandle<usize, (Rc<LineItem>, usize, isize)>,
+    pub nation:     InputHandle<usize, (Nation, usize, isize)>,
+    pub order:      InputHandle<usize, (Order, usize, isize)>,
+    pub part:       InputHandle<usize, (Part, usize, isize)>,
+    pub partsupp:   InputHandle<usize, (PartSupp, usize, isize)>,
+    pub region:     InputHandle<usize, (Region, usize, isize)>,
+    pub supplier:   InputHandle<usize, (Supplier, usize, isize)>,
 }
 
-impl<G: Scope<Timestamp=usize>> Context<G> {
-    pub fn new(scope: G, mut collections: Collections<G>) -> Self {
-        let mut probe = ProbeHandle::new();
-        let arrangements = Arrangements::new(&mut collections, &mut probe);
-        Self { index: true, scope, probe, collections, arrangements }
+impl InputHandles {
+    pub fn new() -> Self {
+        Self {
+            customer: InputHandle::new(),
+            lineitem: InputHandle::new(),
+            nation: InputHandle::new(),
+            order: InputHandle::new(),
+            part: InputHandle::new(),
+            partsupp: InputHandle::new(),
+            region: InputHandle::new(),
+            supplier: InputHandle::new(),
+        }
     }
+    pub fn advance_to(&mut self, time: usize) {
+        self.customer.advance_to(time);
+        self.lineitem.advance_to(time);
+        self.nation.advance_to(time);
+        self.order.advance_to(time);
+        self.part.advance_to(time);
+        self.partsupp.advance_to(time);
+        self.region.advance_to(time);
+        self.supplier.advance_to(time);
+    }
+}
 
-    pub fn advance_by(&mut self, frontier: &[usize]) {
-        self.arrangements.advance_by(frontier);
-    }
+pub struct Experiment {
+    pub index: usize,
+    pub lineitem: InputHandle<usize, (Rc<LineItem>, usize, isize)>,
+    pub buttons: Vec<ShutdownButton<CapabilitySet<usize>>>,
+}
 
-    pub fn customers(&mut self) -> ArrangedScope<G, Customer> {
-        if self.index { self.arrangements.customers.import(&mut self.scope) }
-        else {
-            self.collections.customers().map(|x| (x.cust_key, x)).arrange_by_key()
+impl Experiment {
+    pub fn new(index: usize) -> Self {
+        Self {
+            index,
+            lineitem: InputHandle::new(),
+            buttons: Vec::new(),
         }
     }
-    pub fn nations(&mut self) -> ArrangedScope<G, Nation> {
-        if self.index { self.arrangements.nations.import(&mut self.scope) }
-        else {
-            self.collections.nations().map(|x| (x.nation_key, x)).arrange_by_key()
-        }
+    pub fn lineitem<G: Scope<Timestamp=usize>>(&mut self, scope: &mut G) -> Collection<G, Rc<LineItem>, isize> {
+        use timely::dataflow::operators::Input;
+        use differential_dataflow::AsCollection;
+
+        scope.input_from(&mut self.lineitem).as_collection()
     }
-    pub fn orders(&mut self) -> ArrangedScope<G, Order> {
-        if self.index { self.arrangements.orders.import(&mut self.scope) }
-        else {
-            self.collections.orders().map(|x| (x.order_key, x)).arrange_by_key()
-        }
-    }
-    pub fn parts(&mut self) -> ArrangedScope<G, Part> {
-        if self.index { self.arrangements.parts.import(&mut self.scope) }
-        else {
-            self.collections.parts().map(|x| (x.part_key, x)).arrange_by_key()
-        }
-    }
-    pub fn regions(&mut self) -> ArrangedScope<G, Region> {
-        if self.index { self.arrangements.regions.import(&mut self.scope) }
-        else {
-            self.collections.regions().map(|x| (x.region_key, x)).arrange_by_key()
-        }
-    }
-    pub fn suppliers(&mut self) -> ArrangedScope<G, Supplier> {
-        if self.index { self.arrangements.suppliers.import(&mut self.scope) }
-        else {
-            self.collections.suppliers().map(|x| (x.supp_key, x)).arrange_by_key()
-        }
+    pub fn close(mut self) {
+        for mut button in self.buttons.drain(..) { button.press(); }
     }
 }
 
@@ -127,65 +133,119 @@ impl<G: Scope> Collections<G> {
 use differential_dataflow::trace::implementations::ord::OrdValSpine as DefaultValTrace;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 
-type ArrangedScope<G, T> = Arranged<G, ArrangedIndex<T>>;
-type ArrangedIndex<T> = TraceAgent<DefaultValTrace<usize, T, usize, isize>>;
+type ArrangedScope<G, K, T> = Arranged<G, ArrangedIndex<K, T>>;
+type ArrangedIndex<K, T> = TraceAgent<DefaultValTrace<K, T, usize, isize>>;
+
+pub struct ArrangementsInScope<G: Scope<Timestamp=usize>> {
+    customer:   ArrangedScope<G, usize, Customer>,
+    nation:     ArrangedScope<G, usize, Nation>,
+    order:      ArrangedScope<G, usize, Order>,
+    part:       ArrangedScope<G, usize, Part>,
+    partsupp:   ArrangedScope<G, (usize, usize), PartSupp>,
+    region:     ArrangedScope<G, usize, Region>,
+    supplier:   ArrangedScope<G, usize, Supplier>,
+}
 
 pub struct Arrangements {
-    customers:  ArrangedIndex<Customer>,
-    nations:    ArrangedIndex<Nation>,
-    orders:     ArrangedIndex<Order>,
-    parts:      ArrangedIndex<Part>,
-    regions:    ArrangedIndex<Region>,
-    suppliers:  ArrangedIndex<Supplier>,
+    arrange:    bool,
+    customer:   ArrangedIndex<usize, Customer>,
+    nation:     ArrangedIndex<usize, Nation>,
+    order:      ArrangedIndex<usize, Order>,
+    part:       ArrangedIndex<usize, Part>,
+    partsupp:   ArrangedIndex<(usize, usize), PartSupp>,
+    region:     ArrangedIndex<usize, Region>,
+    supplier:   ArrangedIndex<usize, Supplier>,
 }
 
 use timely::dataflow::Scope;
 
 impl Arrangements {
 
-    pub fn new<G: Scope<Timestamp=usize>>(collections: &mut Collections<G>, probe: &mut ProbeHandle<usize>) -> Self {
+    pub fn new<G: Scope<Timestamp=usize>>(inputs: &mut InputHandles, scope: &mut G, probe: &mut ProbeHandle<usize>, arrange: bool) -> Self {
 
+        use timely::dataflow::operators::Input;
         use timely::dataflow::operators::Probe;
-        use differential_dataflow::operators::arrange::ArrangeByKey;
+        use differential_dataflow::AsCollection;
         use differential_dataflow::trace::TraceReader;
 
-        let mut arranged = collections.customers().map(|x| (x.cust_key, x)).arrange_by_key();
+        let mut arranged = scope.input_from(&mut inputs.customer).as_collection().map(|x| (x.cust_key, x)).arrange_by_key();
         arranged.stream.probe_with(probe);
         arranged.trace.distinguish_since(&[]);
-        let customers = arranged.trace;
+        let customer = arranged.trace;
 
-        let mut arranged = collections.nations().map(|x| (x.nation_key, x)).arrange_by_key();
+        let mut arranged = scope.input_from(&mut inputs.nation).as_collection().map(|x| (x.nation_key, x)).arrange_by_key();
         arranged.stream.probe_with(probe);
         arranged.trace.distinguish_since(&[]);
-        let nations = arranged.trace;
+        let nation = arranged.trace;
 
-        let mut arranged = collections.orders().map(|x| (x.order_key, x)).arrange_by_key();
+        let mut arranged = scope.input_from(&mut inputs.order).as_collection().map(|x| (x.order_key, x)).arrange_by_key();
         arranged.stream.probe_with(probe);
         arranged.trace.distinguish_since(&[]);
-        let orders = arranged.trace;
+        let order = arranged.trace;
 
-        let mut arranged = collections.parts().map(|x| (x.part_key, x)).arrange_by_key();
+        let mut arranged = scope.input_from(&mut inputs.part).as_collection().map(|x| (x.part_key, x)).arrange_by_key();
         arranged.stream.probe_with(probe);
         arranged.trace.distinguish_since(&[]);
-        let parts = arranged.trace;
+        let part = arranged.trace;
 
-        let mut arranged = collections.regions().map(|x| (x.region_key, x)).arrange_by_key();
+        let mut arranged = scope.input_from(&mut inputs.partsupp).as_collection().map(|x| ((x.part_key, x.supp_key), x)).arrange_by_key();
         arranged.stream.probe_with(probe);
         arranged.trace.distinguish_since(&[]);
-        let regions = arranged.trace;
+        let partsupp = arranged.trace;
 
-        let mut arranged = collections.suppliers().map(|x| (x.supp_key, x)).arrange_by_key();
+        let mut arranged = scope.input_from(&mut inputs.region).as_collection().map(|x| (x.region_key, x)).arrange_by_key();
         arranged.stream.probe_with(probe);
         arranged.trace.distinguish_since(&[]);
-        let suppliers = arranged.trace;
+        let region = arranged.trace;
+
+        let mut arranged = scope.input_from(&mut inputs.supplier).as_collection().map(|x| (x.supp_key, x)).arrange_by_key();
+        arranged.stream.probe_with(probe);
+        arranged.trace.distinguish_since(&[]);
+        let supplier = arranged.trace;
 
         Arrangements {
-            customers,
-            nations,
-            orders,
-            parts,
-            regions,
-            suppliers,
+            arrange,
+            customer,
+            nation,
+            order,
+            part,
+            partsupp,
+            region,
+            supplier,
+        }
+    }
+
+    pub fn in_scope<G: Scope<Timestamp=usize>>(&mut self, scope: &mut G, experiment: &mut Experiment) -> ArrangementsInScope<G> {
+        let (mut customer, button) = self.customer.import_core(scope, "customer");
+        if !self.arrange { customer = customer.as_collection(|&k,v| (k,v.clone())).arrange_by_key(); }
+        experiment.buttons.push(button);
+        let (mut nation, button) = self.nation.import_core(scope, "nation");
+        if !self.arrange { nation = nation.as_collection(|&k,v| (k,v.clone())).arrange_by_key(); }
+        experiment.buttons.push(button);
+        let (mut order, button) = self.order.import_core(scope, "order");
+        if !self.arrange { order = order.as_collection(|&k,v| (k,v.clone())).arrange_by_key(); }
+        experiment.buttons.push(button);
+        let (mut part, button) = self.part.import_core(scope, "part");
+        if !self.arrange { part = part.as_collection(|&k,v| (k,v.clone())).arrange_by_key(); }
+        experiment.buttons.push(button);
+        let (mut partsupp, button) = self.partsupp.import_core(scope, "partsupp");
+        if !self.arrange { partsupp = partsupp.as_collection(|&k,v| (k,v.clone())).arrange_by_key(); }
+        experiment.buttons.push(button);
+        let (mut region, button) = self.region.import_core(scope, "region");
+        if !self.arrange { region = region.as_collection(|&k,v| (k,v.clone())).arrange_by_key(); }
+        experiment.buttons.push(button);
+        let (mut supplier, button) = self.supplier.import_core(scope, "supplier");
+        if !self.arrange { supplier = supplier.as_collection(|&k,v| (k,v.clone())).arrange_by_key(); }
+        experiment.buttons.push(button);
+
+        ArrangementsInScope {
+            customer,
+            nation,
+            order,
+            part,
+            partsupp,
+            region,
+            supplier,
         }
     }
 
@@ -193,11 +253,11 @@ impl Arrangements {
 
         use differential_dataflow::trace::TraceReader;
 
-        self.customers.advance_by(frontier);
-        self.nations.advance_by(frontier);
-        self.orders.advance_by(frontier);
-        self.parts.advance_by(frontier);
-        self.regions.advance_by(frontier);
-        self.suppliers.advance_by(frontier);
+        self.customer.advance_by(frontier);
+        self.nation.advance_by(frontier);
+        self.order.advance_by(frontier);
+        self.part.advance_by(frontier);
+        self.region.advance_by(frontier);
+        self.supplier.advance_by(frontier);
     }
 }

--- a/tpchlike/src/lib.rs
+++ b/tpchlike/src/lib.rs
@@ -20,14 +20,14 @@ pub mod queries;
 pub use types::*;
 
 pub struct InputHandles {
-    pub customer:   InputHandle<usize, (Customer, usize, isize)>,
-    pub lineitem:   InputHandle<usize, (Rc<LineItem>, usize, isize)>,
-    pub nation:     InputHandle<usize, (Nation, usize, isize)>,
-    pub order:      InputHandle<usize, (Order, usize, isize)>,
-    pub part:       InputHandle<usize, (Part, usize, isize)>,
-    pub partsupp:   InputHandle<usize, (PartSupp, usize, isize)>,
-    pub region:     InputHandle<usize, (Region, usize, isize)>,
-    pub supplier:   InputHandle<usize, (Supplier, usize, isize)>,
+    pub customer: InputHandle<usize, (Customer, usize, isize)>,
+    pub lineitem: InputHandle<usize, (Rc<LineItem>, usize, isize)>,
+    pub nation: InputHandle<usize, (Nation, usize, isize)>,
+    pub order: InputHandle<usize, (Order, usize, isize)>,
+    pub part: InputHandle<usize, (Part, usize, isize)>,
+    pub partsupp: InputHandle<usize, (PartSupp, usize, isize)>,
+    pub region: InputHandle<usize, (Region, usize, isize)>,
+    pub supplier: InputHandle<usize, (Supplier, usize, isize)>,
 }
 
 impl InputHandles {
@@ -43,40 +43,25 @@ impl InputHandles {
             supplier: InputHandle::new(),
         }
     }
-    pub fn advance_to(&mut self, time: usize) {
-        self.customer.advance_to(time);
-        self.lineitem.advance_to(time);
-        self.nation.advance_to(time);
-        self.order.advance_to(time);
-        self.part.advance_to(time);
-        self.partsupp.advance_to(time);
-        self.region.advance_to(time);
-        self.supplier.advance_to(time);
+    pub fn advance_to(&mut self, round: usize) {
+        self.customer.advance_to(round);
+        self.lineitem.advance_to(round);
+        self.nation.advance_to(round);
+        self.order.advance_to(round);
+        self.part.advance_to(round);
+        self.partsupp.advance_to(round);
+        self.region.advance_to(round);
+        self.supplier.advance_to(round);
     }
-}
-
-pub struct Experiment {
-    pub index: usize,
-    pub lineitem: InputHandle<usize, (Rc<LineItem>, usize, isize)>,
-    pub buttons: Vec<ShutdownButton<CapabilitySet<usize>>>,
-}
-
-impl Experiment {
-    pub fn new(index: usize) -> Self {
-        Self {
-            index,
-            lineitem: InputHandle::new(),
-            buttons: Vec::new(),
-        }
-    }
-    pub fn lineitem<G: Scope<Timestamp=usize>>(&mut self, scope: &mut G) -> Collection<G, Rc<LineItem>, isize> {
-        use timely::dataflow::operators::Input;
-        use differential_dataflow::AsCollection;
-
-        scope.input_from(&mut self.lineitem).as_collection()
-    }
-    pub fn close(mut self) {
-        for mut button in self.buttons.drain(..) { button.press(); }
+    pub fn close(self) {
+        self.customer.close();
+        self.lineitem.close();
+        self.nation.close();
+        self.order.close();
+        self.part.close();
+        self.partsupp.close();
+        self.region.close();
+        self.supplier.close();
     }
 }
 
@@ -257,7 +242,33 @@ impl Arrangements {
         self.nation.advance_by(frontier);
         self.order.advance_by(frontier);
         self.part.advance_by(frontier);
+        self.partsupp.advance_by(frontier);
         self.region.advance_by(frontier);
         self.supplier.advance_by(frontier);
+    }
+}
+
+pub struct Experiment {
+    pub index: usize,
+    pub lineitem: InputHandle<usize, (Rc<LineItem>, usize, isize)>,
+    pub buttons: Vec<ShutdownButton<CapabilitySet<usize>>>,
+}
+
+impl Experiment {
+    pub fn new(index: usize) -> Self {
+        Self {
+            index,
+            lineitem: InputHandle::new(),
+            buttons: Vec::new(),
+        }
+    }
+    pub fn lineitem<G: Scope<Timestamp=usize>>(&mut self, scope: &mut G) -> Collection<G, Rc<LineItem>, isize> {
+        use timely::dataflow::operators::Input;
+        use differential_dataflow::AsCollection;
+        scope.input_from(&mut self.lineitem).as_collection()
+    }
+    pub fn close(mut self) {
+        self.lineitem.close();
+        for mut button in self.buttons.drain(..) { button.press(); }
     }
 }

--- a/tpchlike/src/lib.rs
+++ b/tpchlike/src/lib.rs
@@ -5,6 +5,8 @@ extern crate differential_dataflow;
 extern crate arrayvec;
 extern crate regex;
 
+use std::rc::Rc;
+
 use timely::dataflow::*;
 
 use differential_dataflow::Collection;
@@ -74,7 +76,7 @@ impl<G: Scope<Timestamp=usize>> Context<G> {
 
 pub struct Collections<G: Scope> {
     customers: Collection<G, Customer, isize>,
-    lineitems: Collection<G, LineItem, isize>,
+    lineitems: Collection<G, Rc<LineItem>, isize>,
     nations: Collection<G, Nation, isize>,
     orders: Collection<G, Order, isize>,
     parts: Collection<G, Part, isize>,
@@ -87,7 +89,7 @@ pub struct Collections<G: Scope> {
 impl<G: Scope> Collections<G> {
     pub fn new(
         customers: Collection<G, Customer, isize>,
-        lineitems: Collection<G, LineItem, isize>,
+        lineitems: Collection<G, Rc<LineItem>, isize>,
         nations: Collection<G, Nation, isize>,
         orders: Collection<G, Order, isize>,
         parts: Collection<G, Part, isize>,
@@ -110,7 +112,7 @@ impl<G: Scope> Collections<G> {
     }
 
     pub fn customers(&mut self) -> &Collection<G, Customer, isize> { self.used[0] = true; &self.customers }
-    pub fn lineitems(&mut self) -> &Collection<G, LineItem, isize> { self.used[1] = true; &self.lineitems }
+    pub fn lineitems(&mut self) -> &Collection<G, Rc<LineItem>, isize> { self.used[1] = true; &self.lineitems }
     pub fn nations(&mut self) -> &Collection<G, Nation, isize> { self.used[2] = true; &self.nations }
     pub fn orders(&mut self) -> &Collection<G, Order, isize> { self.used[3] = true; &self.orders }
     pub fn parts(&mut self) -> &Collection<G, Part, isize> { self.used[4] = true; &self.parts }

--- a/tpchlike/src/lib.rs
+++ b/tpchlike/src/lib.rs
@@ -248,16 +248,19 @@ impl Arrangements {
     }
 }
 
+use std::rc::Weak;
 pub struct Experiment {
     pub index: usize,
+    pub token: Weak<()>,
     pub lineitem: InputHandle<usize, (Rc<LineItem>, usize, isize)>,
     pub buttons: Vec<ShutdownButton<CapabilitySet<usize>>>,
 }
 
 impl Experiment {
-    pub fn new(index: usize) -> Self {
+    pub fn new(index: usize, token: &Rc<()>) -> Self {
         Self {
             index,
+            token: std::rc::Rc::downgrade(token),
             lineitem: InputHandle::new(),
             buttons: Vec::new(),
         }
@@ -267,8 +270,9 @@ impl Experiment {
         use differential_dataflow::AsCollection;
         scope.input_from(&mut self.lineitem).as_collection()
     }
-    pub fn close(mut self) {
+    pub fn close(mut self) -> Weak<()> {
         self.lineitem.close();
         for mut button in self.buttons.drain(..) { button.press(); }
+        self.token
     }
 }

--- a/tpchlike/src/queries/query01.rs
+++ b/tpchlike/src/queries/query01.rs
@@ -6,7 +6,7 @@ use differential_dataflow::operators::*;
 use differential_dataflow::difference::DiffPair;
 use differential_dataflow::lattice::Lattice;
 
-use {Context, Collections};
+use {Arrangements, Experiment, Collections};
 
 // -- $ID$
 // -- TPC-H/TPC-R Pricing Summary Report Query (Q1)
@@ -62,14 +62,16 @@ where
 }
 
 pub fn query_arranged<G: Scope<Timestamp=usize>>(
-    context: &mut Context<G>,
+    scope: &mut G,
+    probe: &mut ProbeHandle<usize>,
+    experiment: &mut Experiment,
+    _arrangements: &mut Arrangements,
 )
 where
     G::Timestamp: Lattice+TotalOrder+Ord
 {
-    context
-        .collections
-        .lineitems()
+    experiment
+        .lineitem(scope)
         .explode(|item|
             if item.ship_date <= ::types::create_date(1998, 9, 2) {
                 Some(((item.return_flag[0], item.line_status[0]),
@@ -84,6 +86,5 @@ where
             }
         )
         .count_total()
-        // .inspect(|x| println!("{:?}", x))
-        .probe_with(&mut context.probe);
+        .probe_with(probe);
 }

--- a/tpchlike/src/queries/query02.rs
+++ b/tpchlike/src/queries/query02.rs
@@ -5,7 +5,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 
-use {Collections, Context};
+use {Arrangements, Experiment, Collections};
 
 // -- $ID$
 // -- TPC-H/TPC-R Minimum Cost Supplier Query (Q2)
@@ -117,22 +117,23 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
 }
 
 pub fn query_arranged<G: Scope<Timestamp=usize>>(
-    context: &mut Context<G>,
+    scope: &mut G,
+    probe: &mut ProbeHandle<usize>,
+    experiment: &mut Experiment,
+    arrangements: &mut Arrangements,
 )
+where
+    G::Timestamp: Lattice+TotalOrder+Ord
 {
-    let suppliers = context.suppliers();
-    let nations = context.nations();
-    let regions = context.regions();
-    let parts = context.parts();
+    let arrangements = arrangements.in_scope(scope, experiment);
 
     let relevant_suppliers =
-    context
-        .collections
-        .partsupps()
-        .map(|x| (x.supp_key, (x.part_key, x.supplycost)))
-        .join_core(&suppliers, |&sk, &(pk,sc), s| Some((s.nation_key, (pk,sc,sk))))
-        .join_core(&nations, |_nk, &(pk,sc,sk), n| Some((n.region_key, (pk,sc,sk,n.name))))
-        .join_core(&regions, |_rk, &(pk,sc,sk,nm), r| {
+    arrangements
+        .partsupp
+        .as_collection(|_,x| (x.supp_key, (x.part_key, x.supplycost)))
+        .join_core(&arrangements.supplier, |&sk, &(pk,sc), s| Some((s.nation_key, (pk,sc,sk))))
+        .join_core(&arrangements.nation, |_nk, &(pk,sc,sk), n| Some((n.region_key, (pk,sc,sk,n.name))))
+        .join_core(&arrangements.region, |_rk, &(pk,sc,sk,nm), r| {
             if starts_with(&r.name[..], b"EUROPE") { Some((pk,(sc,sk,nm))) } else { None }
         });
 
@@ -144,7 +145,7 @@ pub fn query_arranged<G: Scope<Timestamp=usize>>(
         });
 
     cheapest_suppliers
-        .join_core(&parts, |&pk,&(sc,sk,nm),p| {
+        .join_core(&arrangements.part, |&pk,&(sc,sk,nm),p| {
             if substring(p.typ.as_str().as_bytes(), b"BRASS") && p.size == 15 {
                 Some((sk, (sc,pk,nm,p.mfgr)))
             }
@@ -152,8 +153,8 @@ pub fn query_arranged<G: Scope<Timestamp=usize>>(
                 None
             }
         })
-        .join_core(&suppliers, |_sk,&(sc,pk,nm,pm),s| {
+        .join_core(&arrangements.supplier, |_sk,&(sc,pk,nm,pm),s| {
             Some((sc,pk,nm,pm,s.acctbal,s.name,s.address,s.phone,s.comment))
         })
-        .probe_with(&mut context.probe);
+        .probe_with(probe);
 }

--- a/tpchlike/src/queries/query07.rs
+++ b/tpchlike/src/queries/query07.rs
@@ -5,7 +5,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 
-use {Collections, Context};
+use {Arrangements, Experiment, Collections};
 use ::types::create_date;
 
 // -- $ID$
@@ -105,26 +105,26 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
 }
 
 pub fn query_arranged<G: Scope<Timestamp=usize>>(
-    context: &mut Context<G>,
+    scope: &mut G,
+    probe: &mut ProbeHandle<usize>,
+    experiment: &mut Experiment,
+    arrangements: &mut Arrangements,
 )
+where
+    G::Timestamp: Lattice+TotalOrder+Ord
 {
-    let customer = context.customers();
-    let order = context.orders();
-    let supplier = context.suppliers();
-    let nation = context.nations();
+    let arrangements = arrangements.in_scope(scope, experiment);
 
-    let shipping =
-    context
-        .collections
-        .lineitems()
+    experiment
+        .lineitem(scope)
         .explode(|l|
             if create_date(1995, 1, 1) <= l.ship_date && l.ship_date <= create_date(1996, 12, 31) {
                 Some(((l.supp_key, (l.order_key, l.ship_date >> 16)), (l.extended_price * (100 - l.discount)) as isize / 100))
             }
             else { None }
         )
-        .join_core(&supplier, |_sk,&(ok,sd),s| Some((s.nation_key,(ok,sd))))
-        .join_core(&nation, |_nk,&(ok,sd),n| {
+        .join_core(&arrangements.supplier, |_sk,&(ok,sd),s| Some((s.nation_key,(ok,sd))))
+        .join_core(&arrangements.nation, |_nk,&(ok,sd),n| {
             if starts_with(&n.name, b"FRANCE") || starts_with(&n.name, b"GERMANY") {
                 Some((ok,(sd,n.name)))
             }
@@ -132,9 +132,9 @@ pub fn query_arranged<G: Scope<Timestamp=usize>>(
                 None
             }
         })
-        .join_core(&order, |_ok,&(sd,n1),o| Some((o.cust_key,(sd,n1))))
-        .join_core(&customer, |_ck,&(sd,n1),c| Some((c.nation_key,(sd,n1))))
-        .join_core(&nation, |_nk,&(sd,n1),n| {
+        .join_core(&arrangements.order, |_ok,&(sd,n1),o| Some((o.cust_key,(sd,n1))))
+        .join_core(&arrangements.customer, |_ck,&(sd,n1),c| Some((c.nation_key,(sd,n1))))
+        .join_core(&arrangements.nation, |_nk,&(sd,n1),n| {
             if starts_with(&n.name, b"FRANCE") || starts_with(&n.name, b"GERMANY") {
                 Some((sd,n1,n.name))
             }
@@ -142,9 +142,7 @@ pub fn query_arranged<G: Scope<Timestamp=usize>>(
                 None
             }
         })
-        .filter(|&(_sd,n1,n2)| n1 != n2);
-
-    shipping
+        .filter(|&(_sd,n1,n2)| n1 != n2)
         .count_total()
-        .probe_with(&mut context.probe);
+        .probe_with(probe);
 }

--- a/tpchlike/src/queries/query08.rs
+++ b/tpchlike/src/queries/query08.rs
@@ -6,7 +6,7 @@ use differential_dataflow::operators::*;
 use differential_dataflow::difference::DiffPair;
 use differential_dataflow::lattice::Lattice;
 
-use {Collections, Context};
+use {Arrangements, Experiment, Collections};
 use ::types::create_date;
 
 // -- $ID$
@@ -101,37 +101,36 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
 }
 
 pub fn query_arranged<G: Scope<Timestamp=usize>>(
-    context: &mut Context<G>,
+    scope: &mut G,
+    probe: &mut ProbeHandle<usize>,
+    experiment: &mut Experiment,
+    arrangements: &mut Arrangements,
 )
+where
+    G::Timestamp: Lattice+TotalOrder+Ord
 {
-    let customer = context.customers();
-    let order = context.orders();
-    let part = context.parts();
-    let supplier = context.suppliers();
-    let nation = context.nations();
-    let region = context.regions();
+    let arrangements = arrangements.in_scope(scope, experiment);
 
-    context
-        .collections
-        .lineitems()
+    experiment
+        .lineitem(scope)
         .explode(|l| Some(((l.part_key, (l.order_key, l.supp_key)), ((l.extended_price * (100 - l.discount)) as isize / 100))))
-        .join_core(&part, |_pk,&(ok,sk),p| {
+        .join_core(&arrangements.part, |_pk,&(ok,sk),p| {
             if p.typ.as_str() == "ECONOMY ANODIZED STEEL" { Some((ok,sk)) } else { None }
         })
-        .join_core(&order, |_ok,&sk,o| {
+        .join_core(&arrangements.order, |_ok,&sk,o| {
             if create_date(1995,1,1) <= o.order_date && o.order_date <= create_date(1996, 12, 31) {
                 Some((o.cust_key, (sk,o.order_date >> 16)))
             }
             else { None }
         })
-        .join_core(&customer, |_ck,&(sk,yr),c| Some((c.nation_key, (sk,yr))))
-        .join_core(&nation, |_nk,&(sk,yr),n| Some((n.region_key, (sk,yr))))
-        .join_core(&region, |_rk,&(sk,yr),r| {
+        .join_core(&arrangements.customer, |_ck,&(sk,yr),c| Some((c.nation_key, (sk,yr))))
+        .join_core(&arrangements.nation, |_nk,&(sk,yr),n| Some((n.region_key, (sk,yr))))
+        .join_core(&arrangements.region, |_rk,&(sk,yr),r| {
             if starts_with(&r.name, b"AMERICA") { Some((sk,yr,true)) } else { Some((sk,yr,false)) }
         })
         .explode(|(sk,yr,is_name)| Some(((sk,yr), DiffPair::new(if is_name { 1 } else { 0 }, 1))))
-        .join_core(&supplier, |_sk,&yr,s| Some((s.nation_key, yr)))
-        .join_core(&nation, |_nk,&yr,n| Some((n.name,yr)))
+        .join_core(&arrangements.supplier, |_sk,&yr,s| Some((s.nation_key, yr)))
+        .join_core(&arrangements.nation, |_nk,&yr,n| Some((n.name,yr)))
         .count_total()
-        .probe_with(&mut context.probe);
+        .probe_with(probe);
 }

--- a/tpchlike/src/queries/query11.rs
+++ b/tpchlike/src/queries/query11.rs
@@ -5,7 +5,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 
-use ::Collections;
+use {Arrangements, Experiment, Collections};
 
 // -- $ID$
 // -- TPC-H/TPC-R Important Stock Identification Query (Q11)
@@ -67,6 +67,34 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
         .explode(|x| Some(((x.supp_key, x.part_key), (x.supplycost as isize) * (x.availqty as isize))))
         .semijoin(&suppliers)
         .map(|(_, part_key)| ((), part_key))
+        .reduce(|_part_key, s, t| {
+            let threshold: isize = s.iter().map(|x| x.1 as isize).sum::<isize>() / 10000;
+            t.extend(s.iter().filter(|x| x.1 > threshold).map(|&(&a,b)| (a, b)));
+        })
+        .map(|(_, part_key)| part_key)
+        .count_total()
+        .probe_with(probe);
+}
+
+pub fn query_arranged<G: Scope<Timestamp=usize>>(
+    scope: &mut G,
+    probe: &mut ProbeHandle<usize>,
+    experiment: &mut Experiment,
+    arrangements: &mut Arrangements,
+)
+where
+    G::Timestamp: Lattice+TotalOrder+Ord
+{
+    let arrangements = arrangements.in_scope(scope, experiment);
+
+    arrangements
+        .partsupp
+        .as_collection(|_,ps| ((ps.supp_key, ps.part_key), (ps.supplycost as isize) * (ps.availqty as isize)))
+        .explode(|((sk,pk),prod)| Some(((sk,pk),prod)))
+        .join_core(&arrangements.supplier, |_sk,&pk,s| Some((s.nation_key, pk)))
+        .join_core(&arrangements.nation, |_nk,&pk,n|
+            if starts_with(&n.name, b"GERMANY") { Some(((), pk)) } else { None }
+        )
         .reduce(|_part_key, s, t| {
             let threshold: isize = s.iter().map(|x| x.1 as isize).sum::<isize>() / 10000;
             t.extend(s.iter().filter(|x| x.1 > threshold).map(|&(&a,b)| (a, b)));

--- a/tpchlike/src/queries/query11.rs
+++ b/tpchlike/src/queries/query11.rs
@@ -81,15 +81,22 @@ pub fn query_arranged<G: Scope<Timestamp=usize>>(
     probe: &mut ProbeHandle<usize>,
     experiment: &mut Experiment,
     arrangements: &mut Arrangements,
+    round: usize,
 )
 where
     G::Timestamp: Lattice+TotalOrder+Ord
 {
+    use timely::dataflow::operators::Map;
+    use differential_dataflow::AsCollection;
+
     let arrangements = arrangements.in_scope(scope, experiment);
 
     arrangements
         .partsupp
         .as_collection(|_,ps| ((ps.supp_key, ps.part_key), (ps.supplycost as isize) * (ps.availqty as isize)))
+        .inner
+        .map(move |(d,t,r)| (d, ::std::cmp::max(t,round),r))
+        .as_collection()
         .explode(|((sk,pk),prod)| Some(((sk,pk),prod)))
         .join_core(&arrangements.supplier, |_sk,&pk,s| Some((s.nation_key, pk)))
         .join_core(&arrangements.nation, |_nk,&pk,n|

--- a/tpchlike/src/queries/query12.rs
+++ b/tpchlike/src/queries/query12.rs
@@ -7,7 +7,7 @@ use differential_dataflow::operators::arrange::{ArrangeBySelf, ArrangeByKey};
 use differential_dataflow::difference::DiffPair;
 use differential_dataflow::lattice::Lattice;
 
-use {Collections, Context};
+use {Arrangements, Experiment, Collections};
 use ::types::create_date;
 
 // -- $ID$
@@ -89,14 +89,18 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
 }
 
 pub fn query_arranged<G: Scope<Timestamp=usize>>(
-    context: &mut Context<G>,
+    scope: &mut G,
+    probe: &mut ProbeHandle<usize>,
+    experiment: &mut Experiment,
+    arrangements: &mut Arrangements,
 )
+where
+    G::Timestamp: Lattice+TotalOrder+Ord
 {
-    let order = context.orders();
+    let arrangements = arrangements.in_scope(scope, experiment);
 
-    context
-        .collections
-        .lineitems()
+    experiment
+        .lineitem(scope)
         .flat_map(|l|
             if (starts_with(&l.ship_mode, b"MAIL") || starts_with(&l.ship_mode, b"SHIP")) &&
                 l.commit_date < l.receipt_date && l.ship_date < l.commit_date &&
@@ -105,10 +109,10 @@ pub fn query_arranged<G: Scope<Timestamp=usize>>(
             }
             else { None }
         )
-        .join_core(&order, |_ok,&sm,o| {
+        .join_core(&arrangements.order, |_ok,&sm,o| {
             Some((sm, starts_with(&o.order_priority, b"1-URGENT") || starts_with(&o.order_priority, b"2-HIGH")))
         })
         .explode(|(sm,priority)| Some((sm, if priority { DiffPair::new(1, 0) } else { DiffPair::new(1, 0) })))
         .count_total()
-        .probe_with(&mut context.probe);
+        .probe_with(probe);
 }

--- a/tpchlike/src/queries/query14.rs
+++ b/tpchlike/src/queries/query14.rs
@@ -7,7 +7,7 @@ use differential_dataflow::operators::arrange::ArrangeBySelf;
 use differential_dataflow::difference::DiffPair;
 use differential_dataflow::lattice::Lattice;
 
-use {Collections, Context};
+use {Arrangements, Experiment, Collections};
 use ::types::create_date;
 
 // -- $ID$
@@ -60,14 +60,18 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
 }
 
 pub fn query_arranged<G: Scope<Timestamp=usize>>(
-    context: &mut Context<G>,
+    scope: &mut G,
+    probe: &mut ProbeHandle<usize>,
+    experiment: &mut Experiment,
+    arrangements: &mut Arrangements,
 )
+where
+    G::Timestamp: Lattice+TotalOrder+Ord
 {
-    let part = context.parts();
+    let arrangements = arrangements.in_scope(scope, experiment);
 
-    context
-        .collections
-        .lineitems()
+    experiment
+        .lineitem(scope)
         .explode(|l|
             if create_date(1995,9,1) <= l.ship_date && l.ship_date < create_date(1995,10,1) {
                 Some((l.part_key, (l.extended_price * (100 - l.discount) / 100) as isize ))
@@ -75,8 +79,8 @@ pub fn query_arranged<G: Scope<Timestamp=usize>>(
             else { None }
         )
         .arrange_by_self()
-        .join_core(&part, |_pk,&(),p| Some(DiffPair::new(1, if starts_with(&p.typ.as_bytes(), b"PROMO") { 1 } else { 0 })))
+        .join_core(&arrangements.part, |_pk,&(),p| Some(DiffPair::new(1, if starts_with(&p.typ.as_bytes(), b"PROMO") { 1 } else { 0 })))
         .explode(|dp| Some(((),dp)))
         .count_total()
-        .probe_with(&mut context.probe);
+        .probe_with(probe);
 }

--- a/tpchlike/src/queries/query16.rs
+++ b/tpchlike/src/queries/query16.rs
@@ -7,7 +7,7 @@ use differential_dataflow::lattice::Lattice;
 
 use regex::Regex;
 
-use {Collections, Context};
+use {Arrangements, Experiment, Collections};
 
 // -- $ID$
 // -- TPC-H/TPC-R Parts/Supplier Relationship Query (Q16)
@@ -83,24 +83,27 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
 }
 
 pub fn query_arranged<G: Scope<Timestamp=usize>>(
-    context: &mut Context<G>,
+    scope: &mut G,
+    probe: &mut ProbeHandle<usize>,
+    experiment: &mut Experiment,
+    arrangements: &mut Arrangements,
 )
+where
+    G::Timestamp: Lattice+TotalOrder+Ord
 {
-    let part = context.parts();
+    let arrangements = arrangements.in_scope(scope, experiment);
 
     let regex = Regex::new("Customer.*Complaints").expect("Regex construction failed");
 
     let suppliers =
-    context
-        .collections
-        .suppliers()
-        .flat_map(move |s| if regex.is_match(&s.comment) { Some(s.supp_key) } else { None } );
+    arrangements
+        .supplier
+        .flat_map_ref(move |_,s| if regex.is_match(&s.comment) { Some(s.supp_key) } else { None } );
 
-    context
-        .collections
-        .partsupps()
-        .map(|ps| (ps.part_key, ps.supp_key))
-        .join_core(&part, |_pk,&sk,p| {
+    arrangements
+        .partsupp
+        .as_collection(|&psk,_| psk)
+        .join_core(&arrangements.part, |_pk,&sk,p| {
             if !starts_with(&p.brand, b"Brand#45") && !starts_with(&p.typ.as_bytes(), b"MEDIUM POLISHED") && [49, 14, 23, 45, 19, 3, 36, 9].contains(&p.size) {
                 Some((sk, (p.brand, p.typ, p.size)))
             }
@@ -110,5 +113,5 @@ pub fn query_arranged<G: Scope<Timestamp=usize>>(
         .antijoin(&suppliers)
         .map(|(_sk, stuff)| stuff)
         .count_total()
-        .probe_with(&mut context.probe);
+        .probe_with(probe);
 }

--- a/tpchlike/src/queries/query16.rs
+++ b/tpchlike/src/queries/query16.rs
@@ -87,10 +87,14 @@ pub fn query_arranged<G: Scope<Timestamp=usize>>(
     probe: &mut ProbeHandle<usize>,
     experiment: &mut Experiment,
     arrangements: &mut Arrangements,
+    round: usize,
 )
 where
     G::Timestamp: Lattice+TotalOrder+Ord
 {
+    use timely::dataflow::operators::Map;
+    use differential_dataflow::AsCollection;
+
     let arrangements = arrangements.in_scope(scope, experiment);
 
     let regex = Regex::new("Customer.*Complaints").expect("Regex construction failed");
@@ -98,11 +102,17 @@ where
     let suppliers =
     arrangements
         .supplier
-        .flat_map_ref(move |_,s| if regex.is_match(&s.comment) { Some(s.supp_key) } else { None } );
+        .flat_map_ref(move |_,s| if regex.is_match(&s.comment) { Some(s.supp_key) } else { None } )
+        .inner
+        .map(move |(d,t,r)| (d, ::std::cmp::max(t,round),r))
+        .as_collection();
 
     arrangements
         .partsupp
         .as_collection(|&psk,_| psk)
+        .inner
+        .map(move |(d,t,r)| (d, ::std::cmp::max(t,round),r))
+        .as_collection()
         .join_core(&arrangements.part, |_pk,&sk,p| {
             if !starts_with(&p.brand, b"Brand#45") && !starts_with(&p.typ.as_bytes(), b"MEDIUM POLISHED") && [49, 14, 23, 45, 19, 3, 36, 9].contains(&p.size) {
                 Some((sk, (p.brand, p.typ, p.size)))

--- a/tpchlike/src/queries/query18.rs
+++ b/tpchlike/src/queries/query18.rs
@@ -5,7 +5,7 @@ use timely::dataflow::operators::probe::Handle as ProbeHandle;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 
-use {Collections, Context};
+use {Arrangements, Experiment, Collections};
 
 // -- $ID$
 // -- TPC-H/TPC-R Large Volume Customer Query (Q18)
@@ -66,20 +66,23 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
 }
 
 pub fn query_arranged<G: Scope<Timestamp=usize>>(
-    context: &mut Context<G>,
+    scope: &mut G,
+    probe: &mut ProbeHandle<usize>,
+    experiment: &mut Experiment,
+    arrangements: &mut Arrangements,
 )
+where
+    G::Timestamp: Lattice+TotalOrder+Ord
 {
-    let order = context.orders();
-    let customer = context.customers();
+    let arrangements = arrangements.in_scope(scope, experiment);
 
-    context
-        .collections
-        .lineitems()
+    experiment
+        .lineitem(scope)
         .explode(|l| Some((l.order_key, l.quantity as isize)))
         .count_total()
         .filter(|&(_key, cnt)| cnt > 300)
-        .join_core(&order, |_ok,&cnt,o| Some((o.cust_key, (o.order_date, o.total_price, cnt))))
-        .join_core(&customer, |&ck,&(od,tp,cnt),c| Some((ck,c.name,od,tp,cnt)))
+        .join_core(&arrangements.order, |_ok,&cnt,o| Some((o.cust_key, (o.order_date, o.total_price, cnt))))
+        .join_core(&arrangements.customer, |&ck,&(od,tp,cnt),c| Some((ck,c.name,od,tp,cnt)))
         .count_total()
-        .probe_with(&mut context.probe);
+        .probe_with(probe);
 }

--- a/tpchlike/src/queries/query19.rs
+++ b/tpchlike/src/queries/query19.rs
@@ -6,7 +6,7 @@ use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::ArrangeBySelf;
 use differential_dataflow::lattice::Lattice;
 
-use {Collections, Context};
+use {Arrangements, Experiment, Collections};
 
 // -- $ID$
 // -- TPC-H/TPC-R Discounted Revenue Query (Q19)
@@ -92,21 +92,25 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
 }
 
 pub fn query_arranged<G: Scope<Timestamp=usize>>(
-    context: &mut Context<G>,
+    scope: &mut G,
+    probe: &mut ProbeHandle<usize>,
+    experiment: &mut Experiment,
+    arrangements: &mut Arrangements,
 )
+where
+    G::Timestamp: Lattice+TotalOrder+Ord
 {
-    let part = context.parts();
+    let arrangements = arrangements.in_scope(scope, experiment);
 
-    context
-        .collections
-        .lineitems()
+    experiment
+        .lineitem(scope)
         .explode(|x|
             if (starts_with(&x.ship_mode, b"AIR") || starts_with(&x.ship_mode, b"AIR REG")) && starts_with(&x.ship_instruct, b"DELIVER IN PERSON") {
                 Some(((x.part_key, x.quantity), (x.extended_price * (100 - x.discount) / 100) as isize))
             }
             else { None }
         )
-        .join_core(&part, |_pk,&qu,p| {
+        .join_core(&arrangements.part, |_pk,&qu,p| {
             if qu >= 1  && qu <= 11 && (starts_with(&p.brand, b"Brand#12") && 1 <= p.size && p.size <= 5  && (starts_with(&p.container, b"SM CASE") || starts_with(&p.container, b"SM BOX") || starts_with(&p.container, b"SM PACK") || starts_with(&p.container, b"MED PKG")))
             && qu >= 10 && qu <= 20 && (starts_with(&p.brand, b"Brand#23") && 1 <= p.size && p.size <= 10 && (starts_with(&p.container, b"MED BAG") || starts_with(&p.container, b"MED BOX") || starts_with(&p.container, b"MED PKG") || starts_with(&p.container, b"MED PACK")))
             && qu >= 20 && qu <= 30 && (starts_with(&p.brand, b"Brand#12") && 1 <= p.size && p.size <= 15 && (starts_with(&p.container, b"LG CASE") || starts_with(&p.container, b"LG BOX") || starts_with(&p.container, b"LG PACK") || starts_with(&p.container, b"LG PKG")))
@@ -119,5 +123,5 @@ pub fn query_arranged<G: Scope<Timestamp=usize>>(
 
         })
         .count_total()
-        .probe_with(&mut context.probe);
+        .probe_with(probe);
 }

--- a/tpchlike/src/queries/query20.rs
+++ b/tpchlike/src/queries/query20.rs
@@ -7,7 +7,7 @@ use differential_dataflow::operators::reduce::ReduceCore;
 use differential_dataflow::trace::implementations::ord::OrdValSpine as DefaultValTrace;
 use differential_dataflow::lattice::Lattice;
 
-use ::Collections;
+use {Arrangements, Experiment, Collections};
 use ::types::create_date;
 
 // -- $ID$
@@ -102,5 +102,40 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
         .semijoin(&suppliers)
         .map(|(_, (name, addr, nation))| (nation, (name, addr)))
         .join(&nations)
+        .probe_with(probe);
+}
+
+pub fn query_arranged<G: Scope<Timestamp=usize>>(
+    scope: &mut G,
+    probe: &mut ProbeHandle<usize>,
+    experiment: &mut Experiment,
+    arrangements: &mut Arrangements,
+)
+where
+    G::Timestamp: Lattice+TotalOrder+Ord
+{
+    let arrangements = arrangements.in_scope(scope, experiment);
+
+    experiment
+        .lineitem(scope)
+        .flat_map(|l|
+            if l.ship_date >= create_date(1994, 1, 1) && l.ship_date < create_date(1995, 1, 1) {
+                Some((l.part_key, (l.supp_key, l.quantity)))
+            }
+            else { None }
+        )
+        .explode(|(pk,(sk,qu))| Some(((pk,sk), qu as isize)))
+        .join_core(&arrangements.part, |&pk,&sk,p|
+            if p.name.as_bytes() == b"forest" { Some((pk,sk)) } else { None }
+        )
+        .count_total()
+        .join_core(&arrangements.partsupp, |&(_pk,sk),tot,ps| {
+            if (ps.availqty as isize) > tot / 2 { Some((sk, ())) } else { None }
+        })
+        .distinct_total()
+        .join_core(&arrangements.supplier, |_sk,&(),s| Some((s.nation_key, (s.name, s.address))))
+        .join_core(&arrangements.nation, |_nk,&(nm,ad),n|
+            if starts_with(&n.name, b"CANADA") { Some((nm,ad)) } else { None }
+        )
         .probe_with(probe);
 }

--- a/tpchlike/src/queries/query20.rs
+++ b/tpchlike/src/queries/query20.rs
@@ -118,13 +118,12 @@ where
 
     experiment
         .lineitem(scope)
-        .flat_map(|l|
+        .explode(|l|
             if l.ship_date >= create_date(1994, 1, 1) && l.ship_date < create_date(1995, 1, 1) {
-                Some((l.part_key, (l.supp_key, l.quantity)))
+                Some(((l.part_key, l.supp_key), l.quantity as isize))
             }
             else { None }
         )
-        .explode(|(pk,(sk,qu))| Some(((pk,sk), qu as isize)))
         .join_core(&arrangements.part, |&pk,&sk,p|
             if p.name.as_bytes() == b"forest" { Some((pk,sk)) } else { None }
         )

--- a/tpchlike/src/queries/query21.rs
+++ b/tpchlike/src/queries/query21.rs
@@ -6,7 +6,7 @@ use differential_dataflow::operators::*;
 use differential_dataflow::operators::ThresholdTotal;
 use differential_dataflow::lattice::Lattice;
 
-use ::Collections;
+use {Arrangements, Experiment, Collections};
 
 // -- $ID$
 // -- TPC-H/TPC-R Suppliers Who Kept Orders Waiting Query (Q21)
@@ -99,6 +99,41 @@ where G::Timestamp: Lattice+TotalOrder+Ord {
         .semijoin(&latesupps)
         .map(|(_, (name, nation))| (nation, name))
         .semijoin(&collections.nations().filter(|n| starts_with(&n.name, b"SAUDI ARABIA")).map(|n| n.nation_key))
+        .count_total()
+        .probe_with(probe);
+}
+pub fn query_arranged<G: Scope<Timestamp=usize>>(
+    scope: &mut G,
+    probe: &mut ProbeHandle<usize>,
+    experiment: &mut Experiment,
+    arrangements: &mut Arrangements,
+)
+where
+    G::Timestamp: Lattice+TotalOrder+Ord
+{
+    let arrangements = arrangements.in_scope(scope, experiment);
+
+    experiment
+        .lineitem(scope)
+        .map(|l| (l.order_key, (l.receipt_date > l.commit_date, l.supp_key)))
+        .reduce(|_ok,input,output| {
+
+            let late_supp = (input[0].0).1;
+            let only_late = input[1..].iter().all(|(x,_)| !x.0);
+            let other_supp = input[1..].iter().any(|(x,_)| x.1 != late_supp);
+
+            if only_late && other_supp {
+                output.push((late_supp, 1));
+            }
+
+        })
+        .join_core(&arrangements.order, |_ok,&sk,o| {
+            if starts_with(&o.order_status, b"F") { Some((sk, ())) } else { None }
+        })
+        .join_core(&arrangements.supplier, |_sk,&(),s| Some((s.nation_key, s.name)))
+        .join_core(&arrangements.nation, |_nk,&nm,n|
+            if starts_with(&n.name, b"SAUDI ARABIA") { Some(nm) } else { None }
+        )
         .count_total()
         .probe_with(probe);
 }


### PR DESCRIPTION
This PR parallels timely dataflow's `Data` and `ExchangeData` traits, with the latter adding the ability to move between workers to the former.

This change allows us to use types like `Rc<T>` in collections, and perhaps eventually within arrangements (we will need specialized `arrange` methods that do not need to exchange their records).

The expected fall-out from this PR is that folks who wrote libraries that used the `Data` trait will likely now need to modify this to be `ExchangeData`. We could have left `Data` as it was and introduced `LocalData`, but then we wouldn't parallel what timely does and would likely confuse people.

cc @comnik @ryzhyk