### PR TITLE
group to reduce

### DIFF
--- a/mdbook/src/SUMMARY.md
+++ b/mdbook/src/SUMMARY.md
@@ -18,7 +18,7 @@
     - [Concat](./chapter_2/chapter_2_3.md)
     - [Consolidate](./chapter_2/chapter_2_4.md)
     - [Join](./chapter_2/chapter_2_5.md)
-    - [Group](./chapter_2/chapter_2_6.md)
+    - [Reduce](./chapter_2/chapter_2_6.md)
     - [Iterate](./chapter_2/chapter_2_7.md)
     - [Arrange](./chapter_2/chapter_2_8.md)
 

--- a/mdbook/src/chapter_1/chapter_1_2.md
+++ b/mdbook/src/chapter_1/chapter_1_2.md
@@ -74,14 +74,14 @@ Alternately, we can use the same relation to find people living at a given addre
 
 As the underlying `ordered_by` and `person_address` collections change, the derived `deliver_to` and `can_sign_for` collections will change as well, maintaining correct and consistent results corresponding to the inputs.
 
-## Group
+## Reduce
 
-The `group` operator applies to one input collection whose records have the form `(key, val)`, and it allows you produce output as an arbitrary function of the key and the list of values. The following example starts from the list of all orders, and produces any duplicate packages in the ordering system (those with count two or greater).
+The `reduce` operator applies to one input collection whose records have the form `(key, val)`, and it allows you produce output as an arbitrary function of the key and the list of values. The following example starts from the list of all orders, and produces any duplicate packages in the ordering system (those with count two or greater).
 
 ```rust,ignore
     ordered_by
         .map(|(package, person)| (person, package))
-        .group(|person, packages, duplicates| {
+        .reduce(|person, packages, duplicates| {
             for (package, count) in packages.iter() {
                 if count > 1 {
                     duplicates.push((package.clone(), count));

--- a/mdbook/src/chapter_2/chapter_2_6.md
+++ b/mdbook/src/chapter_2/chapter_2_6.md
@@ -21,7 +21,7 @@ For example, to produce for each manager their managee with the lowest identifie
         });
 ```
 
-The group operator has some tricky Rust details about how it is expressed. The type of closure you must provide is technically
+The reduce operator has some tricky Rust details about how it is expressed. The type of closure you must provide is technically
 
 ```rust,no_run
         Fn(&Key, &[(&Val, Cnt)], &mut Vec<(Val2, Cnt2)>)

--- a/mdbook/src/chapter_2/chapter_2_8.md
+++ b/mdbook/src/chapter_2/chapter_2_8.md
@@ -2,4 +2,4 @@
 
 The `arrange` operator is a massively important operator that we will discuss in more detail in the chapter on Arrangements. Arrange controls and coordinates how data are stored, indexed, and maintained, and forms the basis of efficient data sharing.
 
-Operators like `consolidate`, `join`, and `group` all use `arrange` internally, and there can be substantial benefit to exposing this use. We will discuss this further.
+Operators like `consolidate`, `join`, and `reduce` all use `arrange` internally, and there can be substantial benefit to exposing this use. We will discuss this further.

--- a/mdbook/src/chapter_4/chapter_4_1.md
+++ b/mdbook/src/chapter_4/chapter_4_1.md
@@ -20,7 +20,7 @@ Let's write this computation starting from a collection `edges`, using different
             inner.join(&edges)
                  .map(|(_src,lbl,dst)| (dst,lbl))
                  .concat(&labels)
-                 .group(|_dst, lbls, out| {
+                 .reduce(|_dst, lbls, out| {
                      let min_lbl =
                      lbls.iter()
                          .map(|x| *x.0)


### PR DESCRIPTION
Some minor adjustments for the mdbook after the name change from `group` to `reduce`