### PR TITLE
Trace batch tidy

### DIFF
--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -120,7 +120,6 @@ where
             .map_batches(|batch| {
                 new_queue.push_back(TraceReplayInstruction::Batch(batch.clone(), Some(Default::default())));
                 upper = Some(batch.upper().to_vec());
-                // new_queue.push_back((vec![Default::default()], batch.clone(), Some(Default::default())));
             });
 
         if let Some(upper) = upper {

--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -47,6 +47,7 @@ where
 
     type Batch = Tr::Batch;
     type Cursor = Tr::Cursor;
+
     fn advance_by(&mut self, frontier: &[Tr::Time]) {
         self.trace.borrow_mut().adjust_advance_frontier(&self.advance[..], frontier);
         self.advance.clear();
@@ -280,9 +281,6 @@ where
     {
         let trace = self.clone();
 
-        // Capabilities shared with a shutdown button.
-        // let shutdown_button = ShutdownButton::new(capabilities.clone());
-
         let mut shutdown_button = None;
 
         let stream = {
@@ -309,29 +307,16 @@ where
                         for instruction in borrow.drain(..) {
                             match instruction {
                                 TraceReplayInstruction::Frontier(frontier) => {
-                                    // println!("DOWNGRADE: {:?}", frontier);
                                     capabilities.downgrade(&frontier[..]);
                                 },
                                 TraceReplayInstruction::Batch(batch, hint) => {
                                     if let Some(time) = hint {
-                                        // println!("TIME: {:?}", time);
                                         let delayed = capabilities.delayed(&time);
                                         output.session(&delayed).give(batch);
                                     }
                                 }
                             }
                         }
-                        // for (frontier, batch, hint) in borrow.drain(..) {
-
-                        //     println!("REPLAY\t{:?}, {:?}, {:?}", frontier, batch.description(), hint);
-
-                        //     if let Some(time) = hint {
-                        //         let delayed = capabilities.delayed(&time);
-                        //         output.session(&delayed).give(batch);
-                        //     }
-
-                        //     capabilities.downgrade(&frontier[..]);
-                        // }
                     }
                 }
             })

--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -1,0 +1,395 @@
+//! Shared read access to a trace.
+
+use std::rc::{Rc, Weak};
+use std::cell::RefCell;
+use std::default::Default;
+use std::collections::VecDeque;
+
+use timely::dataflow::Scope;
+use timely::dataflow::operators::generic::source;
+use timely::progress::Timestamp;
+use timely::dataflow::operators::CapabilitySet;
+
+use lattice::Lattice;
+use trace::{Trace, TraceReader, Batch, BatchReader, Cursor};
+
+use trace::wrappers::rc::TraceBox;
+
+use timely::scheduling::Activator;
+
+use super::{TraceWriter, TraceAgentQueueWriter, TraceAgentQueueReader, Arranged};
+use super::TraceReplayInstruction;
+
+/// A `TraceReader` wrapper which can be imported into other dataflows.
+///
+/// The `TraceAgent` is the default trace type produced by `arranged`, and it can be extracted
+/// from the dataflow in which it was defined, and imported into other dataflows.
+pub struct TraceAgent<Tr>
+where
+    Tr: TraceReader,
+    Tr::Time: Lattice+Ord+Clone+'static,
+{
+    trace: Rc<RefCell<TraceBox<Tr>>>,
+    queues: Weak<RefCell<Vec<TraceAgentQueueWriter<Tr>>>>,
+    advance: Vec<Tr::Time>,
+    through: Vec<Tr::Time>,
+}
+
+impl<Tr> TraceReader for TraceAgent<Tr>
+where
+    Tr: TraceReader,
+    Tr::Time: Lattice+Ord+Clone+'static,
+{
+    type Key = Tr::Key;
+    type Val = Tr::Val;
+    type Time = Tr::Time;
+    type R = Tr::R;
+
+    type Batch = Tr::Batch;
+    type Cursor = Tr::Cursor;
+    fn advance_by(&mut self, frontier: &[Tr::Time]) {
+        self.trace.borrow_mut().adjust_advance_frontier(&self.advance[..], frontier);
+        self.advance.clear();
+        self.advance.extend(frontier.iter().cloned());
+    }
+    fn advance_frontier(&mut self) -> &[Tr::Time] {
+        &self.advance[..]
+    }
+    fn distinguish_since(&mut self, frontier: &[Tr::Time]) {
+        self.trace.borrow_mut().adjust_through_frontier(&self.through[..], frontier);
+        self.through.clear();
+        self.through.extend(frontier.iter().cloned());
+    }
+    fn distinguish_frontier(&mut self) -> &[Tr::Time] {
+        &self.through[..]
+    }
+    fn cursor_through(&mut self, frontier: &[Tr::Time]) -> Option<(Tr::Cursor, <Tr::Cursor as Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>>::Storage)> {
+        self.trace.borrow_mut().trace.cursor_through(frontier)
+    }
+    fn map_batches<F: FnMut(&Self::Batch)>(&mut self, f: F) { self.trace.borrow_mut().trace.map_batches(f) }
+}
+
+impl<Tr> TraceAgent<Tr>
+where
+    Tr: TraceReader,
+    Tr::Time: Timestamp+Lattice,
+{
+    /// Creates a new agent from a trace reader.
+    pub fn new(trace: Tr) -> (Self, TraceWriter<Tr>)
+    where
+        Tr: Trace,
+        Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
+    {
+        let trace = Rc::new(RefCell::new(TraceBox::new(trace)));
+        let queues = Rc::new(RefCell::new(Vec::new()));
+
+        let reader = TraceAgent {
+            trace: trace.clone(),
+            queues: Rc::downgrade(&queues),
+            advance: trace.borrow().advance_frontiers.frontier().to_vec(),
+            through: trace.borrow().through_frontiers.frontier().to_vec(),
+        };
+
+        let writer = TraceWriter::new(
+            vec![Default::default()],
+            Rc::downgrade(&trace),
+            queues,
+        );
+
+        (reader, writer)
+    }
+
+    /// Attaches a new shared queue to the trace.
+    ///
+    /// The queue is first populated with existing batches from the trace,
+    /// The queue will be immediately populated with existing historical batches from the trace, and until the reference
+    /// is dropped the queue will receive new batches as produced by the source `arrange` operator.
+    pub fn new_listener(&mut self, activator: Activator) -> TraceAgentQueueReader<Tr>
+    where
+        Tr::Time: Default
+    {
+        // create a new queue for progress and batch information.
+        let mut new_queue = VecDeque::new();
+
+        // add the existing batches from the trace
+        let mut upper = None;
+        self.trace
+            .borrow_mut()
+            .trace
+            .map_batches(|batch| {
+                new_queue.push_back(TraceReplayInstruction::Batch(batch.clone(), Some(Default::default())));
+                upper = Some(batch.upper().to_vec());
+                // new_queue.push_back((vec![Default::default()], batch.clone(), Some(Default::default())));
+            });
+
+        if let Some(upper) = upper {
+            new_queue.push_back(TraceReplayInstruction::Frontier(upper));
+        }
+
+        let reference = Rc::new((activator, RefCell::new(new_queue)));
+
+        // wraps the queue in a ref-counted ref cell and enqueue/return it.
+        if let Some(queue) = self.queues.upgrade() {
+            queue.borrow_mut().push(Rc::downgrade(&reference));
+        }
+        reference.0.activate();
+        reference
+    }
+}
+
+impl<Tr> TraceAgent<Tr>
+where
+    Tr: TraceReader+'static,
+    Tr::Time: Lattice+Ord+Clone+'static,
+{
+    /// Copies an existing collection into the supplied scope.
+    ///
+    /// This method creates an `Arranged` collection that should appear indistinguishable from applying `arrange`
+    /// directly to the source collection brought into the local scope. The only caveat is that the initial state
+    /// of the collection is its current state, and updates occur from this point forward. The historical changes
+    /// the collection experienced in the past are accumulated, and the distinctions from the initial collection
+    /// are no longer evident.
+    ///
+    /// The current behavior is that the introduced collection accumulates updates to some times less or equal
+    /// to `self.advance_frontier()`. There is *not* currently a guarantee that the updates are accumulated *to*
+    /// the frontier, and the resulting collection history may be weirdly partial until this point. In particular,
+    /// the historical collection may move through configurations that did not actually occur, even if eventually
+    /// arriving at the correct collection. This is probably a bug; although we get to the right place in the end,
+    /// the intermediate computation could do something that the original computation did not, like diverge.
+    ///
+    /// I would expect the semantics to improve to "updates are advanced to `self.advance_frontier()`", which
+    /// means the computation will run as if starting from exactly this frontier. It is not currently clear whose
+    /// responsibility this should be (the trace/batch should only reveal these times, or an operator should know
+    /// to advance times before using them).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate timely;
+    /// extern crate differential_dataflow;
+    ///
+    /// use timely::Configuration;
+    /// use differential_dataflow::input::Input;
+    /// use differential_dataflow::operators::arrange::ArrangeBySelf;
+    /// use differential_dataflow::operators::reduce::Reduce;
+    /// use differential_dataflow::trace::Trace;
+    /// use differential_dataflow::trace::implementations::ord::OrdValSpine;
+    /// use differential_dataflow::hashable::OrdWrapper;
+    ///
+    /// fn main() {
+    ///     ::timely::execute(Configuration::Thread, |worker| {
+    ///
+    ///         // create a first dataflow
+    ///         let mut trace = worker.dataflow::<u32,_,_>(|scope| {
+    ///             // create input handle and collection.
+    ///             scope.new_collection_from(0 .. 10).1
+    ///                  .arrange_by_self()
+    ///                  .trace
+    ///         });
+    ///
+    ///         // do some work.
+    ///         worker.step();
+    ///         worker.step();
+    ///
+    ///         // create a second dataflow
+    ///         worker.dataflow(move |scope| {
+    ///             trace.import(scope)
+    ///                  .reduce(move |_key, src, dst| dst.push((*src[0].0, 1)));
+    ///         });
+    ///
+    ///     }).unwrap();
+    /// }
+    /// ```
+    pub fn import<G>(&mut self, scope: &G) -> Arranged<G, TraceAgent<Tr>>
+    where
+        G: Scope<Timestamp=Tr::Time>,
+        Tr::Time: Timestamp,
+    {
+        self.import_named(scope, "ArrangedSource")
+    }
+
+    /// Same as `import`, but allows to name the source.
+    pub fn import_named<G>(&mut self, scope: &G, name: &str) -> Arranged<G, TraceAgent<Tr>>
+    where
+        G: Scope<Timestamp=Tr::Time>,
+        Tr::Time: Timestamp,
+    {
+        // Drop ShutdownButton and return only the arrangement.
+        self.import_core(scope, name).0
+    }
+    /// Imports an arrangement into the supplied scope.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate timely;
+    /// extern crate differential_dataflow;
+    ///
+    /// use timely::Configuration;
+    /// use timely::dataflow::ProbeHandle;
+    /// use timely::dataflow::operators::Probe;
+    /// use differential_dataflow::input::InputSession;
+    /// use differential_dataflow::operators::arrange::ArrangeBySelf;
+    /// use differential_dataflow::operators::reduce::Reduce;
+    /// use differential_dataflow::trace::Trace;
+    /// use differential_dataflow::trace::implementations::ord::OrdValSpine;
+    /// use differential_dataflow::hashable::OrdWrapper;
+    ///
+    /// fn main() {
+    ///     ::timely::execute(Configuration::Thread, |worker| {
+    ///
+    ///         let mut input = InputSession::<_,(),isize>::new();
+    ///         let mut probe = ProbeHandle::new();
+    ///
+    ///         // create a first dataflow
+    ///         let mut trace = worker.dataflow::<u32,_,_>(|scope| {
+    ///             // create input handle and collection.
+    ///             input.to_collection(scope)
+    ///                  .arrange_by_self()
+    ///                  .trace
+    ///         });
+    ///
+    ///         // do some work.
+    ///         worker.step();
+    ///         worker.step();
+    ///
+    ///         // create a second dataflow
+    ///         let mut shutdown = worker.dataflow(|scope| {
+    ///             let (arrange, button) = trace.import_core(scope, "Import");
+    ///             arrange.stream.probe_with(&mut probe);
+    ///             button
+    ///         });
+    ///
+    ///         worker.step();
+    ///         worker.step();
+    ///         assert!(!probe.done());
+    ///
+    ///         shutdown.press();
+    ///
+    ///         worker.step();
+    ///         worker.step();
+    ///         assert!(probe.done());
+    ///
+    ///     }).unwrap();
+    /// }
+    /// ```
+    pub fn import_core<G>(&mut self, scope: &G, name: &str) -> (Arranged<G, TraceAgent<Tr>>, ShutdownButton<CapabilitySet<Tr::Time>>)
+    where
+        G: Scope<Timestamp=Tr::Time>,
+        Tr::Time: Timestamp,
+    {
+        let trace = self.clone();
+
+        // Capabilities shared with a shutdown button.
+        // let shutdown_button = ShutdownButton::new(capabilities.clone());
+
+        let mut shutdown_button = None;
+
+        let stream = {
+
+            let mut shutdown_button_ref = &mut shutdown_button;
+            source(scope, name, move |capability, info| {
+
+                let capabilities = Rc::new(RefCell::new(Some(CapabilitySet::new())));
+
+                let activator = scope.activator_for(&info.address[..]);
+                let queue = self.new_listener(activator);
+
+                let activator = scope.activator_for(&info.address[..]);
+                *shutdown_button_ref = Some(ShutdownButton::new(capabilities.clone(), activator));
+
+                capabilities.borrow_mut().as_mut().unwrap().insert(capability);
+
+                move |output| {
+
+                    let mut capabilities = capabilities.borrow_mut();
+                    if let Some(ref mut capabilities) = *capabilities {
+
+                        let mut borrow = queue.1.borrow_mut();
+                        for instruction in borrow.drain(..) {
+                            match instruction {
+                                TraceReplayInstruction::Frontier(frontier) => {
+                                    // println!("DOWNGRADE: {:?}", frontier);
+                                    capabilities.downgrade(&frontier[..]);
+                                },
+                                TraceReplayInstruction::Batch(batch, hint) => {
+                                    if let Some(time) = hint {
+                                        // println!("TIME: {:?}", time);
+                                        let delayed = capabilities.delayed(&time);
+                                        output.session(&delayed).give(batch);
+                                    }
+                                }
+                            }
+                        }
+                        // for (frontier, batch, hint) in borrow.drain(..) {
+
+                        //     println!("REPLAY\t{:?}, {:?}, {:?}", frontier, batch.description(), hint);
+
+                        //     if let Some(time) = hint {
+                        //         let delayed = capabilities.delayed(&time);
+                        //         output.session(&delayed).give(batch);
+                        //     }
+
+                        //     capabilities.downgrade(&frontier[..]);
+                        // }
+                    }
+                }
+            })
+        };
+
+        (Arranged { stream, trace }, shutdown_button.unwrap())
+    }
+}
+
+
+
+/// Wrapper than can drop shared references.
+pub struct ShutdownButton<T> {
+    reference: Rc<RefCell<Option<T>>>,
+    activator: Activator,
+}
+
+impl<T> ShutdownButton<T> {
+    /// Creates a new ShutdownButton.
+    pub fn new(reference: Rc<RefCell<Option<T>>>, activator: Activator) -> Self {
+        Self { reference, activator }
+    }
+    /// Push the shutdown button, dropping the shared objects.
+    pub fn press(&mut self) {
+        *self.reference.borrow_mut() = None;
+        self.activator.activate();
+    }
+}
+
+impl<Tr> Clone for TraceAgent<Tr>
+where
+    Tr: TraceReader,
+    Tr::Time: Lattice+Ord+Clone+'static,
+{
+    fn clone(&self) -> Self {
+
+        // increase counts for wrapped `TraceBox`.
+        self.trace.borrow_mut().adjust_advance_frontier(&[], &self.advance[..]);
+        self.trace.borrow_mut().adjust_through_frontier(&[], &self.through[..]);
+
+        TraceAgent {
+            trace: self.trace.clone(),
+            queues: self.queues.clone(),
+            advance: self.advance.clone(),
+            through: self.through.clone(),
+        }
+    }
+}
+
+
+impl<Tr> Drop for TraceAgent<Tr>
+where
+    Tr: TraceReader,
+    Tr::Time: Lattice+Ord+Clone+'static,
+{
+    fn drop(&mut self) {
+        // decrement borrow counts to remove all holds
+        self.trace.borrow_mut().adjust_advance_frontier(&self.advance[..], &[]);
+        self.trace.borrow_mut().adjust_through_frontier(&self.through[..], &[]);
+    }
+}

--- a/src/operators/arrange/mod.rs
+++ b/src/operators/arrange/mod.rs
@@ -1,4 +1,43 @@
 //! Types and traits for arranging collections.
+//!
+//! Differential dataflow collections can be "arranged" into maintained, worker-local
+//! indices that can be re-used by other dataflows at relatively low cost.
+//!
+//! The `arrange` operator, and its variants, takes a `Collection` and produces as an
+//! output an instance of the `Arrangement` type. An arrangement is logically equivalent
+//! to its input collection, but it is distributed across workers and maintained in a
+//! way that makes it easy to re-use.
+//!
+//! The `arrange` operator receives update triples `(data, time, diff)` from its input,
+//! and responds to changes in its input frontier, which as it advances signals further
+//! times that will no longer be observed in input updates. For each frontier advance,
+//! the operator creates a new "batch", containing exactly those updates whose times are
+//! in advance of the previous frontier but not in advance of the new frontier. Updates
+//! are partitioned among workers by a key, and each batch is indexed by this key.
+//!
+//! This sequence of batches defines a continually expanding view of committed updates
+//! in the collection.
+//! The sequence is presented by the `Arrangement` in two forms (its fields):
+//!
+//! 1.  A timely dataflow `Stream` of batch elements.
+//!
+//!     The stream is used by operators that want to exploit the arranged structure of
+//!     batches, but want the push-based computational model of timely dataflow.
+//!     Many differential dataflow operators can consume streams of batches, although
+//!     they may also rely on access to the second representation of the sequence.
+//!
+//! 2.  A `Trace` type that provides a compact representation of the accumulated batches.
+//!
+//!     A trace is logically equivalent to a sequence of batches, but it is able to alter
+//!     the representation for efficiency. In particular, the trace may merge batches so
+//!     that the total number is kept small, and it may merge logical times if it able to
+//!     determine that no trace users can distinguish between them.
+//!
+//! Importantly, the `Trace` type has no connection to the timely dataflow runtime.
+//! This means a trace can be used in a variety of contexts where a `Stream` would not be
+//! appropriate, for example outside of the dataflow in which the arragement is performed.
+//! Traces may be directly inspected by any code with access to them, and they can even be
+//! used to introduce the batches to other dataflows with the `import` method.
 
 use std::rc::{Rc, Weak};
 use std::cell::RefCell;

--- a/src/operators/arrange/mod.rs
+++ b/src/operators/arrange/mod.rs
@@ -5,8 +5,7 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 
 use timely::scheduling::Activator;
-use lattice::Lattice;
-use trace::{Trace, TraceReader, Batch};
+use trace::TraceReader;
 
 /// Operating instructions on how to replay a trace.
 pub enum TraceReplayInstruction<Tr>

--- a/src/operators/arrange/mod.rs
+++ b/src/operators/arrange/mod.rs
@@ -1,0 +1,34 @@
+//! Types and traits for arranging collections.
+
+use std::rc::{Rc, Weak};
+use std::cell::RefCell;
+use std::collections::VecDeque;
+
+use timely::scheduling::Activator;
+use lattice::Lattice;
+use trace::{Trace, TraceReader, Batch};
+
+/// Operating instructions on how to replay a trace.
+pub enum TraceReplayInstruction<Tr>
+where
+    Tr: TraceReader,
+{
+    /// Describes a frontier advance.
+    Frontier(Vec<Tr::Time>),
+    /// Describes a batch of data and a capability hint.
+    Batch(Tr::Batch, Option<Tr::Time>),
+}
+
+// Short names for strongly and weakly owned activators and shared queues.
+type BatchQueue<Tr> = VecDeque<TraceReplayInstruction<Tr>>;
+type TraceAgentQueueReader<Tr> = Rc<(Activator, RefCell<BatchQueue<Tr>>)>;
+type TraceAgentQueueWriter<Tr> = Weak<(Activator, RefCell<BatchQueue<Tr>>)>;
+
+pub mod writer;
+pub mod agent;
+pub mod arrangement;
+
+pub use self::writer::TraceWriter;
+pub use self::agent::TraceAgent;
+
+pub use self::arrangement::{Arranged, ArrangeByKey, ArrangeBySelf};

--- a/src/operators/arrange/writer.rs
+++ b/src/operators/arrange/writer.rs
@@ -55,8 +55,6 @@ where
     /// batch and which is suitable for use as a capability.
     pub fn insert(&mut self, batch: Tr::Batch, hint: Option<Tr::Time>) {
 
-        // println!("WRITTEN\t{:?}, {:?}", batch.description(), hint);
-
         // Something is wrong if not a sequence.
         assert!(&self.upper[..] == batch.lower());
         assert!(batch.lower() != batch.upper());
@@ -68,10 +66,8 @@ where
         let mut borrow = self.queues.borrow_mut();
         for queue in borrow.iter_mut() {
             if let Some(pair) = queue.upgrade() {
-                // println!("PUSHING: {:?}", hint);
                 pair.1.borrow_mut().push_back(TraceReplayInstruction::Batch(batch.clone(), hint.clone()));
                 pair.1.borrow_mut().push_back(TraceReplayInstruction::Frontier(batch.upper().to_vec()));
-                // pair.1.borrow_mut().push_back((batch.upper().to_vec(), batch.clone(), hint.clone()));
                 pair.0.activate();
             }
         }

--- a/src/operators/arrange/writer.rs
+++ b/src/operators/arrange/writer.rs
@@ -1,0 +1,107 @@
+//! Write endpoint for a sequence of batches.
+//!
+//! A `TraceWriter` accepts a sequence of batches and distributes them
+//! to both a shared trace and to a sequence of private queues.
+
+use std::rc::{Rc, Weak};
+use std::cell::RefCell;
+
+use lattice::Lattice;
+use trace::{Trace, Batch, BatchReader};
+
+use trace::wrappers::rc::TraceBox;
+
+use super::TraceAgentQueueWriter;
+use super::TraceReplayInstruction;
+
+/// Write endpoint for a sequence of batches.
+///
+/// A `TraceWriter` accepts a sequence of batches and distributes them
+/// to both a shared trace and to a sequence of private queues.
+pub struct TraceWriter<Tr>
+where
+    Tr: Trace,
+    Tr::Time: Lattice+Ord+Clone+std::fmt::Debug+'static,
+    Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
+{
+    /// Current upper limit.
+    upper: Vec<Tr::Time>,
+    /// Shared trace, possibly absent (due to weakness).
+    trace: Weak<RefCell<TraceBox<Tr>>>,
+    /// A sequence of private queues into which batches are written.
+    queues: Rc<RefCell<Vec<TraceAgentQueueWriter<Tr>>>>,
+}
+
+impl<Tr> TraceWriter<Tr>
+where
+    Tr: Trace,
+    Tr::Time: Lattice+Ord+Clone+std::fmt::Debug+'static,
+    Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
+{
+    /// Creates a new `TraceWriter`.
+    pub fn new(
+        upper: Vec<Tr::Time>,
+        trace: Weak<RefCell<TraceBox<Tr>>>,
+        queues: Rc<RefCell<Vec<TraceAgentQueueWriter<Tr>>>>
+    ) -> Self
+    {
+        Self { upper, trace, queues }
+    }
+
+    /// Advances the trace by `batch`.
+    ///
+    /// The `hint` argument is either `None` in the case of an empty batch,
+    /// or is `Some(time)` for a time less or equal to all updates in the
+    /// batch and which is suitable for use as a capability.
+    pub fn insert(&mut self, batch: Tr::Batch, hint: Option<Tr::Time>) {
+
+        // println!("WRITTEN\t{:?}, {:?}", batch.description(), hint);
+
+        // Something is wrong if not a sequence.
+        assert!(&self.upper[..] == batch.lower());
+        assert!(batch.lower() != batch.upper());
+
+        self.upper.clear();
+        self.upper.extend(batch.upper().iter().cloned());
+
+        // push information to each listener that still exists.
+        let mut borrow = self.queues.borrow_mut();
+        for queue in borrow.iter_mut() {
+            if let Some(pair) = queue.upgrade() {
+                // println!("PUSHING: {:?}", hint);
+                pair.1.borrow_mut().push_back(TraceReplayInstruction::Batch(batch.clone(), hint.clone()));
+                pair.1.borrow_mut().push_back(TraceReplayInstruction::Frontier(batch.upper().to_vec()));
+                // pair.1.borrow_mut().push_back((batch.upper().to_vec(), batch.clone(), hint.clone()));
+                pair.0.activate();
+            }
+        }
+        borrow.retain(|w| w.upgrade().is_some());
+
+        // push data to the trace, if it still exists.
+        if let Some(trace) = self.trace.upgrade() {
+            trace.borrow_mut().trace.insert(batch);
+        }
+
+    }
+
+    /// Inserts an empty batch up to `upper`.
+    pub fn seal(&mut self, upper: &[Tr::Time]) {
+        if &self.upper[..] != upper {
+            use trace::Builder;
+            let builder = <Tr::Batch as Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>>::Builder::new();
+            let batch = builder.done(&self.upper[..], upper, &self.upper[..]);
+            self.insert(batch, None);
+        }
+    }
+}
+
+impl<Tr> Drop for TraceWriter<Tr>
+where
+    Tr: Trace,
+    Tr::Time: Lattice+Ord+Clone+std::fmt::Debug+'static,
+    Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
+{
+    fn drop(&mut self) {
+        self.seal(&[])
+    }
+}

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -402,7 +402,7 @@ where
                         batches.swap(&mut input_buffer);
                         // In principle we could have multiple batches per message (in practice, it would be weird).
                         for batch in input_buffer.drain(..) {
-                            assert!(&upper_received[..] == batch.description().lower());
+                            // assert!(&upper_received[..] == batch.description().lower());
                             upper_received = batch.description().upper().to_vec();
                             batch_cursors.push(batch.cursor());
                             batch_storage.push(batch);
@@ -557,7 +557,7 @@ where
 
                                 // ship batch to the output, and commit to the output trace.
                                 output.session(&capabilities[index]).give(batch.clone());
-                                output_writer.seal(local_upper.elements(), Some((capabilities[index].time().clone(), batch)));
+                                output_writer.insert(batch, Some(capabilities[index].time().clone()));
 
                                 lower_issued = local_upper;
                             }
@@ -585,7 +585,7 @@ where
                         capabilities = new_capabilities;
 
                         // ensure that observed progres is reflected in the output.
-                        output_writer.seal(upper_limit.elements(), None);
+                        output_writer.seal(upper_limit.elements());
                     }
 
                     // We only anticipate future times in advance of `upper_limit`.

--- a/src/trace/description.rs
+++ b/src/trace/description.rs
@@ -1,8 +1,8 @@
 //! Descriptions of intervals of partially ordered times.
 //!
-//! A description provides what intends to be an unambiguous characterization of a batch of 
-//! updates. We do assume that these updates are in the context of a known computation and 
-//! known input, so there is a well-defined "correct answer" for the full set of updates. 
+//! A description provides what intends to be an unambiguous characterization of a batch of
+//! updates. We do assume that these updates are in the context of a known computation and
+//! known input, so there is a well-defined "correct answer" for the full set of updates.
 //!
 //! ```ignore
 //!      full = { (data, time, diff) }
@@ -12,26 +12,26 @@
 //!
 //! Each description contains three frontiers, sets of mutually incomparable partially ordered
 //! times. The first two frontiers are `lower` and `upper`, and they indicate the subset of
-//! `full` represented in the batch: those updates whose times are greater or equal to some 
+//! `full` represented in the batch: those updates whose times are greater or equal to some
 //! element of `lower` but not greater or equal to any element of `upper`.
 //!
 //! ```ignore
-//!     subset = { (data, time, diff) in full | lower.any(|t| t.le(time)) && 
-//! 										   !upper.any(|t| t.le(time)) }
+//!     subset = { (data, time, diff) in full | lower.any(|t| t.le(time)) &&
+//!                                            !upper.any(|t| t.le(time)) }
 //! ```
 //!
 //! The third frontier `since` is used to indicate that the times presented by the batch may
-//! no longer reflect the values in `subset` above. Although the updates are precisely those 
+//! no longer reflect the values in `subset` above. Although the updates are precisely those
 //! bound by `lower` and `upper`, we may have *advanced* some of the times.
 //!
-//! The guarantee provided by a batch is that for any time greater or equal to some element of 
-//! `since`, the accumulated weight of batch updates before that time is identical to the accumulated 
-//! weights of updates from `full` at times greater or equal to an element of `lower`, greater 
+//! The guarantee provided by a batch is that for any time greater or equal to some element of
+//! `since`, the accumulated weight of batch updates before that time is identical to the accumulated
+//! weights of updates from `full` at times greater or equal to an element of `lower`, greater
 //! or equal to no element of `upper`, and less or equal to the query time.
 //!
 //! ```ignore
 //!     for all times t1:
-//! 
+//!
 //!        if since.any(|t2| t2.less_equal(t1)) then:
 //!
 //!            for all data:
@@ -46,12 +46,12 @@
 //! Very importantly, this equality does not make any other guarantees about the contents of
 //! the batch when one iterates through it. There are some consequences of the math that can
 //! be relied upon, though.
-//! 
-//! The most important consequence is that when `since <= lower` the contents of the batch 
+//!
+//! The most important consequence is that when `since <= lower` the contents of the batch
 //! must be identical to the updates in `subset`. If it is ever the case that `since` is
 //! in advance of `lower`, consumers of the batch must take care that they not use the times
 //! observed in the batch without ensuring that they are appropriately advanced (typically by
-//! `since`). Failing to do so may produce updates that are not in advance of `since`, which 
+//! `since`). Failing to do so may produce updates that are not in advance of `since`, which
 //! will often be a logic bug, as `since` does not advance without a corresponding advance in
 //! times at which data may possibly be sent.
 
@@ -59,7 +59,7 @@
 ///
 /// A `Description` indicates a set of partially ordered times, and a moment at which they are
 /// observed. The `lower` and `upper` frontiers bound the times contained within, and the `since`
-/// frontier indicates a moment at which the times were observed. If `since` is strictly in 
+/// frontier indicates a moment at which the times were observed. If `since` is strictly in
 /// advance of `lower`, the contained times may be "advanced" to times which appear equivalent to
 /// any time after `since`.
 #[derive(Clone, Debug, Abomonation)]

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -46,59 +46,54 @@ where
 
         let mut builder = B::Builder::new();
 
-        // If all of our updates are greater or equal to an element of `upper`,
-        // we will mint an empty batch and can skip the process.
-        if self.frontier.elements().iter().all(|t1| upper.iter().any(|t2| t2.less_equal(t1))) {
+        let mut merged = Vec::new();
+        self.sorter.finish_into(&mut merged);
 
-            let mut merged = Vec::new();
-            self.sorter.finish_into(&mut merged);
+        let mut kept = Vec::new();
+        let mut keep = Vec::new();
 
-            let mut kept = Vec::new();
-            let mut keep = Vec::new();
+        self.frontier.clear();
 
-            self.frontier.clear();
-
-            // TODO: Re-use buffer, rather than dropping.
-            for mut buffer in merged.drain(..) {
-                for ((key, val), time, diff) in buffer.drain(..) {
-                    if upper.iter().any(|t| t.less_equal(&time)) {
-                        // keep_count += 1;
-                        self.frontier.insert(time.clone());
-                        if keep.len() == keep.capacity() {
-                            if keep.len() > 0 {
-                                kept.push(keep);
-                                keep = self.sorter.empty();
-                            }
+        // TODO: Re-use buffer, rather than dropping.
+        for mut buffer in merged.drain(..) {
+            for ((key, val), time, diff) in buffer.drain(..) {
+                if upper.iter().any(|t| t.less_equal(&time)) {
+                    // keep_count += 1;
+                    self.frontier.insert(time.clone());
+                    if keep.len() == keep.capacity() {
+                        if keep.len() > 0 {
+                            kept.push(keep);
+                            keep = self.sorter.empty();
                         }
-                        keep.push(((key, val), time, diff));
                     }
-                    else {
-                        // seal_count += 1;
-                        builder.push((key, val, time, diff));
-                    }
+                    keep.push(((key, val), time, diff));
                 }
-                // Recycling buffer.
-                self.sorter.push(&mut buffer);
+                else {
+                    // seal_count += 1;
+                    builder.push((key, val, time, diff));
+                }
             }
-
-            // Finish the kept data.
-            if keep.len() > 0 {
-                kept.push(keep);
-            }
-            if kept.len() > 0 {
-                self.sorter.push_list(kept);
-            }
-
-            // Drain buffers (fast reclaimation).
-            // TODO : This isn't obviously the best policy, but "safe" wrt footprint.
-            //        In particular, if we are reading serialized input data, we may
-            //        prefer to keep these buffers around to re-fill, if possible.
-            let mut buffer = Vec::new();
+            // Recycling buffer.
             self.sorter.push(&mut buffer);
-            while buffer.capacity() > 0 {
-                buffer = Vec::new();
-                self.sorter.push(&mut buffer);
-            }
+        }
+
+        // Finish the kept data.
+        if keep.len() > 0 {
+            kept.push(keep);
+        }
+        if kept.len() > 0 {
+            self.sorter.push_list(kept);
+        }
+
+        // Drain buffers (fast reclaimation).
+        // TODO : This isn't obviously the best policy, but "safe" wrt footprint.
+        //        In particular, if we are reading serialized input data, we may
+        //        prefer to keep these buffers around to re-fill, if possible.
+        let mut buffer = Vec::new();
+        self.sorter.push(&mut buffer);
+        while buffer.capacity() > 0 {
+            buffer = Vec::new();
+            self.sorter.push(&mut buffer);
         }
 
         let seal = builder.done(&self.lower[..], &upper[..], &self.lower[..]);

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -109,7 +109,7 @@ pub trait TraceReader {
 	/// this frontier are not guaranteed to return a cursor.
 	fn distinguish_frontier(&mut self) -> &[Self::Time];
 
-	/// Maps some logic across the batches the collection manages.
+	/// Maps logic across the non-empty sequence of batches in the trace.
 	///
 	/// This is currently used only to extract historical data to prime late-starting operators who want to reproduce
 	/// the stream of batches moving past the trace. It could also be a fine basis for a default implementation of the

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -180,7 +180,7 @@ pub trait BatchReader<K, V, T, R> where Self: ::std::marker::Sized
 	/// The number of updates in the batch.
 	fn len(&self) -> usize;
 	/// True if the batch is empty.
-	fn is_empty(&self) -> usize { self.len() == 0 }
+	fn is_empty(&self) -> bool { self.len() == 0 }
 	/// Describes the times of the updates in the batch.
 	fn description(&self) -> &Description<T>;
 

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -54,6 +54,11 @@ pub trait TraceReader {
 	/// The type used to enumerate the collections contents.
 	type Cursor: Cursor<Self::Key, Self::Val, Self::Time, Self::R>;
 
+	// /// The upper frontier of committed times.
+	// ///
+	// ///
+	// fn upper(&self) -> &[Self::Time];
+
 	/// Provides a cursor over updates contained in the trace.
 	fn cursor(&mut self) -> (Self::Cursor, <Self::Cursor as Cursor<Self::Key, Self::Val, Self::Time, Self::R>>::Storage) {
 		if let Some(cursor) = self.cursor_through(&[]) {
@@ -185,6 +190,10 @@ pub trait Batch<K, V, T, R> : BatchReader<K, V, T, R> where Self: ::std::marker:
 	fn begin_merge(&self, other: &Self) -> Self::Merger {
 		Self::Merger::new(self, other)
 	}
+	// ///
+	// fn empty(lower: &[T], upper: &[T], since: &[T]) -> Output {
+	// 	<Self::Builder>::new().done(lower, upper, since)
+	// }
 }
 
 /// Functionality for collecting and batching updates.

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -179,6 +179,8 @@ pub trait BatchReader<K, V, T, R> where Self: ::std::marker::Sized
 	fn cursor(&self) -> Self::Cursor;
 	/// The number of updates in the batch.
 	fn len(&self) -> usize;
+	/// True if the batch is empty.
+	fn is_empty(&self) -> usize { self.len() == 0 }
 	/// Describes the times of the updates in the batch.
 	fn description(&self) -> &Description<T>;
 

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -43,7 +43,7 @@ fn run_test<T>(test: T, expected: Vec<(usize, Vec<((u64, i64), i64)>)>) -> ()
 }
 
 #[test]
-fn test_import() {
+fn test_import_vanilla() {
     run_test(|input_epochs| {
         timely::execute(timely::Configuration::Process(4), move |worker| {
             let ref input_epochs = input_epochs;
@@ -193,6 +193,9 @@ fn test_import_stalled_dataflow() {
         worker.step();
         worker.step();
         worker.step();
+
+        println!("input:\t{:?}", input.time());
+        probe2.with_frontier(|f| println!("{:?}", &f[..]));
 
         assert!(!probe2.less_than(input.time()));
 


### PR DESCRIPTION
This PR is trying to add a bit more discipline to how traces are built from batches. Previously, a trace would contain all non-empty batches, but empty batches didn't quite make it to the trace until there were some records to transmit and .. it was all a bit hack-y with some unfortunate consequences.

The PR also re-organizes `operators/arrange.rs` into several files, in part so that each of the moving parts more obviously should have independently specifiable behaviors.

The `TraceWriter` accepts a sequence of batches, whose `lower` and `upper` frontiers should line up. It also has a `seal` method which helps submit an empty batch up to a supplied frontier. These batches go to the shared trace (if it exists), and to each of the private queues associated with imports.

The `TraceAgent` implements the `TraceReader` trait and supports the importing of traces into other dataflows. This does a bit of a dance with the existing trace: reading its current batches out, pushing them into a new private queue, and then dropping that queue into the list of the `TraceWriter`. The `import_core` method is its core functionality.

The `Arrangement` is the arranged analogue of a `Collection`, and has lots of methods that allow you to use it in weird ways.

---

The PR should be mostly functionality *preserving*, with a few new features: a trace now has a `read_upper` method that allows you to read out its current upper frontier (previously, there was some dead time until non-empty batches arrived).

There is the risk that the PR has some performance regressions, as we are now moving around more empty batches. We will have to check for that. Nothing requires the internals of the trace to actually move these many batches around, but we do now need to respect the contract that having shown the trace some empty batches it properly reflects that information.