### PR TITLE
Enrich shutdown button

### DIFF
--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -329,6 +329,7 @@ where
 
 /// Wrapper than can drop shared references.
 pub struct ShutdownButton<T> {
+    on_drop: bool,
     reference: Rc<RefCell<Option<T>>>,
     activator: Activator,
 }
@@ -336,12 +337,24 @@ pub struct ShutdownButton<T> {
 impl<T> ShutdownButton<T> {
     /// Creates a new ShutdownButton.
     pub fn new(reference: Rc<RefCell<Option<T>>>, activator: Activator) -> Self {
-        Self { reference, activator }
+        Self { on_drop: false, reference, activator }
     }
     /// Push the shutdown button, dropping the shared objects.
     pub fn press(&mut self) {
         *self.reference.borrow_mut() = None;
         self.activator.activate();
+    }
+    /// Sets the button to auto-press on drop.
+    pub fn press_on_drop(&mut self) {
+        self.on_drop = true;
+    }
+}
+
+impl<T> Drop for ShutdownButton<T> {
+    fn drop(&mut self) {
+        if self.on_drop {
+            self.press();
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds a `press_on_drop` method to `ShutdownButton`, which changes its behavior to shut down an import when the button is dropped. If this method is not called then dropping the button will not shut down the import.

@comnik 
