### PR TITLE
Enter and leave for regions

### DIFF
--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -413,7 +413,7 @@ where
     Tr::Batch: BatchReader<Tr::Key, Tr::Val, G::Timestamp, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, G::Timestamp, Tr::R>,
 {
-    /// Brings an arranged collection into a nested region.
+    /// Brings an arranged collection out of a nested region.
     ///
     /// This method only applies to *regions*, which are subscopes with the same timestamp
     /// as their containing scope. In this case, the trace type does not need to change.

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -111,6 +111,24 @@ where
         }
     }
 
+    /// Brings an arranged collection into a nested region.
+    ///
+    /// This method only applies to *regions*, which are subscopes with the same timestamp
+    /// as their containing scope. In this case, the trace type does not need to change.
+    pub fn enter_region<'a>(&self, child: &Child<'a, G, G::Timestamp>)
+        -> Arranged<Child<'a, G, G::Timestamp>, Tr>
+        where
+            Tr::Key: 'static,
+            Tr::Val: 'static,
+            Tr::R: 'static,
+            G::Timestamp: Clone+Default+'static,
+    {
+        Arranged {
+            stream: self.stream.enter(child),
+            trace: self.trace.clone(),
+        }
+    }
+
     /// Brings an arranged collection into a nested scope.
     ///
     /// This method produces a proxy trace handle that uses the same backing data, but acts as if the timestamps
@@ -385,6 +403,26 @@ where
                 }
             }
         })
+    }
+}
+
+impl<'a, G: Scope, Tr> Arranged<Child<'a, G, G::Timestamp>, Tr>
+where
+    G::Timestamp: Lattice+Ord,
+    Tr: TraceReader<Time=G::Timestamp> + Clone,
+    Tr::Batch: BatchReader<Tr::Key, Tr::Val, G::Timestamp, Tr::R>,
+    Tr::Cursor: Cursor<Tr::Key, Tr::Val, G::Timestamp, Tr::R>,
+{
+    /// Brings an arranged collection into a nested region.
+    ///
+    /// This method only applies to *regions*, which are subscopes with the same timestamp
+    /// as their containing scope. In this case, the trace type does not need to change.
+    pub fn leave_region(&self) -> Arranged<G, Tr> {
+        use timely::dataflow::operators::Leave;
+        Arranged {
+            stream: self.stream.leave(),
+            trace: self.trace.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
A "region" is the term used for subscopes with the same timestamp as their parent scope, and which are intended mostly for abstraction, rather than altering the computation. This PR adds an `enter_region` method to an arrangement, and a `leave_region` to arrangements in a region. The intent is to make it less painful and lower cost to use regions.