### PR TITLE
Enable logging function

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,6 +3,19 @@
 /// Logger for differential dataflow events.
 pub type Logger = ::timely::logging::Logger<DifferentialEvent>;
 
+/// Enables logging of differential dataflow events.
+pub fn enable<A, W>(worker: &mut timely::worker::Worker<A>, writer: W) -> Option<Box<std::any::Any+'static>>
+where
+    A: timely::communication::Allocate,
+    W: std::io::Write+'static,
+{
+    let writer = ::timely::dataflow::operators::capture::EventWriter::new(writer);
+    let mut logger = ::timely::logging::BatchLogger::new(writer);
+    worker
+        .log_register()
+        .insert::<DifferentialEvent,_>("differential/arrange", move |time, data| logger.publish_batch(time, data))
+}
+
 /// Possible different differential events.
 #[derive(Debug, Clone, Abomonation, Ord, PartialOrd, Eq, PartialEq)]
 pub enum DifferentialEvent {


### PR DESCRIPTION
This PR introduces a `logging::enable()` function to enable the logging of differential dataflow events. It takes as an argument the worker, and a `W: Write` at which to log (not uncommonly: a TCP connection). The method also returns any previously registered logger, so that it can be recovered.

Related to: https://github.com/TimelyDataflow/diagnostics/pull/7

cc @comnik @utaal 