### PR TITLE
WIP: Enter frontier

### DIFF
--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -20,6 +20,9 @@ use timely::scheduling::Activator;
 use super::{TraceWriter, TraceAgentQueueWriter, TraceAgentQueueReader, Arranged};
 use super::TraceReplayInstruction;
 
+use crate::trace::wrappers::frontier::{TraceFrontier, BatchFrontier};
+
+
 /// A `TraceReader` wrapper which can be imported into other dataflows.
 ///
 /// The `TraceAgent` is the default trace type produced by `arranged`, and it can be extracted
@@ -217,6 +220,7 @@ where
         // Drop ShutdownButton and return only the arrangement.
         self.import_core(scope, name).0
     }
+
     /// Imports an arrangement into the supplied scope.
     ///
     /// # Examples
@@ -312,6 +316,133 @@ where
                                     if let Some(time) = hint {
                                         let delayed = capabilities.delayed(&time);
                                         output.session(&delayed).give(batch);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+        };
+
+        (Arranged { stream, trace }, shutdown_button.unwrap())
+    }
+
+    /// Imports an arrangement into the supplied scope.
+    ///
+    /// This variant of import uses the `advance_frontier` to forcibly advance timestamps in updates.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// extern crate timely;
+    /// extern crate differential_dataflow;
+    ///
+    /// use timely::Configuration;
+    /// use timely::dataflow::ProbeHandle;
+    /// use timely::dataflow::operators::Probe;
+    /// use timely::dataflow::operators::Inspect;
+    /// use differential_dataflow::input::InputSession;
+    /// use differential_dataflow::operators::arrange::ArrangeBySelf;
+    /// use differential_dataflow::operators::reduce::Reduce;
+    /// use differential_dataflow::trace::Trace;
+    /// use differential_dataflow::trace::TraceReader;
+    /// use differential_dataflow::trace::implementations::ord::OrdValSpine;
+    /// use differential_dataflow::hashable::OrdWrapper;
+    /// use differential_dataflow::input::Input;
+    ///
+    /// fn main() {
+    ///     ::timely::execute(Configuration::Thread, |worker| {
+    ///
+    ///         let mut probe = ProbeHandle::new();
+    ///
+    ///         // create a first dataflow
+    ///         let (mut handle, mut trace) = worker.dataflow::<u32,_,_>(|scope| {
+    ///             // create input handle and collection.
+    ///             let (handle, stream) = scope.new_collection();
+    ///             let trace = stream.arrange_by_self().trace;
+    ///             (handle, trace)
+    ///         });
+    ///
+    ///         handle.insert(0); handle.advance_to(1); handle.flush(); worker.step();
+    ///         handle.remove(0); handle.advance_to(2); handle.flush(); worker.step();
+    ///         handle.insert(1); handle.advance_to(3); handle.flush(); worker.step();
+    ///         handle.remove(1); handle.advance_to(4); handle.flush(); worker.step();
+    ///         handle.insert(0); handle.advance_to(5); handle.flush(); worker.step();
+    ///
+    ///         trace.advance_by(&[5]);
+    ///
+    ///         // create a second dataflow
+    ///         let mut shutdown = worker.dataflow(|scope| {
+    ///             let (arrange, button) = trace.import_frontier(scope, "Import");
+    ///             arrange
+    ///                 .as_collection(|k,v| (*k,*v))
+    ///                 .inner
+    ///                 .inspect(|(d,t,r)| {
+    ///                     assert!(t >= &5);
+    ///                 })
+    ///                 .probe_with(&mut probe);
+    ///
+    ///             button
+    ///         });
+    ///
+    ///         worker.step();
+    ///         worker.step();
+    ///         assert!(!probe.done());
+    ///
+    ///         shutdown.press();
+    ///
+    ///         worker.step();
+    ///         worker.step();
+    ///         assert!(probe.done());
+    ///
+    ///     }).unwrap();
+    /// }
+    /// ```
+    pub fn import_frontier<G>(&mut self, scope: &G, name: &str) -> (Arranged<G, TraceFrontier<TraceAgent<Tr>>>, ShutdownButton<CapabilitySet<Tr::Time>>)
+    where
+        G: Scope<Timestamp=Tr::Time>,
+        Tr::Time: Timestamp+ Lattice+Ord+Clone+'static,
+        Tr: TraceReader,
+    {
+        // This frontier describes our only guarantee on the compaction frontier.
+        let frontier = self.advance_frontier().to_vec();
+
+        let trace = self.clone();
+        let trace = TraceFrontier::make_from(trace, &frontier[..]);
+
+        let mut shutdown_button = None;
+
+        let stream = {
+
+            let shutdown_button_ref = &mut shutdown_button;
+            source(scope, name, move |capability, info| {
+
+                let capabilities = Rc::new(RefCell::new(Some(CapabilitySet::new())));
+
+                let activator = scope.activator_for(&info.address[..]);
+                let queue = self.new_listener(activator);
+
+                let activator = scope.activator_for(&info.address[..]);
+                *shutdown_button_ref = Some(ShutdownButton::new(capabilities.clone(), activator));
+
+                capabilities.borrow_mut().as_mut().unwrap().insert(capability);
+
+                move |output| {
+
+                    let mut capabilities = capabilities.borrow_mut();
+                    if let Some(ref mut capabilities) = *capabilities {
+
+                        let mut borrow = queue.1.borrow_mut();
+                        for instruction in borrow.drain(..) {
+                            match instruction {
+                                TraceReplayInstruction::Frontier(frontier) => {
+                                    capabilities.downgrade(&frontier[..]);
+                                },
+                                TraceReplayInstruction::Batch(batch, hint) => {
+                                    if let Some(time) = hint {
+                                        let delayed = capabilities.delayed(&time);
+                                        output.session(&delayed).give(BatchFrontier::make_from(batch, &frontier[..]));
                                     }
                                 }
                             }

--- a/src/trace/wrappers/enter_frontier.rs
+++ b/src/trace/wrappers/enter_frontier.rs
@@ -1,0 +1,237 @@
+//! Wrapper for frontiered trace.
+//!
+//! Wraps a trace with a frontier so that all exposed timestamps are first advanced by the frontier.
+//! This ensures that even for traces that have been advanced, all views provided through cursors
+//! present deterministic times, independent of the compaction strategy.
+
+use timely::progress::Timestamp;
+
+use trace::{TraceReader, BatchReader, Description};
+use trace::cursor::Cursor;
+use crate::lattice::Lattice;
+
+/// Wrapper to provide trace to nested scope.
+pub struct TraceFrontier<Tr>
+where
+    Tr: TraceReader,
+{
+    trace: Tr,
+    frontier: Vec<Tr::Time>,
+}
+
+impl<Tr> Clone for TraceFrontier<Tr>
+where
+    Tr: TraceReader+Clone,
+    Tr::Time: Clone,
+{
+    fn clone(&self) -> Self {
+        TraceFrontier {
+            trace: self.trace.clone(),
+            frontier: self.frontier.clone(),
+        }
+    }
+}
+
+impl<Tr> TraceReader for TraceFrontier<Tr>
+where
+    Tr: TraceReader,
+    Tr::Batch: Clone,
+    Tr::Key: 'static,
+    Tr::Val: 'static,
+    Tr::Time: Timestamp+Lattice,
+    Tr::R: 'static,
+{
+    type Key = Tr::Key;
+    type Val = Tr::Val;
+    type Time = Tr::Time;
+    type R = Tr::R;
+
+    type Batch = BatchFrontier<Tr::Key, Tr::Val, Tr::Time, Tr::R, Tr::Batch>;
+    type Cursor = CursorFrontier<Tr::Key, Tr::Val, Tr::Time, Tr::R, Tr::Cursor>;
+
+    fn map_batches<F: FnMut(&Self::Batch)>(&mut self, mut f: F) {
+        let frontier = &self.frontier[..];
+        self.trace.map_batches(|batch| f(&Self::Batch::make_from(batch.clone(), frontier)))
+    }
+
+    fn advance_by(&mut self, frontier: &[Tr::Time]) { self.trace.advance_by(frontier) }
+    fn advance_frontier(&mut self) -> &[Tr::Time] { self.trace.advance_frontier() }
+
+    fn distinguish_since(&mut self, frontier: &[Tr::Time]) { self.trace.distinguish_since(frontier) }
+    fn distinguish_frontier(&mut self) -> &[Tr::Time] { self.trace.distinguish_frontier() }
+
+    fn cursor_through(&mut self, upper: &[Tr::Time]) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>>::Storage)> {
+        let frontier = &self.frontier[..];
+        self.trace.cursor_through(upper).map(|(x,y)| (CursorFrontier::new(x, frontier), y))
+    }
+}
+
+impl<Tr> TraceFrontier<Tr>
+where
+    Tr: TraceReader,
+    Tr::Time: Timestamp,
+{
+    /// Makes a new trace wrapper
+    pub fn make_from(trace: Tr, frontier: &[Tr::Time]) -> Self {
+        TraceFrontier {
+            trace,
+            frontier: frontier.to_vec(),
+        }
+    }
+}
+
+
+/// Wrapper to provide batch to nested scope.
+pub struct BatchFrontier<K, V, T, R, B> {
+    phantom: ::std::marker::PhantomData<(K, V, T, R)>,
+    batch: B,
+    frontier: Vec<T>,
+}
+
+impl<K, V, T: Clone, R, B: Clone> Clone for BatchFrontier<K, V, T, R, B> {
+    fn clone(&self) -> Self {
+        BatchFrontier {
+            phantom: ::std::marker::PhantomData,
+            batch: self.batch.clone(),
+            frontier: self.frontier.clone(),
+        }
+    }
+}
+
+impl<K, V, T, R, B> BatchReader<K, V, T, R> for BatchFrontier<K, V, T, R, B>
+where
+    B: BatchReader<K, V, T, R>,
+    T: Timestamp+Lattice,
+{
+    type Cursor = BatchCursorFrontier<K, V, T, R, B>;
+
+    fn cursor(&self) -> Self::Cursor {
+        BatchCursorFrontier::new(self.batch.cursor(), &self.frontier[..])
+    }
+    fn len(&self) -> usize { self.batch.len() }
+    fn description(&self) -> &Description<T> { &self.batch.description() }
+}
+
+impl<K, V, T, R, B> BatchFrontier<K, V, T, R, B>
+where
+    B: BatchReader<K, V, T, R>,
+    T: Timestamp+Lattice,
+{
+    /// Makes a new batch wrapper
+    pub fn make_from(batch: B, frontier: &[T]) -> Self {
+        BatchFrontier {
+            phantom: ::std::marker::PhantomData,
+            batch,
+            frontier: frontier.to_vec(),
+        }
+    }
+}
+
+/// Wrapper to provide cursor to nested scope.
+pub struct CursorFrontier<K, V, T, R, C: Cursor<K, V, T, R>> {
+    phantom: ::std::marker::PhantomData<(K, V, T, R)>,
+    cursor: C,
+    // logic: Rc<F>,
+    frontier: Vec<T>,
+}
+
+impl<K, V, T: Clone, R, C: Cursor<K, V, T, R>> CursorFrontier<K, V, T, R, C> {
+    fn new(cursor: C, frontier: &[T]) -> Self {
+        CursorFrontier {
+            phantom: ::std::marker::PhantomData,
+            cursor,
+            // logic,
+            frontier: frontier.to_vec(),
+        }
+    }
+}
+
+impl<K, V, T, R, C> Cursor<K, V, T, R> for CursorFrontier<K, V, T, R, C>
+where
+    C: Cursor<K, V, T, R>,
+    T: Timestamp+Lattice,
+    // F: Fn(&K, &V)->bool+'static
+{
+    type Storage = C::Storage;
+
+    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
+    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
+
+    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(storage) }
+    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(storage) }
+
+    #[inline]
+    fn map_times<L: FnMut(&T,&R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+        let frontier = &self.frontier[..];
+        let mut temp: T = Default::default();
+        self.cursor.map_times(storage, |time, diff| {
+            temp.clone_from(time);
+            temp.advance_by(frontier);
+            logic(&temp, diff);
+        })
+    }
+
+    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(storage, key) }
+
+    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(storage, val) }
+
+    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
+    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
+}
+
+
+
+/// Wrapper to provide cursor to nested scope.
+pub struct BatchCursorFrontier<K, V, T, R, B: BatchReader<K, V, T, R>> {
+    phantom: ::std::marker::PhantomData<(K, V, R)>,
+    cursor: B::Cursor,
+    // logic: Rc<F>,
+    frontier: Vec<T>,
+}
+
+impl<K, V, T: Clone, R, B: BatchReader<K, V, T, R>> BatchCursorFrontier<K, V, T, R, B> {
+    fn new(cursor: B::Cursor, frontier: &[T]) -> Self {
+        BatchCursorFrontier {
+            phantom: ::std::marker::PhantomData,
+            cursor,
+            // logic,
+            frontier: frontier.to_vec(),
+        }
+    }
+}
+
+impl<K, V, T, R, B: BatchReader<K, V, T, R>> Cursor<K, V, T, R> for BatchCursorFrontier<K, V, T, R, B>
+where
+    T: Timestamp+Lattice,
+    // F: Fn(&K, &V)->bool+'static,
+{
+    type Storage = BatchFrontier<K, V, T, R, B>;
+
+    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }
+    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(&storage.batch) }
+
+    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { self.cursor.key(&storage.batch) }
+    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { self.cursor.val(&storage.batch) }
+
+    #[inline]
+    fn map_times<L: FnMut(&T,&R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+        let frontier = &self.frontier[..];
+        let mut temp: T = Default::default();
+        self.cursor.map_times(&storage.batch, |time, diff| {
+            temp.clone_from(time);
+            temp.advance_by(frontier);
+            logic(&temp, diff);
+        })
+    }
+
+    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek_key(&storage.batch, key) }
+
+    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.seek_val(&storage.batch, val) }
+
+    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
+    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }
+}

--- a/src/trace/wrappers/frontier.rs
+++ b/src/trace/wrappers/frontier.rs
@@ -131,7 +131,6 @@ where
 pub struct CursorFrontier<K, V, T, R, C: Cursor<K, V, T, R>> {
     phantom: ::std::marker::PhantomData<(K, V, T, R)>,
     cursor: C,
-    // logic: Rc<F>,
     frontier: Vec<T>,
 }
 
@@ -140,7 +139,6 @@ impl<K, V, T: Clone, R, C: Cursor<K, V, T, R>> CursorFrontier<K, V, T, R, C> {
         CursorFrontier {
             phantom: ::std::marker::PhantomData,
             cursor,
-            // logic,
             frontier: frontier.to_vec(),
         }
     }
@@ -150,7 +148,6 @@ impl<K, V, T, R, C> Cursor<K, V, T, R> for CursorFrontier<K, V, T, R, C>
 where
     C: Cursor<K, V, T, R>,
     T: Timestamp+Lattice,
-    // F: Fn(&K, &V)->bool+'static
 {
     type Storage = C::Storage;
 
@@ -187,7 +184,6 @@ where
 pub struct BatchCursorFrontier<K, V, T, R, B: BatchReader<K, V, T, R>> {
     phantom: ::std::marker::PhantomData<(K, V, R)>,
     cursor: B::Cursor,
-    // logic: Rc<F>,
     frontier: Vec<T>,
 }
 
@@ -196,7 +192,6 @@ impl<K, V, T: Clone, R, B: BatchReader<K, V, T, R>> BatchCursorFrontier<K, V, T,
         BatchCursorFrontier {
             phantom: ::std::marker::PhantomData,
             cursor,
-            // logic,
             frontier: frontier.to_vec(),
         }
     }
@@ -205,7 +200,6 @@ impl<K, V, T: Clone, R, B: BatchReader<K, V, T, R>> BatchCursorFrontier<K, V, T,
 impl<K, V, T, R, B: BatchReader<K, V, T, R>> Cursor<K, V, T, R> for BatchCursorFrontier<K, V, T, R, B>
 where
     T: Timestamp+Lattice,
-    // F: Fn(&K, &V)->bool+'static,
 {
     type Storage = BatchFrontier<K, V, T, R, B>;
 

--- a/src/trace/wrappers/mod.rs
+++ b/src/trace/wrappers/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod enter;
 pub mod enter_at;
-pub mod enter_frontier;
+pub mod frontier;
 pub mod rc;
 
 pub mod filter;

--- a/src/trace/wrappers/mod.rs
+++ b/src/trace/wrappers/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod enter;
 pub mod enter_at;
+pub mod enter_frontier;
 pub mod rc;
 
 pub mod filter;


### PR DESCRIPTION
This WIP PR proposes a new form of trace enter intended for regions, which allows the specification of a frontier, and which forcibly advances all times to that frontier (using `Lattice::advance_by`). The intent is that imported traces can then be entered into a region while advancing their frontier, to ensure that even for traces with non-trivially advanced frontiers one gets a consistent view of the times inside.

Alternately, we could write a more complicated `import` method, which seems like perhaps the right place to do this, but it seems like it would involve a larger amount of code and even more duplication (as `import_core` would need a new flavor for re-wrapping batches, unless we wanted to abandon non-importing imports).

cc @comnik 