### PR TITLE
Log state drops

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -23,6 +23,8 @@ pub enum DifferentialEvent {
     Batch(BatchEvent),
     /// Merge start and stop events.
     Merge(MergeEvent),
+    /// Batch dropped when trace dropped.
+    Drop(DropEvent),
     /// A merge failed to complete in time.
     MergeShortfall(MergeShortfall),
 }
@@ -37,6 +39,18 @@ pub struct BatchEvent {
 }
 
 impl From<BatchEvent> for DifferentialEvent { fn from(e: BatchEvent) -> Self { DifferentialEvent::Batch(e) } }
+
+
+/// Either the start or end of a merge event.
+#[derive(Debug, Clone, Abomonation, Ord, PartialOrd, Eq, PartialEq)]
+pub struct DropEvent {
+    /// Operator identifier.
+    pub operator: usize,
+    /// Which order of magnitude.
+    pub length: usize,
+}
+
+impl From<DropEvent> for DifferentialEvent { fn from(e: DropEvent) -> Self { DifferentialEvent::Drop(e) } }
 
 /// Either the start or end of a merge event.
 #[derive(Debug, Clone, Abomonation, Ord, PartialOrd, Eq, PartialEq)]

--- a/src/trace/implementations/spine_fueled.rs
+++ b/src/trace/implementations/spine_fueled.rs
@@ -269,6 +269,34 @@ where
     }
 }
 
+// Drop implementation allows us to log batch drops, to zero out maintained totals.
+impl<K, V, T, R, B> Drop for Spine<K, V, T, R, B>
+where
+    T: Lattice+Ord,
+    R: Semigroup,
+    B: Batch<K, V, T, R>,
+{
+    fn drop(&mut self) {
+
+        if let Some(logger) = &self.logger {
+            for batch in self.merging.drain(..) {
+                if let Some(batch) = batch {
+                    logger.log(::logging::DropEvent {
+                        operator: self.operator.global_id,
+                        length: batch.len(),
+                    });
+                }
+            }
+            for batch in self.pending.drain(..) {
+                logger.log(::logging::DropEvent {
+                    operator: self.operator.global_id,
+                    length: batch.len(),
+                });
+            }
+        }
+    }
+}
+
 impl<K, V, T, R, B> Spine<K, V, T, R, B>
 where
     K: Ord+Clone,


### PR DESCRIPTION
This PR corrects what seems to have been an oversight, that we didn't log arranged state **drops**, so cumulative counts of maintained state would be wrong. Drops only happen when a dataflow is shut down or a trace handle dropped; they don't happen in the normal execution of a dataflow, so this shouldn't impact folks other than those who start and stop dataflows.

It is a breaking change, in that we have a new enum variant for exhaustive matches, but such is the cost of progress!

cc @comnik @ryzhyk