### PR TITLE
improve propagate, allow names

### DIFF
--- a/examples/monoid-bfs.rs
+++ b/examples/monoid-bfs.rs
@@ -159,7 +159,7 @@ where G::Timestamp: Lattice+Ord {
             .join_map(&edges, |_k,&(),d| *d)
             .concat(&roots)
             .map(|x| (x,()))
-            .reduce_core::<_,DefaultKeyTrace<_,_,_>>(|_key, input, output, updates| {
+            .reduce_core::<_,DefaultKeyTrace<_,_,_>>("Reduce", |_key, input, output, updates| {
                 if output.is_empty() || input[0].1 < output[0].1 {
                     updates.push(((), input[0].1));
                 }

--- a/src/algorithms/graphs/propagate.rs
+++ b/src/algorithms/graphs/propagate.rs
@@ -9,6 +9,10 @@ use ::operators::*;
 use ::lattice::Lattice;
 
 /// Propagates labels forward, retaining the minimum label.
+///
+/// This algorithm naively propagates all labels at once, much like standard label propagation.
+/// To more carefully control the label propagation, consider `propagate_core` which supports a
+/// method to limit the introduction of labels.
 pub fn propagate<G, N, L>(edges: &Collection<G, (N,N)>, nodes: &Collection<G,(N,L)>) -> Collection<G,(N,L)>
 where
     G: Scope,
@@ -16,19 +20,14 @@ where
     N: ExchangeData+Hash,
     L: ExchangeData,
 {
-    nodes.filter(|_| false)
-         .iterate(|inner| {
-             let edges = edges.enter(&inner.scope());
-             let nodes = nodes.enter(&inner.scope());
-
-             inner.join_map(&edges, |_k,l,d| (d.clone(),l.clone()))
-                  .concat(&nodes)
-                  .reduce(|_, s, t| t.push((s[0].0.clone(), 1)))
-
-         })
+    propagate_core(&edges.arrange_by_key(), nodes, |_label| 0)
 }
 
 /// Propagates labels forward, retaining the minimum label.
+///
+/// This algorithm naively propagates all labels at once, much like standard label propagation.
+/// To more carefully control the label propagation, consider `propagate_core` which supports a
+/// method to limit the introduction of labels.
 pub fn propagate_at<G, N, L, F>(edges: &Collection<G, (N,N)>, nodes: &Collection<G,(N,L)>, logic: F) -> Collection<G,(N,L)>
 where
     G: Scope,
@@ -37,14 +36,70 @@ where
     L: ExchangeData,
     F: Fn(&L)->u64+'static,
 {
-    nodes.filter(|_| false)
-         .iterate(|inner| {
-             let edges = edges.enter(&inner.scope());
-             let nodes = nodes.enter_at(&inner.scope(), move |r| 256 * (64 - (logic(&r.1)).leading_zeros() as u64));
+    propagate_core(&edges.arrange_by_key(), nodes, logic)
+}
 
-             inner.join_map(&edges, |_k,l,d| (d.clone(),l.clone()))
-                  .concat(&nodes)
-                  .reduce(|_, s, t| t.push((s[0].0.clone(), 1)))
+use trace::TraceReader;
+use operators::arrange::arrangement::Arranged;
+use operators::arrange::arrangement::ArrangeByKey;
 
-         })
+/// Propagates labels forward, retaining the minimum label.
+///
+/// This variant takes a pre-arranged edge collection, to facilitate re-use, and allows
+/// a method `logic` to specify the rounds in which we introduce various labels. The output
+/// of `logic should be a number in the interval [0,64],
+pub fn propagate_core<G, N, L, Tr, F>(edges: &Arranged<G,Tr>, nodes: &Collection<G,(N,L)>, logic: F) -> Collection<G,(N,L)>
+where
+    G: Scope,
+    G::Timestamp: Lattice+Ord,
+    N: ExchangeData+Hash,
+    L: ExchangeData,
+    Tr: TraceReader<Key=N, Val=N, Time=G::Timestamp, R=isize>+Clone+'static,
+    Tr::Batch: crate::trace::BatchReader<N, N, G::Timestamp, Tr::R>+'static,
+    Tr::Cursor: crate::trace::Cursor<N, N, G::Timestamp, Tr::R>+'static,
+    F: Fn(&L)->u64+'static,
+{
+    // Morally the code performs the following iterative computation. However, in the interest of a simplified
+    // dataflow graph and reduced memory footprint we instead have a wordier version below. The core differences
+    // between the two are that 1. the former filters its input and pretends to perform non-monotonic computation,
+    // whereas the latter creates an initially empty monotonic iteration variable, and 2. the latter rotates the
+    // iterative computation so that the arrangement produced by `reduce` can be re-used.
+
+    // nodes.filter(|_| false)
+    //      .iterate(|inner| {
+    //          let edges = edges.enter(&inner.scope());
+    //          let nodes = nodes.enter_at(&inner.scope(), move |r| 256 * (64 - (logic(&r.1)).leading_zeros() as u64));
+    //          inner.join_map(&edges, |_k,l,d| (d.clone(),l.clone()))
+    //               .concat(&nodes)
+    //               .reduce(|_, s, t| t.push((s[0].0.clone(), 1)))
+    //      })
+
+    nodes.scope().iterative::<usize,_,_>(|scope| {
+
+        use crate::operators::reduce::ReduceCore;
+        use crate::operators::iterate::SemigroupVariable;
+        use crate::trace::implementations::ord::OrdValSpine as DefaultValTrace;
+
+        use timely::order::Product;
+
+        let edges = edges.enter(scope);
+        let nodes = nodes.enter_at(scope, move |r| 256 * (64 - (logic(&r.1)).leading_zeros() as usize));
+
+        let proposals = SemigroupVariable::new(scope, Product::new(Default::default(), 1usize));
+
+        let labels =
+        proposals
+            .concat(&nodes)
+            .reduce_abelian::<_,DefaultValTrace<_,_,_,_>>("Propagate", |_, s, t| t.push((s[0].0.clone(), 1)));
+
+        let propagate: Collection<_, (N, L)> =
+        labels
+            .join_core(&edges, |_k, l: &L, d| Some((d.clone(), l.clone())));
+
+        proposals.set(&propagate);
+
+        labels
+            .as_collection(|k,v| (k.clone(), v.clone()))
+            .leave()
+    })
 }


### PR DESCRIPTION
This PR intends to land two improvements: 1. many reduce operators now allow naming to provide more information through logging channels, and 2. the graph `propagate` algorithms are more memory efficient, have smaller dataflow graphs, and allow pre-arranged edge collections.

cc @ryzhyk