### PR TITLE
Add ord32 layers and trace

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -4,7 +4,7 @@
 pub type Logger = ::timely::logging::Logger<DifferentialEvent>;
 
 /// Enables logging of differential dataflow events.
-pub fn enable<A, W>(worker: &mut timely::worker::Worker<A>, writer: W) -> Option<Box<std::any::Any+'static>>
+pub fn enable<A, W>(worker: &mut timely::worker::Worker<A>, writer: W) -> Option<Box<dyn std::any::Any+'static>>
 where
     A: timely::communication::Allocate,
     W: std::io::Write+'static,

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -45,4 +45,5 @@ mod merge_batcher;
 pub use self::merge_batcher::MergeBatcher as Batcher;
 
 pub mod ord;
+pub mod ord32;
 // pub mod hash;

--- a/src/trace/implementations/ord32.rs
+++ b/src/trace/implementations/ord32.rs
@@ -150,8 +150,8 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fm
 		let mut write_position = key_start;
 		for i in key_start .. layer.keys.len() {
 
-			let lower = layer.offs[i];
-			let upper = layer.offs[i+1];
+			let lower = layer.offs[i] as usize;
+			let upper = layer.offs[i+1] as usize;
 
 			if lower < upper {
 				layer.keys.swap(write_position, i);
@@ -212,54 +212,34 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fm
 			desc: self.description,
 		}
 	}
-	fn work(&mut self, source1: &OrdValBatch<K,V,T,R>, source2: &OrdValBatch<K,V,T,R>, frontier: &Option<Vec<T>>, fuel: &mut isize) {
+	fn work(&mut self, source1: &OrdValBatch<K,V,T,R>, source2: &OrdValBatch<K,V,T,R>, frontier: &Option<Vec<T>>, fuel: &mut usize) {
 
 		let starting_updates = self.result.vals.vals.vals.len();
-		let mut effort = 0isize;
+		let mut effort = 0;
 
 		let initial_key_pos = self.result.keys.len();
 
 		// while both mergees are still active
 		while self.lower1 < self.upper1 && self.lower2 < self.upper2 && effort < *fuel {
 			self.result.merge_step((&source1.layer, &mut self.lower1, self.upper1), (&source2.layer, &mut self.lower2, self.upper2));
-			effort = (self.result.vals.vals.vals.len() - starting_updates) as isize;
+			effort = self.result.vals.vals.vals.len() - starting_updates;
 		}
 
-        // Merging is complete; only copying remains. Copying is probably faster than merging, so could take some liberties here.
 		if self.lower1 == self.upper1 || self.lower2 == self.upper2 {
-            // Limit merging by remaining fuel.
-            let remaining_fuel = *fuel - effort;
-            if remaining_fuel > 0 {
-                if self.lower1 < self.upper1 {
-                    let mut to_copy = remaining_fuel as usize;
-                    if to_copy < 1_000 { to_copy = 1_000; }
-                    if to_copy > (self.upper1 - self.lower1) { to_copy = self.upper1 - self.lower1; }
-                    self.result.copy_range(&source1.layer, self.lower1, self.lower1 + to_copy);
-                    self.lower1 += to_copy;
-                }
-                if self.lower2 < self.upper2 {
-                    // self.result.copy_range(&source2.layer, self.lower2, self.upper2); self.lower2 = self.upper2;
-                    let mut to_copy = remaining_fuel as usize;
-                    if to_copy < 1_000 { to_copy = 1_000; }
-                    if to_copy > (self.upper2 - self.lower2) { to_copy = self.upper2 - self.lower2; }
-                    self.result.copy_range(&source2.layer, self.lower2, self.lower2 + to_copy);
-                    self.lower2 += to_copy;
-                }
-            }
+			// these are just copies, so let's bite the bullet and just do them.
+			if self.lower1 < self.upper1 { self.result.copy_range(&source1.layer, self.lower1, self.upper1); self.lower1 = self.upper1; }
+			if self.lower2 < self.upper2 { self.result.copy_range(&source2.layer, self.lower2, self.upper2); self.lower2 = self.upper2; }
 		}
 
-		effort = (self.result.vals.vals.vals.len() - starting_updates) as isize;
+		effort = self.result.vals.vals.vals.len() - starting_updates;
 
 		// if we are supplied a frontier, we should compact.
 		if let Some(frontier) = frontier.as_ref() {
 			OrdValBatch::advance_builder_from(&mut self.result, frontier, initial_key_pos)
 		}
 
-        *fuel -= effort;
-
-        if *fuel < -1_000_000 {
-            println!("Massive deficit OrdVal::work: {}", fuel);
-        }
+		if effort >= *fuel { *fuel = 0; }
+		else 			   { *fuel -= effort; }
 	}
 }
 
@@ -414,8 +394,8 @@ where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Semigroup {
 		let mut write_position = key_start;
 		for i in key_start .. layer.keys.len() {
 
-			let lower = layer.offs[i];
-			let upper = layer.offs[i+1];
+			let lower = layer.offs[i] as usize;
+			let upper = layer.offs[i+1] as usize;
 
 			if lower < upper {
 				layer.keys.swap(write_position, i);
@@ -476,59 +456,33 @@ where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Semigroup {
 			desc: self.description,
 		}
 	}
-	fn work(&mut self, source1: &OrdKeyBatch<K,T,R>, source2: &OrdKeyBatch<K,T,R>, frontier: &Option<Vec<T>>, fuel: &mut isize) {
+	fn work(&mut self, source1: &OrdKeyBatch<K,T,R>, source2: &OrdKeyBatch<K,T,R>, frontier: &Option<Vec<T>>, fuel: &mut usize) {
 
 		let starting_updates = self.result.vals.vals.len();
-		let mut effort = 0isize;
+		let mut effort = 0;
 
 		let initial_key_pos = self.result.keys.len();
 
 		// while both mergees are still active
 		while self.lower1 < self.upper1 && self.lower2 < self.upper2 && effort < *fuel {
 			self.result.merge_step((&source1.layer, &mut self.lower1, self.upper1), (&source2.layer, &mut self.lower2, self.upper2));
-			effort = (self.result.vals.vals.len() - starting_updates) as isize;
+			effort = self.result.vals.vals.len() - starting_updates;
 		}
 
-		// if self.lower1 == self.upper1 || self.lower2 == self.upper2 {
-		// 	// these are just copies, so let's bite the bullet and just do them.
-		// 	if self.lower1 < self.upper1 { self.result.copy_range(&source1.layer, self.lower1, self.upper1); self.lower1 = self.upper1; }
-		// 	if self.lower2 < self.upper2 { self.result.copy_range(&source2.layer, self.lower2, self.upper2); self.lower2 = self.upper2; }
-		// }
-        // Merging is complete; only copying remains. Copying is probably faster than merging, so could take some liberties here.
 		if self.lower1 == self.upper1 || self.lower2 == self.upper2 {
-            // Limit merging by remaining fuel.
-            let remaining_fuel = *fuel - effort;
-            if remaining_fuel > 0 {
-                if self.lower1 < self.upper1 {
-                    let mut to_copy = remaining_fuel as usize;
-                    if to_copy < 1_000 { to_copy = 1_000; }
-                    if to_copy > (self.upper1 - self.lower1) { to_copy = self.upper1 - self.lower1; }
-                    self.result.copy_range(&source1.layer, self.lower1, self.lower1 + to_copy);
-                    self.lower1 += to_copy;
-                }
-                if self.lower2 < self.upper2 {
-                    // self.result.copy_range(&source2.layer, self.lower2, self.upper2); self.lower2 = self.upper2;
-                    let mut to_copy = remaining_fuel as usize;
-                    if to_copy < 1_000 { to_copy = 1_000; }
-                    if to_copy > (self.upper2 - self.lower2) { to_copy = self.upper2 - self.lower2; }
-                    self.result.copy_range(&source2.layer, self.lower2, self.lower2 + to_copy);
-                    self.lower2 += to_copy;
-                }
-            }
+			// these are just copies, so let's bite the bullet and just do them.
+			if self.lower1 < self.upper1 { self.result.copy_range(&source1.layer, self.lower1, self.upper1); self.lower1 = self.upper1; }
+			if self.lower2 < self.upper2 { self.result.copy_range(&source2.layer, self.lower2, self.upper2); self.lower2 = self.upper2; }
 		}
 
-
-        effort = (self.result.vals.vals.len() - starting_updates) as isize;
+		effort = self.result.vals.vals.len() - starting_updates;
 
 		if let Some(frontier) = frontier.as_ref() {
 			OrdKeyBatch::advance_builder_from(&mut self.result, frontier, initial_key_pos);
 		}
 
-        *fuel -= effort;
-
-        if *fuel < -1_000_000 {
-            println!("Massive deficit OrdKey::work: {}", fuel);
-        }
+		if effort >= *fuel { *fuel = 0; }
+		else 			   { *fuel -= effort; }
 	}
 }
 

--- a/src/trace/implementations/ord32.rs
+++ b/src/trace/implementations/ord32.rs
@@ -1,0 +1,600 @@
+//! Trace and batch implementations based on sorted ranges.
+//!
+//! The types and type aliases in this module start with either
+//!
+//! * `OrdVal`: Collections whose data have the form `(key, val)` where `key` is ordered.
+//! * `OrdKey`: Collections whose data have the form `key` where `key` is ordered.
+//!
+//! Although `OrdVal` is more general than `OrdKey`, the latter has a simpler representation
+//! and should consume fewer resources (computation and memory) when it applies.
+
+use std::rc::Rc;
+
+use ::difference::Semigroup;
+use lattice::Lattice;
+
+use trace::layers::{Trie, TupleBuilder};
+use trace::layers::Builder as TrieBuilder;
+use trace::layers::Cursor as TrieCursor;
+use trace::layers::ordered32::{OrderedLayer, OrderedBuilder, OrderedCursor};
+use trace::layers::ordered_leaf::{OrderedLeaf, OrderedLeafBuilder};
+use trace::{Batch, BatchReader, Builder, Merger, Cursor};
+use trace::description::Description;
+
+use trace::layers::MergeBuilder;
+
+// use super::spine::Spine;
+use super::spine_fueled::Spine;
+use super::merge_batcher::MergeBatcher;
+
+use abomonation::abomonated::Abomonated;
+
+/// A trace implementation using a spine of ordered lists.
+pub type OrdValSpine<K, V, T, R> = Spine<K, V, T, R, Rc<OrdValBatch<K, V, T, R>>>;
+
+/// A trace implementation using a spine of abomonated ordered lists.
+pub type OrdValSpineAbom<K, V, T, R> = Spine<K, V, T, R, Rc<Abomonated<OrdValBatch<K, V, T, R>, Vec<u8>>>>;
+
+/// A trace implementation for empty values using a spine of ordered lists.
+pub type OrdKeySpine<K, T, R> = Spine<K, (), T, R, Rc<OrdKeyBatch<K, T, R>>>;
+
+/// A trace implementation for empty values using a spine of abomonated ordered lists.
+pub type OrdKeySpineAbom<K, T, R> = Spine<K, (), T, R, Rc<Abomonated<OrdKeyBatch<K, T, R>, Vec<u8>>>>;
+
+
+/// An immutable collection of update tuples, from a contiguous interval of logical times.
+#[derive(Debug, Abomonation)]
+pub struct OrdValBatch<K: Ord, V: Ord, T: Lattice, R> {
+	/// Where all the dataz is.
+	pub layer: OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>>,
+	/// Description of the update times this layer represents.
+	pub desc: Description<T>,
+}
+
+impl<K, V, T, R> BatchReader<K, V, T, R> for OrdValBatch<K, V, T, R>
+where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Semigroup {
+	type Cursor = OrdValCursor<V, T, R>;
+	fn cursor(&self) -> Self::Cursor { OrdValCursor { cursor: self.layer.cursor() } }
+	fn len(&self) -> usize { <OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>> as Trie>::tuples(&self.layer) }
+	fn description(&self) -> &Description<T> { &self.desc }
+}
+
+impl<K, V, T, R> Batch<K, V, T, R> for OrdValBatch<K, V, T, R>
+where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Semigroup {
+	type Batcher = MergeBatcher<K, V, T, R, Self>;
+	type Builder = OrdValBuilder<K, V, T, R>;
+	type Merger = OrdValMerger<K, V, T, R>;
+
+	fn begin_merge(&self, other: &Self) -> Self::Merger {
+		OrdValMerger::new(self, other)
+	}
+}
+
+impl<K, V, T, R> OrdValBatch<K, V, T, R>
+where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Semigroup {
+	fn advance_builder_from(layer: &mut OrderedBuilder<K, OrderedBuilder<V, OrderedLeafBuilder<T, R>>>, frontier: &[T], key_pos: usize) {
+
+		let key_start = key_pos;
+		let val_start = layer.offs[key_pos] as usize;
+		let time_start = layer.vals.offs[val_start] as usize;
+
+		// We have unique ownership of the batch, and can advance times in place.
+		// We must still sort, collapse, and remove empty updates.
+
+		// We will zip throught the time leaves, calling advance on each,
+		//    then zip through the value layer, sorting and collapsing each,
+		//    then zip through the key layer, collapsing each .. ?
+
+		// 1. For each (time, diff) pair, advance the time.
+		for i in time_start .. layer.vals.vals.vals.len() {
+			layer.vals.vals.vals[i].0.advance_by(frontier);
+		}
+
+		// 2. For each `(val, off)` pair, sort the range, compact, and rewrite `off`.
+		//    This may leave `val` with an empty range; filtering happens in step 3.
+		let mut write_position = time_start;
+		for i in val_start .. layer.vals.keys.len() {
+
+			// NB: batch.layer.vals.offs[i+1] will be used next iteration, and should not be changed.
+			//     we will change batch.layer.vals.offs[i] in this iteration, from `write_position`'s
+			//     initial value.
+
+			let lower = layer.vals.offs[i] as usize;
+			let upper = layer.vals.offs[i+1] as usize;
+
+			layer.vals.offs[i] = write_position as u32;
+
+			let updates = &mut layer.vals.vals.vals[..];
+
+			// sort the range by the times (ignore the diffs; they will collapse).
+			let count = crate::consolidation::consolidate_slice(&mut updates[lower .. upper]);
+
+			for index in lower .. (lower + count) {
+				updates.swap(write_position, index);
+				write_position += 1;
+			}
+		}
+		layer.vals.vals.vals.truncate(write_position);
+		layer.vals.offs[layer.vals.keys.len()] = write_position as u32;
+
+		// 3. For each `(key, off)` pair, (values already sorted), filter vals, and rewrite `off`.
+		//    This may leave `key` with an empty range. Filtering happens in step 4.
+		let mut write_position = val_start;
+		for i in key_start .. layer.keys.len() {
+
+			// NB: batch.layer.offs[i+1] must remain as is for the next iteration.
+			//     instead, we update batch.layer.offs[i]
+
+			let lower = layer.offs[i] as usize;
+			let upper = layer.offs[i+1] as usize;
+
+			layer.offs[i] = write_position as u32;
+
+			// values should already be sorted, but some might now be empty.
+			for index in lower .. upper {
+				let val_lower = layer.vals.offs[index] as usize;
+				let val_upper = layer.vals.offs[index+1] as usize;
+				if val_lower < val_upper {
+					layer.vals.keys.swap(write_position, index);
+					layer.vals.offs[write_position+1] = layer.vals.offs[index+1];
+					write_position += 1;
+				}
+			}
+			// batch.layer.offs[i+1] = write_position;
+		}
+		layer.vals.keys.truncate(write_position);
+		layer.vals.offs.truncate(write_position + 1);
+		layer.offs[layer.keys.len()] = write_position as u32;
+
+		// 4. Remove empty keys.
+		let mut write_position = key_start;
+		for i in key_start .. layer.keys.len() {
+
+			let lower = layer.offs[i];
+			let upper = layer.offs[i+1];
+
+			if lower < upper {
+				layer.keys.swap(write_position, i);
+				// batch.layer.offs updated via `dedup` below; keeps me sane.
+				write_position += 1;
+			}
+		}
+		layer.offs.dedup();
+		layer.keys.truncate(write_position);
+		layer.offs.truncate(write_position+1);
+	}
+}
+
+/// State for an in-progress merge.
+pub struct OrdValMerger<K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Semigroup> {
+	// first batch, and position therein.
+	lower1: usize,
+	upper1: usize,
+	// second batch, and position therein.
+	lower2: usize,
+	upper2: usize,
+	// result that we are currently assembling.
+	result: <OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>> as Trie>::MergeBuilder,
+	description: Description<T>,
+}
+
+impl<K, V, T, R> Merger<K, V, T, R, OrdValBatch<K, V, T, R>> for OrdValMerger<K, V, T, R>
+where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Semigroup {
+	fn new(batch1: &OrdValBatch<K, V, T, R>, batch2: &OrdValBatch<K, V, T, R>) -> Self {
+
+		assert!(batch1.upper() == batch2.lower());
+
+		let since = if batch1.description().since().iter().all(|t1| batch2.description().since().iter().any(|t2| t2.less_equal(t1))) {
+			batch2.description().since()
+		}
+		else {
+			batch1.description().since()
+		};
+
+		let description = Description::new(batch1.lower(), batch2.upper(), since);
+
+		OrdValMerger {
+			lower1: 0,
+			upper1: batch1.layer.keys(),
+			lower2: 0,
+			upper2: batch2.layer.keys(),
+			result: <<OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>>> as Trie>::MergeBuilder as MergeBuilder>::with_capacity(&batch1.layer, &batch2.layer),
+			description: description,
+		}
+	}
+	fn done(self) -> OrdValBatch<K, V, T, R> {
+
+		assert!(self.lower1 == self.upper1);
+		assert!(self.lower2 == self.upper2);
+
+		OrdValBatch {
+			layer: self.result.done(),
+			desc: self.description,
+		}
+	}
+	fn work(&mut self, source1: &OrdValBatch<K,V,T,R>, source2: &OrdValBatch<K,V,T,R>, frontier: &Option<Vec<T>>, fuel: &mut isize) {
+
+		let starting_updates = self.result.vals.vals.vals.len();
+		let mut effort = 0isize;
+
+		let initial_key_pos = self.result.keys.len();
+
+		// while both mergees are still active
+		while self.lower1 < self.upper1 && self.lower2 < self.upper2 && effort < *fuel {
+			self.result.merge_step((&source1.layer, &mut self.lower1, self.upper1), (&source2.layer, &mut self.lower2, self.upper2));
+			effort = (self.result.vals.vals.vals.len() - starting_updates) as isize;
+		}
+
+        // Merging is complete; only copying remains. Copying is probably faster than merging, so could take some liberties here.
+		if self.lower1 == self.upper1 || self.lower2 == self.upper2 {
+            // Limit merging by remaining fuel.
+            let remaining_fuel = *fuel - effort;
+            if remaining_fuel > 0 {
+                if self.lower1 < self.upper1 {
+                    let mut to_copy = remaining_fuel as usize;
+                    if to_copy < 1_000 { to_copy = 1_000; }
+                    if to_copy > (self.upper1 - self.lower1) { to_copy = self.upper1 - self.lower1; }
+                    self.result.copy_range(&source1.layer, self.lower1, self.lower1 + to_copy);
+                    self.lower1 += to_copy;
+                }
+                if self.lower2 < self.upper2 {
+                    // self.result.copy_range(&source2.layer, self.lower2, self.upper2); self.lower2 = self.upper2;
+                    let mut to_copy = remaining_fuel as usize;
+                    if to_copy < 1_000 { to_copy = 1_000; }
+                    if to_copy > (self.upper2 - self.lower2) { to_copy = self.upper2 - self.lower2; }
+                    self.result.copy_range(&source2.layer, self.lower2, self.lower2 + to_copy);
+                    self.lower2 += to_copy;
+                }
+            }
+		}
+
+		effort = (self.result.vals.vals.vals.len() - starting_updates) as isize;
+
+		// if we are supplied a frontier, we should compact.
+		if let Some(frontier) = frontier.as_ref() {
+			OrdValBatch::advance_builder_from(&mut self.result, frontier, initial_key_pos)
+		}
+
+        *fuel -= effort;
+
+        if *fuel < -1_000_000 {
+            println!("Massive deficit OrdVal::work: {}", fuel);
+        }
+	}
+}
+
+/// A cursor for navigating a single layer.
+#[derive(Debug)]
+pub struct OrdValCursor<V: Ord+Clone, T: Lattice+Ord+Clone, R: Semigroup> {
+	cursor: OrderedCursor<OrderedLayer<V, OrderedLeaf<T, R>>>,
+}
+
+impl<K, V, T, R> Cursor<K, V, T, R> for OrdValCursor<V, T, R>
+where K: Ord+Clone, V: Ord+Clone, T: Lattice+Ord+Clone, R: Semigroup {
+
+	type Storage = OrdValBatch<K, V, T, R>;
+
+	fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { &self.cursor.key(&storage.layer) }
+	fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V { &self.cursor.child.key(&storage.layer.vals) }
+	fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+		self.cursor.child.child.rewind(&storage.layer.vals.vals);
+		while self.cursor.child.child.valid(&storage.layer.vals.vals) {
+			logic(&self.cursor.child.child.key(&storage.layer.vals.vals).0, &self.cursor.child.child.key(&storage.layer.vals.vals).1);
+			self.cursor.child.child.step(&storage.layer.vals.vals);
+		}
+	}
+	fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.valid(&storage.layer) }
+	fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.child.valid(&storage.layer.vals) }
+	fn step_key(&mut self, storage: &Self::Storage){ self.cursor.step(&storage.layer); }
+	fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek(&storage.layer, key); }
+	fn step_val(&mut self, storage: &Self::Storage) { self.cursor.child.step(&storage.layer.vals); }
+	fn seek_val(&mut self, storage: &Self::Storage, val: &V) { self.cursor.child.seek(&storage.layer.vals, val); }
+	fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind(&storage.layer); }
+	fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.child.rewind(&storage.layer.vals); }
+}
+
+
+/// A builder for creating layers from unsorted update tuples.
+pub struct OrdValBuilder<K: Ord, V: Ord, T: Ord+Lattice, R: Semigroup> {
+	builder: OrderedBuilder<K, OrderedBuilder<V, OrderedLeafBuilder<T, R>>>,
+}
+
+impl<K, V, T, R> Builder<K, V, T, R, OrdValBatch<K, V, T, R>> for OrdValBuilder<K, V, T, R>
+where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Ord+Clone+::std::fmt::Debug+'static, R: Semigroup {
+
+	fn new() -> Self {
+		OrdValBuilder {
+			builder: OrderedBuilder::<K, OrderedBuilder<V, OrderedLeafBuilder<T, R>>>::new()
+		}
+	}
+	fn with_capacity(cap: usize) -> Self {
+		OrdValBuilder {
+			builder: <OrderedBuilder<K, OrderedBuilder<V, OrderedLeafBuilder<T, R>>> as TupleBuilder>::with_capacity(cap)
+		}
+	}
+
+	#[inline]
+	fn push(&mut self, (key, val, time, diff): (K, V, T, R)) {
+		self.builder.push_tuple((key, (val, (time, diff))));
+	}
+
+	#[inline(never)]
+	fn done(self, lower: &[T], upper: &[T], since: &[T]) -> OrdValBatch<K, V, T, R> {
+		OrdValBatch {
+			layer: self.builder.done(),
+			desc: Description::new(lower, upper, since)
+		}
+	}
+}
+
+
+
+
+/// An immutable collection of update tuples, from a contiguous interval of logical times.
+#[derive(Debug, Abomonation)]
+pub struct OrdKeyBatch<K: Ord, T: Lattice, R> {
+	/// Where all the dataz is.
+	pub layer: OrderedLayer<K, OrderedLeaf<T, R>>,
+	/// Description of the update times this layer represents.
+	pub desc: Description<T>,
+}
+
+impl<K, T, R> BatchReader<K, (), T, R> for OrdKeyBatch<K, T, R>
+where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Semigroup {
+	type Cursor = OrdKeyCursor<T, R>;
+	fn cursor(&self) -> Self::Cursor {
+		OrdKeyCursor {
+			empty: (),
+			valid: true,
+			cursor: self.layer.cursor(),
+		}
+	}
+	fn len(&self) -> usize { <OrderedLayer<K, OrderedLeaf<T, R>> as Trie>::tuples(&self.layer) }
+	fn description(&self) -> &Description<T> { &self.desc }
+}
+
+impl<K, T, R> Batch<K, (), T, R> for OrdKeyBatch<K, T, R>
+where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Semigroup {
+	type Batcher = MergeBatcher<K, (), T, R, Self>;
+	type Builder = OrdKeyBuilder<K, T, R>;
+	type Merger = OrdKeyMerger<K, T, R>;
+
+	fn begin_merge(&self, other: &Self) -> Self::Merger {
+		OrdKeyMerger::new(self, other)
+	}
+}
+
+impl<K, T, R> OrdKeyBatch<K, T, R>
+where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Semigroup {
+	fn advance_builder_from(layer: &mut OrderedBuilder<K, OrderedLeafBuilder<T, R>>, frontier: &[T], key_pos: usize) {
+
+		let key_start = key_pos;
+		let time_start = layer.offs[key_pos] as usize;
+
+		// We will zip through the time leaves, calling advance on each,
+		//    then zip through the value layer, sorting and collapsing each,
+		//    then zip through the key layer, collapsing each .. ?
+
+		// 1. For each (time, diff) pair, advance the time.
+		for i in time_start .. layer.vals.vals.len() {
+			layer.vals.vals[i].0.advance_by(frontier);
+		}
+		// for time_diff in self.layer.vals.vals.iter_mut() {
+		// 	time_diff.0 = time_diff.0.advance_by(frontier);
+		// }
+
+		// 2. For each `(val, off)` pair, sort the range, compact, and rewrite `off`.
+		//    This may leave `val` with an empty range; filtering happens in step 3.
+		let mut write_position = time_start;
+		for i in key_start .. layer.keys.len() {
+
+			// NB: batch.layer.vals.offs[i+1] will be used next iteration, and should not be changed.
+			//     we will change batch.layer.vals.offs[i] in this iteration, from `write_position`'s
+			//     initial value.
+
+			let lower = layer.offs[i] as usize;
+			let upper = layer.offs[i+1] as usize;
+
+			layer.offs[i] = write_position as u32;
+
+			let updates = &mut layer.vals.vals[..];
+
+			// sort the range by the times (ignore the diffs; they will collapse).
+		 	let count = crate::consolidation::consolidate_slice(&mut updates[lower .. upper]);
+
+			for index in lower .. (lower + count) {
+				updates.swap(write_position, index);
+				write_position += 1;
+			}
+		}
+		layer.vals.vals.truncate(write_position);
+		layer.offs[layer.keys.len()] = write_position as u32;
+
+		// 4. Remove empty keys.
+		let mut write_position = key_start;
+		for i in key_start .. layer.keys.len() {
+
+			let lower = layer.offs[i];
+			let upper = layer.offs[i+1];
+
+			if lower < upper {
+				layer.keys.swap(write_position, i);
+				// batch.layer.offs updated via `dedup` below; keeps me sane.
+				write_position += 1;
+			}
+		}
+		layer.offs.dedup();
+		layer.keys.truncate(write_position);
+		layer.offs.truncate(write_position+1);
+	}
+}
+
+/// State for an in-progress merge.
+pub struct OrdKeyMerger<K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Semigroup> {
+	// first batch, and position therein.
+	lower1: usize,
+	upper1: usize,
+	// second batch, and position therein.
+	lower2: usize,
+	upper2: usize,
+	// result that we are currently assembling.
+	result: <OrderedLayer<K, OrderedLeaf<T, R>> as Trie>::MergeBuilder,
+	description: Description<T>,
+}
+
+impl<K, T, R> Merger<K, (), T, R, OrdKeyBatch<K, T, R>> for OrdKeyMerger<K, T, R>
+where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Semigroup {
+	fn new(batch1: &OrdKeyBatch<K, T, R>, batch2: &OrdKeyBatch<K, T, R>) -> Self {
+
+		assert!(batch1.upper() == batch2.lower());
+
+		let since = if batch1.description().since().iter().all(|t1| batch2.description().since().iter().any(|t2| t2.less_equal(t1))) {
+			batch2.description().since()
+		}
+		else {
+			batch1.description().since()
+		};
+
+		let description = Description::new(batch1.lower(), batch2.upper(), since);
+
+		OrdKeyMerger {
+			lower1: 0,
+			upper1: batch1.layer.keys(),
+			lower2: 0,
+			upper2: batch2.layer.keys(),
+			result: <<OrderedLayer<K, OrderedLeaf<T, R>> as Trie>::MergeBuilder as MergeBuilder>::with_capacity(&batch1.layer, &batch2.layer),
+			description: description,
+		}
+	}
+	fn done(self) -> OrdKeyBatch<K, T, R> {
+
+		assert!(self.lower1 == self.upper1);
+		assert!(self.lower2 == self.upper2);
+
+		OrdKeyBatch {
+			layer: self.result.done(),
+			desc: self.description,
+		}
+	}
+	fn work(&mut self, source1: &OrdKeyBatch<K,T,R>, source2: &OrdKeyBatch<K,T,R>, frontier: &Option<Vec<T>>, fuel: &mut isize) {
+
+		let starting_updates = self.result.vals.vals.len();
+		let mut effort = 0isize;
+
+		let initial_key_pos = self.result.keys.len();
+
+		// while both mergees are still active
+		while self.lower1 < self.upper1 && self.lower2 < self.upper2 && effort < *fuel {
+			self.result.merge_step((&source1.layer, &mut self.lower1, self.upper1), (&source2.layer, &mut self.lower2, self.upper2));
+			effort = (self.result.vals.vals.len() - starting_updates) as isize;
+		}
+
+		// if self.lower1 == self.upper1 || self.lower2 == self.upper2 {
+		// 	// these are just copies, so let's bite the bullet and just do them.
+		// 	if self.lower1 < self.upper1 { self.result.copy_range(&source1.layer, self.lower1, self.upper1); self.lower1 = self.upper1; }
+		// 	if self.lower2 < self.upper2 { self.result.copy_range(&source2.layer, self.lower2, self.upper2); self.lower2 = self.upper2; }
+		// }
+        // Merging is complete; only copying remains. Copying is probably faster than merging, so could take some liberties here.
+		if self.lower1 == self.upper1 || self.lower2 == self.upper2 {
+            // Limit merging by remaining fuel.
+            let remaining_fuel = *fuel - effort;
+            if remaining_fuel > 0 {
+                if self.lower1 < self.upper1 {
+                    let mut to_copy = remaining_fuel as usize;
+                    if to_copy < 1_000 { to_copy = 1_000; }
+                    if to_copy > (self.upper1 - self.lower1) { to_copy = self.upper1 - self.lower1; }
+                    self.result.copy_range(&source1.layer, self.lower1, self.lower1 + to_copy);
+                    self.lower1 += to_copy;
+                }
+                if self.lower2 < self.upper2 {
+                    // self.result.copy_range(&source2.layer, self.lower2, self.upper2); self.lower2 = self.upper2;
+                    let mut to_copy = remaining_fuel as usize;
+                    if to_copy < 1_000 { to_copy = 1_000; }
+                    if to_copy > (self.upper2 - self.lower2) { to_copy = self.upper2 - self.lower2; }
+                    self.result.copy_range(&source2.layer, self.lower2, self.lower2 + to_copy);
+                    self.lower2 += to_copy;
+                }
+            }
+		}
+
+
+        effort = (self.result.vals.vals.len() - starting_updates) as isize;
+
+		if let Some(frontier) = frontier.as_ref() {
+			OrdKeyBatch::advance_builder_from(&mut self.result, frontier, initial_key_pos);
+		}
+
+        *fuel -= effort;
+
+        if *fuel < -1_000_000 {
+            println!("Massive deficit OrdKey::work: {}", fuel);
+        }
+	}
+}
+
+
+/// A cursor for navigating a single layer.
+#[derive(Debug)]
+pub struct OrdKeyCursor<T: Lattice+Ord+Clone, R: Semigroup> {
+	valid: bool,
+	empty: (),
+	cursor: OrderedCursor<OrderedLeaf<T, R>>,
+}
+
+impl<K: Ord+Clone, T: Lattice+Ord+Clone, R: Semigroup> Cursor<K, (), T, R> for OrdKeyCursor<T, R> {
+
+	type Storage = OrdKeyBatch<K, T, R>;
+
+	fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { &self.cursor.key(&storage.layer) }
+	fn val<'a>(&self, _storage: &'a Self::Storage) -> &'a () { unsafe { ::std::mem::transmute(&self.empty) } }
+	fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+		self.cursor.child.rewind(&storage.layer.vals);
+		while self.cursor.child.valid(&storage.layer.vals) {
+			logic(&self.cursor.child.key(&storage.layer.vals).0, &self.cursor.child.key(&storage.layer.vals).1);
+			self.cursor.child.step(&storage.layer.vals);
+		}
+	}
+	fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.valid(&storage.layer) }
+	fn val_valid(&self, _storage: &Self::Storage) -> bool { self.valid }
+	fn step_key(&mut self, storage: &Self::Storage){ self.cursor.step(&storage.layer); self.valid = true; }
+	fn seek_key(&mut self, storage: &Self::Storage, key: &K) { self.cursor.seek(&storage.layer, key); self.valid = true; }
+	fn step_val(&mut self, _storage: &Self::Storage) { self.valid = false; }
+	fn seek_val(&mut self, _storage: &Self::Storage, _val: &()) { }
+	fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind(&storage.layer); self.valid = true; }
+	fn rewind_vals(&mut self, _storage: &Self::Storage) { self.valid = true; }
+}
+
+
+/// A builder for creating layers from unsorted update tuples.
+pub struct OrdKeyBuilder<K: Ord, T: Ord+Lattice, R: Semigroup> {
+	builder: OrderedBuilder<K, OrderedLeafBuilder<T, R>>,
+}
+
+impl<K, T, R> Builder<K, (), T, R, OrdKeyBatch<K, T, R>> for OrdKeyBuilder<K, T, R>
+where K: Ord+Clone+'static, T: Lattice+Ord+Clone+'static, R: Semigroup {
+
+	fn new() -> Self {
+		OrdKeyBuilder {
+			builder: OrderedBuilder::<K, OrderedLeafBuilder<T, R>>::new()
+		}
+	}
+
+	fn with_capacity(cap: usize) -> Self {
+		OrdKeyBuilder {
+			builder: <OrderedBuilder<K, OrderedLeafBuilder<T, R>> as TupleBuilder>::with_capacity(cap)
+		}
+	}
+
+	#[inline]
+	fn push(&mut self, (key, _, time, diff): (K, (), T, R)) {
+		self.builder.push_tuple((key, (time, diff)));
+	}
+
+	#[inline(never)]
+	fn done(self, lower: &[T], upper: &[T], since: &[T]) -> OrdKeyBatch<K, T, R> {
+		OrdKeyBatch {
+			layer: self.builder.done(),
+			desc: Description::new(lower, upper, since)
+		}
+	}
+}

--- a/src/trace/layers/mod.rs
+++ b/src/trace/layers/mod.rs
@@ -5,6 +5,7 @@
 //! to single elements in the layer above.
 
 pub mod ordered;
+pub mod ordered32;
 pub mod ordered_leaf;
 // pub mod hashed;
 // pub mod weighted;

--- a/src/trace/layers/ordered32.rs
+++ b/src/trace/layers/ordered32.rs
@@ -1,0 +1,235 @@
+//! Implementation using ordered keys and exponential search.
+
+use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, advance};
+
+/// A level of the trie, with keys and offsets into a lower layer.
+///
+/// In this representation, the values for `keys[i]` are found at `vals[offs[i] .. offs[i+1]]`.
+#[derive(Debug, Eq, PartialEq, Clone, Abomonation)]
+pub struct OrderedLayer<K: Ord, L> {
+	/// The keys of the layer.
+	pub keys: Vec<K>,
+	/// The offsets associate with each key.
+	///
+	/// The bounds for `keys[i]` are `(offs[i], offs[i+1]`). The offset array is guaranteed to be one
+	/// element longer than the keys array, ensuring that these accesses do not panic.
+	pub offs: Vec<u32>,
+	/// The ranges of values associated with the keys.
+	pub vals: L,
+}
+
+impl<K: Ord+Clone, L: Trie> Trie for OrderedLayer<K, L> {
+	type Item = (K, L::Item);
+	type Cursor = OrderedCursor<L>;
+	type MergeBuilder = OrderedBuilder<K, L::MergeBuilder>;
+	type TupleBuilder = OrderedBuilder<K, L::TupleBuilder>;
+
+	fn keys(&self) -> usize { self.keys.len() }
+	fn tuples(&self) -> usize { self.vals.tuples() }
+	fn cursor_from(&self, lower: usize, upper: usize) -> Self::Cursor {
+
+		if lower < upper {
+
+			let child_lower = self.offs[lower];
+			let child_upper = self.offs[lower + 1];
+			OrderedCursor {
+				bounds: (lower, upper),
+				child: self.vals.cursor_from(child_lower as usize, child_upper as usize),
+				pos: lower,
+			}
+		}
+		else {
+			OrderedCursor {
+				bounds: (0, 0),
+				child: self.vals.cursor_from(0, 0),
+				pos: 0,
+			}
+		}
+	}
+}
+
+/// Assembles a layer of this
+pub struct OrderedBuilder<K: Ord, L> {
+	/// Keys
+	pub keys: Vec<K>,
+	/// Offsets
+	pub offs: Vec<u32>,
+	/// The next layer down
+	pub vals: L,
+}
+
+impl<K: Ord+Clone, L: Builder> Builder for OrderedBuilder<K, L> {
+	type Trie = OrderedLayer<K, L::Trie>;
+	fn boundary(&mut self) -> usize {
+		self.offs[self.keys.len()] = self.vals.boundary() as u32;
+		self.keys.len()
+	}
+	fn done(mut self) -> Self::Trie {
+		if self.keys.len() > 0 && self.offs[self.keys.len()] == 0 {
+			self.offs[self.keys.len()] = self.vals.boundary() as u32;
+		}
+		OrderedLayer {
+			keys: self.keys,
+			offs: self.offs,
+			vals: self.vals.done(),
+		}
+	}
+}
+
+impl<K: Ord+Clone, L: MergeBuilder> MergeBuilder for OrderedBuilder<K, L> {
+	fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
+		let mut offs = Vec::with_capacity(other1.keys() + other2.keys() + 1);
+		offs.push(0);
+		OrderedBuilder {
+			keys: Vec::with_capacity(other1.keys() + other2.keys()),
+			offs: offs,
+			vals: L::with_capacity(&other1.vals, &other2.vals),
+		}
+	}
+	#[inline]
+	fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
+		debug_assert!(lower < upper);
+		let other_basis = other.offs[lower];
+		let self_basis = self.offs.last().map(|&x| x).unwrap_or(0);
+
+		self.keys.extend_from_slice(&other.keys[lower .. upper]);
+		for index in lower .. upper {
+			self.offs.push((other.offs[index + 1] + self_basis) - other_basis);
+		}
+		self.vals.copy_range(&other.vals, other_basis as usize, other.offs[upper] as usize);
+	}
+
+	fn push_merge(&mut self, other1: (&Self::Trie, usize, usize), other2: (&Self::Trie, usize, usize)) -> usize {
+		let (trie1, mut lower1, upper1) = other1;
+		let (trie2, mut lower2, upper2) = other2;
+
+		self.keys.reserve((upper1 - lower1) + (upper2 - lower2));
+
+		// while both mergees are still active
+		while lower1 < upper1 && lower2 < upper2 {
+			self.merge_step((trie1, &mut lower1, upper1), (trie2, &mut lower2, upper2));
+		}
+
+		if lower1 < upper1 { self.copy_range(trie1, lower1, upper1); }
+		if lower2 < upper2 { self.copy_range(trie2, lower2, upper2); }
+
+		self.keys.len()
+	}
+}
+
+impl<K: Ord+Clone, L: MergeBuilder> OrderedBuilder<K, L> {
+
+	/// Performs one step of merging.
+	#[inline]
+	pub fn merge_step(&mut self, other1: (&<Self as Builder>::Trie, &mut usize, usize), other2: (&<Self as Builder>::Trie, &mut usize, usize)) {
+
+		let (trie1, lower1, upper1) = other1;
+		let (trie2, lower2, upper2) = other2;
+
+		match trie1.keys[*lower1].cmp(&trie2.keys[*lower2]) {
+			::std::cmp::Ordering::Less => {
+				// determine how far we can advance lower1 until we reach/pass lower2
+				let step = 1 + advance(&trie1.keys[(1 + *lower1)..upper1], |x| x < &trie2.keys[*lower2]);
+                let step = std::cmp::min(step, 1_000);
+				self.copy_range(trie1, *lower1, *lower1 + step);
+				*lower1 += step;
+			},
+			::std::cmp::Ordering::Equal => {
+				let lower = self.vals.boundary();
+				// record vals_length so we can tell if anything was pushed.
+				let upper = self.vals.push_merge(
+					(&trie1.vals, trie1.offs[*lower1] as usize, trie1.offs[*lower1 + 1] as usize),
+					(&trie2.vals, trie2.offs[*lower2] as usize, trie2.offs[*lower2 + 1] as usize)
+				);
+				if upper > lower {
+					self.keys.push(trie1.keys[*lower1].clone());
+					self.offs.push(upper as u32);
+				}
+
+				*lower1 += 1;
+				*lower2 += 1;
+			},
+			::std::cmp::Ordering::Greater => {
+				// determine how far we can advance lower2 until we reach/pass lower1
+				let step = 1 + advance(&trie2.keys[(1 + *lower2)..upper2], |x| x < &trie1.keys[*lower1]);
+                let step = std::cmp::min(step, 1_000);
+				self.copy_range(trie2, *lower2, *lower2 + step);
+				*lower2 += step;
+			},
+		}
+	}
+}
+
+impl<K: Ord+Clone, L: TupleBuilder> TupleBuilder for OrderedBuilder<K, L> {
+
+	type Item = (K, L::Item);
+	fn new() -> Self { OrderedBuilder { keys: Vec::new(), offs: vec![0], vals: L::new() } }
+	fn with_capacity(cap: usize) -> Self {
+		let mut offs = Vec::with_capacity(cap + 1);
+		offs.push(0);
+		OrderedBuilder{
+			keys: Vec::with_capacity(cap),
+			offs: offs,
+			vals: L::with_capacity(cap),
+		}
+	}
+	#[inline]
+	fn push_tuple(&mut self, (key, val): (K, L::Item)) {
+
+		// if first element, prior element finish, or different element, need to push and maybe punctuate.
+		if self.keys.len() == 0 || self.offs[self.keys.len()] != 0 || self.keys[self.keys.len()-1] != key {
+			if self.keys.len() > 0 && self.offs[self.keys.len()] == 0 {
+				self.offs[self.keys.len()] = self.vals.boundary() as u32;
+			}
+			self.keys.push(key);
+			self.offs.push(0);		// <-- indicates "unfinished".
+		}
+		self.vals.push_tuple(val);
+	}
+}
+
+/// A cursor with a child cursor that is updated as we move.
+#[derive(Debug)]
+pub struct OrderedCursor<L: Trie> {
+	// keys: OwningRef<Rc<Erased>, [K]>,
+	// offs: OwningRef<Rc<Erased>, [usize]>,
+	pos: usize,
+	bounds: (usize, usize),
+	/// The cursor for the trie layer below this one.
+	pub child: L::Cursor,
+}
+
+impl<K: Ord, L: Trie> Cursor<OrderedLayer<K, L>> for OrderedCursor<L> {
+	type Key = K;
+	fn key<'a>(&self, storage: &'a OrderedLayer<K, L>) -> &'a Self::Key { &storage.keys[self.pos] }
+	fn step(&mut self, storage: &OrderedLayer<K, L>) {
+		self.pos += 1;
+		if self.valid(storage) {
+			self.child.reposition(&storage.vals, storage.offs[self.pos] as usize, storage.offs[self.pos + 1] as usize);
+		}
+		else {
+			self.pos = self.bounds.1;
+		}
+	}
+	fn seek(&mut self, storage: &OrderedLayer<K, L>, key: &Self::Key) {
+		self.pos += advance(&storage.keys[self.pos .. self.bounds.1], |k| k.lt(key));
+		if self.valid(storage) {
+			self.child.reposition(&storage.vals, storage.offs[self.pos] as usize, storage.offs[self.pos + 1] as usize);
+		}
+	}
+	// fn size(&self) -> usize { self.bounds.1 - self.bounds.0 }
+	fn valid(&self, _storage: &OrderedLayer<K, L>) -> bool { self.pos < self.bounds.1 }
+	fn rewind(&mut self, storage: &OrderedLayer<K, L>) {
+		self.pos = self.bounds.0;
+		if self.valid(storage) {
+			self.child.reposition(&storage.vals, storage.offs[self.pos] as usize, storage.offs[self.pos + 1] as usize);
+		}
+	}
+	fn reposition(&mut self, storage: &OrderedLayer<K, L>, lower: usize, upper: usize) {
+		self.pos = lower;
+		self.bounds = (lower, upper);
+		if self.valid(storage) {
+			self.child.reposition(&storage.vals, storage.offs[self.pos] as usize, storage.offs[self.pos + 1] as usize);
+		}
+	}
+}


### PR DESCRIPTION
This PR adds an `ord32` alternative to the `ord` trace implementation, one which uses `u32` values for array offsets rather than `usize` values. This restricts each batch to at most 4 billion elements, which is plausible for several use cases.

cc @ryzhyk