### PR TITLE
Generalize output of distinct

### DIFF
--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -153,7 +153,16 @@ pub trait Threshold<G: Scope, K: Data, R1: Semigroup> where G::Timestamp: Lattic
     /// }
     /// ```
     fn distinct(&self) -> Collection<G, K, isize> {
-        self.threshold_named("Distinct", |_,c| if c.is_zero() { 0 } else { 1 })
+        self.distinct_core()
+    }
+
+    /// Distinct for general integer differences.
+    ///
+    /// This method allows `distinct` to produce collections whose difference
+    /// type is something other than an `isize` integer, for example perhaps an
+    /// `i32`.
+    fn distinct_core<R2: Abelian+From<i8>>(&self) -> Collection<G, K, R2> {
+        self.threshold_named("Distinct", |_,_| R2::from(1i8))
     }
 }
 

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -64,8 +64,18 @@ pub trait ThresholdTotal<G: Scope, K: ExchangeData, R: ExchangeData+Semigroup> w
     /// }
     /// ```
     fn distinct_total(&self) -> Collection<G, K, isize> {
-        self.threshold_total(|_,c| if c.is_zero() { 0isize } else { 1isize })
+        self.distinct_total_core()
     }
+
+    /// Distinct for general integer differences.
+    ///
+    /// This method allows `distinct` to produce collections whose difference
+    /// type is something other than an `isize` integer, for example perhaps an
+    /// `i32`.
+    fn distinct_total_core<R2: Abelian+From<i8>>(&self) -> Collection<G, K, R2> {
+        self.threshold_total(|_,_| R2::from(1i8))
+    }
+
 }
 
 impl<G: Scope, K: ExchangeData+Hashable, R: ExchangeData+Semigroup> ThresholdTotal<G, K, R> for Collection<G, K, R>


### PR DESCRIPTION
Light changes to `distinct` to allow general integer output difference types, for example `i32` for the memory-conscious computation. Similarly for `distinct_total`.