### PR TITLE
revise graspan

### DIFF
--- a/experiments/src/bin/graspan2.rs
+++ b/experiments/src/bin/graspan2.rs
@@ -13,10 +13,15 @@ use differential_dataflow::operators::iterate::Variable;
 use differential_dataflow::Collection;
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::*;
-use differential_dataflow::operators::arrange::ArrangeByKey;
+use differential_dataflow::operators::arrange::Arrange;
+use differential_dataflow::trace::implementations::ord::{OrdValSpine, OrdKeySpine};
 
-type Iter = u64;
-type Difference = i64;
+
+type Node = u32;
+type Time = ();
+type Iter = u32;
+type Diff = i32;
+type Offs = u32;
 
 fn main() {
     if std::env::args().any(|x| x == "optimized") {
@@ -36,19 +41,19 @@ fn unoptimized() {
         let peers = worker.peers();
         let index = worker.index();
 
-        let (mut a, mut d) = worker.dataflow::<(),_,_>(|scope| {
+        let (mut a, mut d) = worker.dataflow::<Time,_,_>(|scope| {
 
             // let timer = timer.clone();
 
-            let (a_handle, assignment) = scope.new_collection::<_,Difference>();
-            let (d_handle, dereference) = scope.new_collection::<_,Difference>();
+            let (a_handle, assignment) = scope.new_collection::<_,Diff>();
+            let (d_handle, dereference) = scope.new_collection::<_,Diff>();
 
             let nodes =
             assignment
                 .flat_map(|(a,b)| vec![a,b])
                 .concat(&dereference.flat_map(|(a,b)| vec![a,b]));
 
-            let dereference = dereference.arrange_by_key();
+            let dereference = dereference.arrange::<OrdValSpine<_,_,_,_,Offs>>();
 
             let (value_flow, memory_alias, value_alias) =
             scope
@@ -58,30 +63,20 @@ fn unoptimized() {
                     let assignment = assignment.enter(scope);
                     let dereference = dereference.enter(scope);
 
-                    // let value_flow = CoreVariable::<_,_,Difference,_>::from_args(Iter::max_value(), 1, nodes.filter(|_| false).map(|n| (n,n)));
-                    // let memory_alias = CoreVariable::<_,_,Difference,_>::from_args(Iter::max_value(), 1, nodes.filter(|_| false).map(|n| (n,n)));
-                    // let value_alias = CoreVariable::<_,_,Difference,_>::from_args(Iter::max_value(), 1, nodes.filter(|_| false).map(|n| (n,n)));
-
                     let value_flow = Variable::new(scope, Product::new(Default::default(), 1));
                     let memory_alias = Variable::new(scope, Product::new(Default::default(), 1));
                     // let value_alias = Variable::from(nodes.filter(|_| false).map(|n| (n,n)));
 
-                    let value_flow_arranged = value_flow.arrange_by_key();
-                    let memory_alias_arranged = memory_alias.arrange_by_key();
+                    let value_flow_arranged = value_flow.arrange::<OrdValSpine<_,_,_,_,Offs>>();
+                    let memory_alias_arranged = memory_alias.arrange::<OrdValSpine<_,_,_,_,Offs>>();
 
                     // VA(a,b) <- VF(x,a),VF(x,b)
                     // VA(a,b) <- VF(x,a),MA(x,y),VF(y,b)
                     let value_alias_next = value_flow_arranged.join_core(&value_flow_arranged, |_,&a,&b| Some((a,b)));
                     let value_alias_next = value_flow_arranged.join_core(&memory_alias_arranged, |_,&a,&b| Some((b,a)))
+                                                              .arrange::<OrdValSpine<_,_,_,_,Offs>>()
                                                               .join_core(&value_flow_arranged, |_,&a,&b| Some((a,b)))
                                                               .concat(&value_alias_next);
-
-                    // value_alias_next.map(|_|()).consolidate().inspect(|x| println!("VA-total: {:?}", x.2));
-
-                    // let value_alias_next =
-                    // value_alias_next
-                    //     .threshold_total(|x| if x > 0 { 1 as Difference } else { 0 });
-
 
                     // VF(a,a) <-
                     // VF(a,b) <- A(a,x),VF(x,b)
@@ -89,35 +84,34 @@ fn unoptimized() {
                     let value_flow_next =
                     assignment
                         .map(|(a,b)| (b,a))
+                        .arrange::<OrdValSpine<_,_,_,_,Offs>>()
                         .join_core(&memory_alias_arranged, |_,&a,&b| Some((b,a)))
                         .concat(&assignment.map(|(a,b)| (b,a)))
+                        .arrange::<OrdValSpine<_,_,_,_,Offs>>()
                         .join_core(&value_flow_arranged, |_,&a,&b| Some((a,b)))
                         .concat(&nodes.map(|n| (n,n)));
 
-                    // value_flow_next.map(|_|()).consolidate().inspect(|x| println!("VF-total: {:?}", x.2));
-
                     let value_flow_next =
                     value_flow_next
-                        .threshold_total(|_,_| 1 as Difference);
+                        .arrange::<OrdKeySpine<_,_,_,Offs>>()
+                        .distinct_total_core::<Diff>();
 
                     // MA(a,b) <- D(x,a),VA(x,y),D(y,b)
-                    let memory_alias_next: Collection<_,_,Difference> =
+                    let memory_alias_next: Collection<_,_,Diff> =
                     value_alias_next
                         .join_core(&dereference, |_x,&y,&a| Some((y,a)))
+                        .arrange::<OrdValSpine<_,_,_,_,Offs>>()
                         .join_core(&dereference, |_y,&a,&b| Some((a,b)));
 
-                    // memory_alias_next.map(|_|()).consolidate().inspect(|x| println!("MA-total: {:?}", x.2));
-
-                    let memory_alias_next: Collection<_,_,Difference>  =
+                    let memory_alias_next: Collection<_,_,Diff>  =
                     memory_alias_next
-                        .threshold_total(|_,_| 1 as Difference);
+                        .arrange::<OrdKeySpine<_,_,_,Offs>>()
+                        .distinct_total_core::<Diff>();
 
                     value_flow.set(&value_flow_next);
                     memory_alias.set(&memory_alias_next);
-                    // value_alias.set(&value_alias_next);
 
                     (value_flow_next.leave(), memory_alias_next.leave(), value_alias_next.leave())
-
                 });
 
                 value_flow.map(|_| ()).consolidate().inspect(|x| println!("VF: {:?}", x));
@@ -136,9 +130,9 @@ fn unoptimized() {
             let line = readline.ok().expect("read error");
             if !line.starts_with('#') && line.len() > 0 {
                 let mut elts = line[..].split_whitespace();
-                let src: u32 = elts.next().unwrap().parse().ok().expect("malformed src");
+                let src: Node = elts.next().unwrap().parse().ok().expect("malformed src");
                 if (src as usize) % peers == index {
-                    let dst: u32 = elts.next().unwrap().parse().ok().expect("malformed dst");
+                    let dst: Node = elts.next().unwrap().parse().ok().expect("malformed dst");
                     let typ: &str = elts.next().unwrap();
                     match typ {
                         // "a" => { a.insert((src, dst)); },
@@ -182,7 +176,7 @@ fn optimized() {
                 .flat_map(|(a,b)| vec![a,b])
                 .concat(&dereference.flat_map(|(a,b)| vec![a,b]));
 
-            let dereference = dereference.arrange_by_key();
+            let dereference = dereference.arrange::<OrdValSpine<_,_,_,_,u32>>();
 
             let (value_flow, memory_alias) =
             scope
@@ -195,8 +189,8 @@ fn optimized() {
                     let value_flow = Variable::new(scope, Product::new(Default::default(), 1));
                     let memory_alias = Variable::new(scope, Product::new(Default::default(), 1));
 
-                    let value_flow_arranged = value_flow.arrange_by_key();
-                    let memory_alias_arranged = memory_alias.arrange_by_key();
+                    let value_flow_arranged = value_flow.arrange::<OrdValSpine<_,_,_,_,u32>>();
+                    let memory_alias_arranged = memory_alias.arrange::<OrdValSpine<_,_,_,_,u32>>();
 
                     // VF(a,a) <-
                     // VF(a,b) <- A(a,x),VF(x,b)
@@ -204,18 +198,22 @@ fn optimized() {
                     let value_flow_next =
                     assignment
                         .map(|(a,b)| (b,a))
+                        .arrange::<OrdValSpine<_,_,_,_,u32>>()
                         .join_core(&memory_alias_arranged, |_,&a,&b| Some((b,a)))
                         .concat(&assignment.map(|(a,b)| (b,a)))
+                        .arrange::<OrdValSpine<_,_,_,_,u32>>()
                         .join_core(&value_flow_arranged, |_,&a,&b| Some((a,b)))
                         .concat(&nodes.map(|n| (n,n)))
-                        .distinct_total();
+                        .arrange::<OrdKeySpine<_,_,_,u32>>()
+                        .distinct_total_core::<Diff>();
 
                     // VFD(a,b) <- VF(a,x),D(x,b)
                     let value_flow_deref =
                     value_flow
                         .map(|(a,b)| (b,a))
+                        .arrange::<OrdValSpine<_,_,_,_,u32>>()
                         .join_core(&dereference, |_x,&a,&b| Some((a,b)))
-                        .arrange_by_key();
+                        .arrange::<OrdValSpine<_,_,_,_,u32>>();
 
                     // MA(a,b) <- VFD(x,a),VFD(y,b)
                     // MA(a,b) <- VFD(x,a),MA(x,y),VFD(y,b)
@@ -226,15 +224,16 @@ fn optimized() {
                     let memory_alias_next =
                     memory_alias_arranged
                         .join_core(&value_flow_deref, |_x,&y,&a| Some((y,a)))
+                        .arrange::<OrdValSpine<_,_,_,_,u32>>()
                         .join_core(&value_flow_deref, |_y,&a,&b| Some((a,b)))
                         .concat(&memory_alias_next)
-                        .distinct_total();
+                        .arrange::<OrdKeySpine<_,_,_,u32>>()
+                        .distinct_total_core::<Diff>();
 
                     value_flow.set(&value_flow_next);
                     memory_alias.set(&memory_alias_next);
 
                     (value_flow_next.leave(), memory_alias_next.leave())
-
                 });
 
                 value_flow.map(|_| ()).consolidate().inspect(|x| println!("VF: {:?}", x));
@@ -252,13 +251,13 @@ fn optimized() {
             let line = readline.ok().expect("read error");
             if !line.starts_with('#') && line.len() > 0 {
                 let mut elts = line[..].split_whitespace();
-                let src: u32 = elts.next().unwrap().parse().ok().expect("malformed src");
+                let src: Node = elts.next().unwrap().parse().ok().expect("malformed src");
                 if (src as usize) % peers == index {
-                    let dst: u32 = elts.next().unwrap().parse().ok().expect("malformed dst");
+                    let dst: Node = elts.next().unwrap().parse().ok().expect("malformed dst");
                     let typ: &str = elts.next().unwrap();
                     match typ {
-                        "a" => { a.insert((src, dst)); },
-                        "d" => { d.insert((src, dst)); },
+                        "a" => { a.update((src, dst), 1 as Diff); },
+                        "d" => { d.update((src, dst), 1 as Diff); },
                         _ => { },
                     }
                 }


### PR DESCRIPTION
This PR revises the two graspan implementations to track current differential dataflow idioms, including the ability to parameterize the types used in internal structures. There remains the potential improvement of using an empty `Diff` type to indicate `Present`, which will involve the improvement of the total order operators.