### PR TITLE
Log arrangement sharing

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -84,8 +84,6 @@ pub struct MergeShortfall {
 
 impl From<MergeShortfall> for DifferentialEvent { fn from(e: MergeShortfall) -> Self { DifferentialEvent::MergeShortfall(e) } }
 
-
-
 /// Either the start or end of a merge event.
 #[derive(Debug, Clone, Abomonation, Ord, PartialOrd, Eq, PartialEq)]
 pub struct TraceShare {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -27,6 +27,8 @@ pub enum DifferentialEvent {
     Drop(DropEvent),
     /// A merge failed to complete in time.
     MergeShortfall(MergeShortfall),
+    /// Trace sharing event.
+    TraceShare(TraceShare),
 }
 
 /// Either the start or end of a merge event.
@@ -81,3 +83,16 @@ pub struct MergeShortfall {
 }
 
 impl From<MergeShortfall> for DifferentialEvent { fn from(e: MergeShortfall) -> Self { DifferentialEvent::MergeShortfall(e) } }
+
+
+
+/// Either the start or end of a merge event.
+#[derive(Debug, Clone, Abomonation, Ord, PartialOrd, Eq, PartialEq)]
+pub struct TraceShare {
+    /// Operator identifier.
+    pub operator: usize,
+    /// Change in number of shares.
+    pub diff: isize,
+}
+
+impl From<TraceShare> for DifferentialEvent { fn from(e: TraceShare) -> Self { DifferentialEvent::TraceShare(e) } }

--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -37,7 +37,7 @@ where
     advance: Vec<Tr::Time>,
     through: Vec<Tr::Time>,
 
-    info: ::timely::dataflow::operators::generic::OperatorInfo,
+    operator: ::timely::dataflow::operators::generic::OperatorInfo,
     logging: Option<::logging::Logger>,
 }
 
@@ -82,7 +82,7 @@ where
     Tr::Time: Timestamp+Lattice,
 {
     /// Creates a new agent from a trace reader.
-    pub fn new(trace: Tr, info: ::timely::dataflow::operators::generic::OperatorInfo, logging: Option<::logging::Logger>) -> (Self, TraceWriter<Tr>)
+    pub fn new(trace: Tr, operator: ::timely::dataflow::operators::generic::OperatorInfo, logging: Option<::logging::Logger>) -> (Self, TraceWriter<Tr>)
     where
         Tr: Trace,
         Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
@@ -92,7 +92,7 @@ where
 
         if let Some(logging) = &logging {
             logging.log(
-                ::logging::TraceShare { operator: info.global_id, diff: 1 }
+                ::logging::TraceShare { operator: operator.global_id, diff: 1 }
             );
         }
 
@@ -101,7 +101,7 @@ where
             queues: Rc::downgrade(&queues),
             advance: trace.borrow().advance_frontiers.frontier().to_vec(),
             through: trace.borrow().through_frontiers.frontier().to_vec(),
-            info,
+            operator,
             logging,
         };
 
@@ -524,7 +524,7 @@ where
 
         if let Some(logging) = &self.logging {
             logging.log(
-                ::logging::TraceShare { operator: self.info.global_id, diff: 1 }
+                ::logging::TraceShare { operator: self.operator.global_id, diff: 1 }
             );
         }
 
@@ -537,7 +537,7 @@ where
             queues: self.queues.clone(),
             advance: self.advance.clone(),
             through: self.through.clone(),
-            info: self.info.clone(),
+            operator: self.operator.clone(),
             logging: self.logging.clone(),
         }
     }
@@ -554,7 +554,7 @@ where
 
         if let Some(logging) = &self.logging {
             logging.log(
-                ::logging::TraceShare { operator: self.info.global_id, diff: -1 }
+                ::logging::TraceShare { operator: self.operator.global_id, diff: -1 }
             );
         }
 

--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -543,7 +543,6 @@ where
     }
 }
 
-
 impl<Tr> Drop for TraceAgent<Tr>
 where
     Tr: TraceReader,
@@ -551,13 +550,11 @@ where
 {
     fn drop(&mut self) {
 
-
         if let Some(logging) = &self.logging {
             logging.log(
                 ::logging::TraceShare { operator: self.operator.global_id, diff: -1 }
             );
         }
-
 
         // decrement borrow counts to remove all holds
         self.trace.borrow_mut().adjust_advance_frontier(&self.advance[..], &[]);

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -539,8 +539,8 @@ where
 
                 let mut buffer = Vec::new();
 
-                let empty_trace = Tr::new(_info, logger);
-                let (reader_local, mut writer) = TraceAgent::new(empty_trace);
+                let empty_trace = Tr::new(_info.clone(), logger.clone());
+                let (reader_local, mut writer) = TraceAgent::new(empty_trace, _info, logger);
                 *reader = Some(reader_local);
 
                 // Initialize to the minimal input frontier.

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -354,11 +354,10 @@ where
                     register.get::<::logging::DifferentialEvent>("differential/arrange")
                 };
 
-                let empty = T2::new(operator_info, logger);
+                let empty = T2::new(operator_info.clone(), logger.clone());
                 let mut source_trace = self.trace.clone();
 
-
-                let (mut output_reader, mut output_writer) = TraceAgent::new(empty);
+                let (mut output_reader, mut output_writer) = TraceAgent::new(empty, operator_info, logger);
 
                 // let mut output_trace = TraceRc::make_from(agent).0;
                 *result_trace = Some(output_reader.clone());


### PR DESCRIPTION
This PR introduces logging statements in the construction, clone, and drop of the `TraceAgent` type, which logs the wrapped operator id and a signed integer indicating the change in occurrence count for the agent (plus one on construction and clone, minus one on drop).

This information is meant to allow introspection into the amount of re-use in the system, for diagnostic purposes (to see if sharing is effective, and to report the degree for celebration).

cc @comnik @utaal 