### PR TITLE
Cross empty batches better

### DIFF
--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -74,7 +74,7 @@ where
         let mut trace = self.trace.clone();
         let mut buffer = Vec::new();
 
-        self.stream.unary(Pipeline, "CountTotal", move |_,_| move |input, output| {
+        self.stream.unary_frontier(Pipeline, "CountTotal", move |_,_| move |input, output| {
 
             // tracks the upper limit of known-complete timestamps.
             let mut upper_limit = timely::progress::frontier::Antichain::from_elem(<G::Timestamp>::minimum());

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -112,7 +112,7 @@ where
         let mut trace = self.trace.clone();
         let mut buffer = Vec::new();
 
-        self.stream.unary(Pipeline, "ThresholdTotal", move |_,_| {
+        self.stream.unary_frontier(Pipeline, "ThresholdTotal", move |_,_| {
 
             // tracks the upper limit of known-complete timestamps.
             let mut upper_limit = timely::progress::frontier::Antichain::from_elem(<G::Timestamp>::minimum());

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -133,35 +133,20 @@ pub trait TraceReader {
 		});
 	}
 
-    /// Advances `upper` by any empty batches, as if they had been received.
+    /// Advances `upper` by any empty batches.
+    ///
+    /// An empty batch whose `batch.lower` bound equals the current
+    /// contents of `upper` will advance `upper` to `batch.upper`.
+    /// Taken across all batches, this should advance `upper` across
+    /// empty batch regions.
     fn advance_upper(&mut self, upper: &mut Antichain<Self::Time>)
     where
         Self::Time: Timestamp,
     {
-        let mut found = false;  // true once upper is found in a batch upper.
-        let mut cease = false;  // true once found, and then a non-empty batch.
-
         self.map_batches(|batch| {
-
-            // We should advance until we find the indicated upper bound.
-            // We then copy upper bounds from each subsequent empty batch.
-            // We stop as soon as we see a non-empty batch, without adopting
-            // its upper bound.
-
-            if !cease {
-                // Cease the once we've found our goal and then see a non-empty batch.
-                if found && !batch.is_empty() {
-                    cease = true;
-                }
-                // If we find the right upper bound, good for us!
-                if !found && batch.upper() == upper.elements() {
-                    found = true;
-                }
-                // Empty batches once found advance the frontier.
-                if batch.is_empty() && found {
-                    upper.clear();
-                    upper.extend(batch.upper().iter().cloned());
-                }
+            if batch.is_empty() && batch.lower() == upper.elements() {
+                upper.clear();
+                upper.extend(batch.upper().iter().cloned());
             }
         });
     }


### PR DESCRIPTION
This PR attempts to fix #219 which observes memory leaks if data are not inserted. What seems to have happened is that the logic for spanning empty batches erroneously started from the upper limit of batches, where it should have started from the lower limit of batches. This was everywhere correct except when the first batch is empty, in that we would fail to see it.

In addition, both `threshold_total` and `count_total` erroneously announced themselves as `unary` operators, which do not get progress notifications. This means that they would also stall on intervals of empty time. That has also been fixed.

cc @ryzhyk 