### PR TITLE
Change fn to fnmut

### DIFF
--- a/experiments/src/bin/graspan2.rs
+++ b/experiments/src/bin/graspan2.rs
@@ -146,13 +146,13 @@ fn unoptimized() {
             }
         }
 
-        if index == 0 { println!("{:?}:\tData loaded", timer.elapsed()); }
+        if index == 0 { println!("{:?}:\tData loaded", timer.elapsed().as_nanos()); }
 
         a.close();
         d.close();
         while worker.step() { }
 
-        if index == 0 { println!("{:?}:\tComputation complete", timer.elapsed()); }
+        if index == 0 { println!("{:?}:\tComputation complete", timer.elapsed().as_nanos()); }
     }).unwrap();
 }
 
@@ -270,13 +270,13 @@ fn optimized() {
             }
         }
 
-        if index == 0 { println!("{:?}:\tData loaded", timer.elapsed()); }
+        if index == 0 { println!("{:?}:\tData loaded", timer.elapsed().as_nanos()); }
 
         a.close();
         d.close();
         while worker.step() { }
 
-        if index == 0 { println!("{:?}:\tComputation complete", timer.elapsed()); }
+        if index == 0 { println!("{:?}:\tComputation complete", timer.elapsed().as_nanos()); }
 
     }).unwrap();
 }

--- a/src/algorithms/graphs/bijkstra.rs
+++ b/src/algorithms/graphs/bijkstra.rs
@@ -64,6 +64,9 @@ where
         let forward = Variable::new_from(goals.map(|(x,_)| (x.clone(),(x.clone(),0))).enter(inner), Product::new(Default::default(), 1));
         let reverse = Variable::new_from(goals.map(|(_,y)| (y.clone(),(y.clone(),0))).enter(inner), Product::new(Default::default(), 1));
 
+        forward.map(|_| ()).consolidate().inspect(|x| println!("forward: {:?}", x));
+        reverse.map(|_| ()).consolidate().inspect(|x| println!("reverse: {:?}", x));
+
         let goals = goals.enter(inner);
         // let edges = edges.enter(inner);
 
@@ -98,6 +101,8 @@ where
             .reduce(|_key, s, t| t.push((s[0].0.clone(), 1)))
             .map(|((next, src), dist)| (next, (src, dist)));
 
+        forward_next.map(|_| ()).consolidate().inspect(|x| println!("forward_next: {:?}", x));
+
         forward.set(&forward_next);
 
         // Let's expand out reverse queries that are active.
@@ -112,6 +117,8 @@ where
             .map(|(next, (rev, dist))| ((next, rev), dist))
             .reduce(|_key, s, t| t.push((s[0].0.clone(), 1)))
             .map(|((next,rev), dist)| (next, (rev, dist)));
+
+        reverse_next.map(|_| ()).consolidate().inspect(|x| println!("reverse_next: {:?}", x));
 
         reverse.set(&reverse_next);
 

--- a/src/algorithms/graphs/propagate.rs
+++ b/src/algorithms/graphs/propagate.rs
@@ -43,7 +43,7 @@ where
     R: Mul<R, Output=R>,
     R: From<i8>,
     L: ExchangeData,
-    F: Fn(&L)->u64+'static,
+    F: Fn(&L)->u64+Clone+'static,
 {
     propagate_core(&edges.arrange_by_key(), nodes, logic)
 }
@@ -68,7 +68,7 @@ where
     Tr: TraceReader<Key=N, Val=N, Time=G::Timestamp, R=R>+Clone+'static,
     Tr::Batch: crate::trace::BatchReader<N, N, G::Timestamp, Tr::R>+'static,
     Tr::Cursor: crate::trace::Cursor<N, N, G::Timestamp, Tr::R>+'static,
-    F: Fn(&L)->u64+'static,
+    F: Fn(&L)->u64+Clone+'static,
 {
     // Morally the code performs the following iterative computation. However, in the interest of a simplified
     // dataflow graph and reduced memory footprint we instead have a wordier version below. The core differences

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -17,7 +17,6 @@
 //! see ill-defined data at times for which the trace is not complete. (All current implementations
 //! commit only completed data to the trace).
 
-use std::rc::Rc;
 use std::default::Default;
 
 use timely::dataflow::operators::{Enter, Map};
@@ -142,12 +141,13 @@ where
             Tr::R: 'static,
             G::Timestamp: Clone+Default+'static,
             TInner: Refines<G::Timestamp>+Lattice+Timestamp+Clone+Default+'static,
-            F: Fn(&Tr::Key, &Tr::Val, &G::Timestamp)->TInner+'static,
+            F: FnMut(&Tr::Key, &Tr::Val, &G::Timestamp)->TInner+Clone+'static,
     {
-        let logic = Rc::new(logic);
+        let logic1 = logic.clone();
+        let logic2 = logic.clone();
         Arranged {
-            trace: TraceEnterAt::make_from(self.trace.clone(), logic.clone()),
-            stream: self.stream.enter(child).map(move |bw| BatchEnterAt::make_from(bw, logic.clone())),
+            trace: TraceEnterAt::make_from(self.trace.clone(), logic1),
+            stream: self.stream.enter(child).map(move |bw| BatchEnterAt::make_from(bw, logic2.clone())),
         }
     }
 
@@ -189,12 +189,13 @@ where
             Tr::Val: 'static,
             Tr::R: 'static,
             G::Timestamp: Clone+Default+'static,
-            F: Fn(&Tr::Key, &Tr::Val)->bool+'static,
+            F: FnMut(&Tr::Key, &Tr::Val)->bool+Clone+'static,
     {
-        let logic = Rc::new(logic);
+        let logic1 = logic.clone();
+        let logic2 = logic.clone();
         Arranged {
-            trace: TraceFilter::make_from(self.trace.clone(), logic.clone()),
-            stream: self.stream.map(move |bw| BatchFilter::make_from(bw, logic.clone())),
+            trace: TraceFilter::make_from(self.trace.clone(), logic1),
+            stream: self.stream.map(move |bw| BatchFilter::make_from(bw, logic2.clone())),
         }
     }
     /// Flattens the stream into a `Collection`.
@@ -202,10 +203,10 @@ where
     /// The underlying `Stream<G, BatchWrapper<T::Batch>>` is a much more efficient way to access the data,
     /// and this method should only be used when the data need to be transformed or exchanged, rather than
     /// supplied as arguments to an operator using the same key-value structure.
-    pub fn as_collection<D: Data, L>(&self, logic: L) -> Collection<G, D, Tr::R>
+    pub fn as_collection<D: Data, L>(&self, mut logic: L) -> Collection<G, D, Tr::R>
         where
             Tr::R: Semigroup,
-            L: Fn(&Tr::Key, &Tr::Val) -> D+'static,
+            L: FnMut(&Tr::Key, &Tr::Val) -> D+'static,
     {
         self.flat_map_ref(move |key, val| Some(logic(key,val)))
     }
@@ -214,12 +215,12 @@ where
     ///
     /// The supplied logic may produce an iterator over output values, allowing either
     /// filtering or flat mapping as part of the extraction.
-    pub fn flat_map_ref<I, L>(&self, logic: L) -> Collection<G, I::Item, Tr::R>
+    pub fn flat_map_ref<I, L>(&self, mut logic: L) -> Collection<G, I::Item, Tr::R>
         where
             Tr::R: Semigroup,
             I: IntoIterator,
             I::Item: Data,
-            L: Fn(&Tr::Key, &Tr::Val) -> I+'static,
+            L: FnMut(&Tr::Key, &Tr::Val) -> I+'static,
     {
         self.stream.unary(Pipeline, "AsCollection", move |_,_| move |input, output| {
 

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -68,7 +68,6 @@ where
     T1::Batch: BatchReader<T1::Key, (), G::Timestamp, T1::R>,
     T1::Cursor: Cursor<T1::Key, (), G::Timestamp, T1::R>,
 {
-
     fn count_total(&self) -> Collection<G, (T1::Key, T1::R), isize> {
 
         let mut trace = self.trace.clone();

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -1,7 +1,5 @@
 //! Wrappers to provide trace access to nested scopes.
 
-use std::rc::Rc;
-
 use timely::progress::timestamp::Refines;
 use timely::progress::Timestamp;
 
@@ -17,12 +15,13 @@ where
     trace: Tr,
     stash1: Vec<Tr::Time>,
     stash2: Vec<TInner>,
-    logic: Rc<F>,
+    logic: F,
 }
 
 impl<Tr,TInner,F> Clone for TraceEnter<Tr, TInner,F>
 where
     Tr: TraceReader+Clone,
+    F: Clone,
 {
     fn clone(&self) -> Self {
         TraceEnter {
@@ -44,7 +43,7 @@ where
     TInner: Refines<Tr::Time>+Lattice,
     Tr::R: 'static,
     F: 'static,
-    F: Fn(&Tr::Key, &Tr::Val, &Tr::Time)->TInner,
+    F: FnMut(&Tr::Key, &Tr::Val, &Tr::Time)->TInner+Clone,
 {
     type Key = Tr::Key;
     type Val = Tr::Val;
@@ -107,7 +106,7 @@ where
     TInner: Refines<Tr::Time>+Lattice,
 {
     /// Makes a new trace wrapper
-    pub fn make_from(trace: Tr, logic: Rc<F>) -> Self {
+    pub fn make_from(trace: Tr, logic: F) -> Self {
         TraceEnter {
             trace: trace,
             stash1: Vec::new(),
@@ -123,10 +122,10 @@ pub struct BatchEnter<K, V, T, R, B, TInner, F> {
     phantom: ::std::marker::PhantomData<(K, V, T, R)>,
     batch: B,
     description: Description<TInner>,
-    logic: Rc<F>,
+    logic: F,
 }
 
-impl<K, V, T, R, B: Clone, TInner: Clone, F> Clone for BatchEnter<K, V, T, R, B, TInner, F> {
+impl<K, V, T, R, B: Clone, TInner: Clone, F: Clone> Clone for BatchEnter<K, V, T, R, B, TInner, F> {
     fn clone(&self) -> Self {
         BatchEnter {
             phantom: ::std::marker::PhantomData,
@@ -142,7 +141,7 @@ where
     B: BatchReader<K, V, T, R>,
     T: Timestamp,
     TInner: Refines<T>+Lattice,
-    F: Fn(&K, &V, &T)->TInner,
+    F: FnMut(&K, &V, &T)->TInner+Clone,
 {
     type Cursor = BatchCursorEnter<K, V, T, R, B, TInner, F>;
 
@@ -160,7 +159,7 @@ where
     TInner: Refines<T>+Lattice,
 {
     /// Makes a new batch wrapper
-    pub fn make_from(batch: B, logic: Rc<F>) -> Self {
+    pub fn make_from(batch: B, logic: F) -> Self {
         let lower: Vec<_> = batch.description().lower().iter().map(|x| TInner::to_inner(x.clone())).collect();
         let upper: Vec<_> = batch.description().upper().iter().map(|x| TInner::to_inner(x.clone())).collect();
         let since: Vec<_> = batch.description().since().iter().map(|x| TInner::to_inner(x.clone())).collect();
@@ -178,11 +177,11 @@ where
 pub struct CursorEnter<K, V, T, R, C: Cursor<K, V, T, R>, TInner, F> {
     phantom: ::std::marker::PhantomData<(K, V, T, R, TInner)>,
     cursor: C,
-    logic: Rc<F>,
+    logic: F,
 }
 
 impl<K, V, T, R, C: Cursor<K, V, T, R>, TInner, F> CursorEnter<K, V, T, R, C, TInner, F> {
-    fn new(cursor: C, logic: Rc<F>) -> Self {
+    fn new(cursor: C, logic: F) -> Self {
         CursorEnter {
             phantom: ::std::marker::PhantomData,
             cursor,
@@ -196,7 +195,7 @@ where
     C: Cursor<K, V, T, R>,
     T: Timestamp,
     TInner: Refines<T>+Lattice,
-    F: Fn(&K, &V, &T)->TInner,
+    F: FnMut(&K, &V, &T)->TInner,
 {
     type Storage = C::Storage;
 
@@ -210,7 +209,7 @@ where
     fn map_times<L: FnMut(&TInner, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
-        let logic2 = &self.logic;
+        let logic2 = &mut self.logic;
         self.cursor.map_times(storage, |time, diff| {
             logic(&logic2(key, val, time), diff)
         })
@@ -232,11 +231,11 @@ where
 pub struct BatchCursorEnter<K, V, T, R, B: BatchReader<K, V, T, R>, TInner, F> {
     phantom: ::std::marker::PhantomData<(K, V, R, TInner)>,
     cursor: B::Cursor,
-    logic: Rc<F>,
+    logic: F,
 }
 
 impl<K, V, T, R, B: BatchReader<K, V, T, R>, TInner, F> BatchCursorEnter<K, V, T, R, B, TInner, F> {
-    fn new(cursor: B::Cursor, logic: Rc<F>) -> Self {
+    fn new(cursor: B::Cursor, logic: F) -> Self {
         BatchCursorEnter {
             phantom: ::std::marker::PhantomData,
             cursor,
@@ -249,7 +248,7 @@ impl<K, V, T, R, TInner, B: BatchReader<K, V, T, R>, F> Cursor<K, V, TInner, R> 
 where
     T: Timestamp,
     TInner: Refines<T>+Lattice,
-    F: Fn(&K, &V, &T)->TInner,
+    F: FnMut(&K, &V, &T)->TInner,
 {
     type Storage = BatchEnter<K, V, T, R, B, TInner, F>;
 
@@ -263,7 +262,7 @@ where
     fn map_times<L: FnMut(&TInner, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
-        let logic2 = &self.logic;
+        let logic2 = &mut self.logic;
         self.cursor.map_times(&storage.batch, |time, diff| {
             logic(&logic2(key, val, time), diff)
         })

--- a/src/trace/wrappers/filter.rs
+++ b/src/trace/wrappers/filter.rs
@@ -1,7 +1,5 @@
 //! Wrapper for filtered trace.
 
-use std::rc::Rc;
-
 use timely::progress::Timestamp;
 
 use trace::{TraceReader, BatchReader, Description};
@@ -10,12 +8,13 @@ use trace::cursor::Cursor;
 /// Wrapper to provide trace to nested scope.
 pub struct TraceFilter<Tr, F> {
     trace: Tr,
-    logic: Rc<F>,
+    logic: F,
 }
 
 impl<Tr,F> Clone for TraceFilter<Tr, F>
 where
     Tr: TraceReader+Clone,
+    F: Clone,
 {
     fn clone(&self) -> Self {
         TraceFilter {
@@ -33,7 +32,7 @@ where
     Tr::Val: 'static,
     Tr::Time: Timestamp,
     Tr::R: 'static,
-    F: Fn(&Tr::Key, &Tr::Val)->bool+'static,
+    F: FnMut(&Tr::Key, &Tr::Val)->bool+Clone+'static,
 {
     type Key = Tr::Key;
     type Val = Tr::Val;
@@ -66,7 +65,7 @@ where
     Tr::Time: Timestamp,
 {
     /// Makes a new trace wrapper
-    pub fn make_from(trace: Tr, logic: Rc<F>) -> Self {
+    pub fn make_from(trace: Tr, logic: F) -> Self {
         TraceFilter {
             trace,
             logic,
@@ -79,10 +78,10 @@ where
 pub struct BatchFilter<K, V, T, R, B, F> {
     phantom: ::std::marker::PhantomData<(K, V, T, R)>,
     batch: B,
-    logic: Rc<F>,
+    logic: F,
 }
 
-impl<K, V, T, R, B: Clone, F> Clone for BatchFilter<K, V, T, R, B, F> {
+impl<K, V, T, R, B: Clone, F: Clone> Clone for BatchFilter<K, V, T, R, B, F> {
     fn clone(&self) -> Self {
         BatchFilter {
             phantom: ::std::marker::PhantomData,
@@ -96,7 +95,7 @@ impl<K, V, T, R, B, F> BatchReader<K, V, T, R> for BatchFilter<K, V, T, R, B, F>
 where
     B: BatchReader<K, V, T, R>,
     T: Timestamp,
-    F: Fn(&K, &V)->bool+'static
+    F: FnMut(&K, &V)->bool+Clone+'static
 {
     type Cursor = BatchCursorFilter<K, V, T, R, B, F>;
 
@@ -113,7 +112,7 @@ where
     T: Timestamp,
 {
     /// Makes a new batch wrapper
-    pub fn make_from(batch: B, logic: Rc<F>) -> Self {
+    pub fn make_from(batch: B, logic: F) -> Self {
         BatchFilter {
             phantom: ::std::marker::PhantomData,
             batch,
@@ -126,11 +125,11 @@ where
 pub struct CursorFilter<K, V, T, R, C: Cursor<K, V, T, R>, F> {
     phantom: ::std::marker::PhantomData<(K, V, T, R)>,
     cursor: C,
-    logic: Rc<F>,
+    logic: F,
 }
 
 impl<K, V, T, R, C: Cursor<K, V, T, R>, F> CursorFilter<K, V, T, R, C, F> {
-    fn new(cursor: C, logic: Rc<F>) -> Self {
+    fn new(cursor: C, logic: F) -> Self {
         CursorFilter {
             phantom: ::std::marker::PhantomData,
             cursor,
@@ -143,7 +142,7 @@ impl<K, V, T, R, C, F> Cursor<K, V, T, R> for CursorFilter<K, V, T, R, C, F>
 where
     C: Cursor<K, V, T, R>,
     T: Timestamp,
-    F: Fn(&K, &V)->bool+'static
+    F: FnMut(&K, &V)->bool+'static
 {
     type Storage = C::Storage;
 
@@ -178,11 +177,11 @@ where
 pub struct BatchCursorFilter<K, V, T, R, B: BatchReader<K, V, T, R>, F> {
     phantom: ::std::marker::PhantomData<(K, V, R)>,
     cursor: B::Cursor,
-    logic: Rc<F>,
+    logic: F,
 }
 
 impl<K, V, T, R, B: BatchReader<K, V, T, R>, F> BatchCursorFilter<K, V, T, R, B, F> {
-    fn new(cursor: B::Cursor, logic: Rc<F>) -> Self {
+    fn new(cursor: B::Cursor, logic: F) -> Self {
         BatchCursorFilter {
             phantom: ::std::marker::PhantomData,
             cursor,
@@ -194,7 +193,7 @@ impl<K, V, T, R, B: BatchReader<K, V, T, R>, F> BatchCursorFilter<K, V, T, R, B,
 impl<K, V, T, R, B: BatchReader<K, V, T, R>, F> Cursor<K, V, T, R> for BatchCursorFilter<K, V, T, R, B, F>
 where
     T: Timestamp,
-    F: Fn(&K, &V)->bool+'static,
+    F: FnMut(&K, &V)->bool+'static,
 {
     type Storage = BatchFilter<K, V, T, R, B, F>;
 


### PR DESCRIPTION
This PR changes many occurrences of `Fn` to `FnMut` to allow more flexible closures that can re-use resources.

cc @jamii