### PR TITLE
Do not drop batches.

### DIFF
--- a/src/trace/implementations/spine_fueled.rs
+++ b/src/trace/implementations/spine_fueled.rs
@@ -199,9 +199,14 @@ where
     }
     fn advance_by(&mut self, frontier: &[T]) {
         self.advance_frontier = frontier.to_vec();
-        if self.advance_frontier.len() == 0 {
-            self.drop_batches();
-        }
+
+        // Commenting out for now; causes problems in `read_upper()`.
+        // If one has an urgent need to release these resources, it
+        // is probably best just to drop the trace.
+
+        // if self.advance_frontier.len() == 0 {
+        //     self.drop_batches();
+        // }
     }
     fn advance_frontier(&mut self) -> &[T] { &self.advance_frontier[..] }
     fn distinguish_since(&mut self, frontier: &[T]) {


### PR DESCRIPTION
Previously, if the advance frontier for a trace reached the empty set, indicating that no further requirements exist for correct accumulation, the trace would drop all batches. This has some problematic interactions with `read_upper()` and `map_batches()` which cannot tell that things are broken. It seems that there is no urgency to drop the batches, as they will be dropped the instant the last trace handle is dropped. If they are not dropped this way, it is because some weirdo is holding on to a defunct trace handle. I'm sure we will find out that I am such a weirdo, but it seems like the correct fix in that case is to drop the handle rather than monkey around with the implementation.

This also updates the logging for `spine_fueled_neu.rs` to correctly record batch drops when the trace is dropped.

cc: @umanwizard 