### PR TITLE
dogs/Cargo.toml: Use timely 0.11 in dogs^3.

### DIFF
--- a/dogsdogsdogs/Cargo.toml
+++ b/dogsdogsdogs/Cargo.toml
@@ -6,7 +6,8 @@ authors = ["Frank McSherry <fmcsherry@me.com>"]
 [dependencies]
 abomonation = "0.7"
 abomonation_derive = "0.5"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
+timely = "0.11"
+#timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
 timely_sort="0.1.6"
 differential-dataflow = { path = "../" }
 graph_map = "0.1"


### PR DESCRIPTION
Point `dogsdogsdogs/Cargo.toml` to timely v0.11 (from crates.io) so that
it's consistent with the main DD crate.