### PR TITLE
Timely minima

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ An implementation of [differential dataflow](https://github.com/timelydataflow/d
 
 ## Background
 
-Differential dataflow is a data-parallel programming framework designed to efficiently process large volumes of data and to quickly respond to arbitrary changes in input collections. You can read more in the [differential dataflow mdbook](https://timelydataflow.github.io/differential-dataflow/) and in the [differential dataflow documentation](https://docs.rs/differential-dataflow/0.8.0/differential_dataflow/).
+Differential dataflow is a data-parallel programming framework designed to efficiently process large volumes of data and to quickly respond to arbitrary changes in input collections. You can read more in the [differential dataflow mdbook](https://timelydataflow.github.io/differential-dataflow/) and in the [differential dataflow documentation](https://docs.rs/differential-dataflow/).
 
 Differential dataflow programs are written as functional transformations of collections of data, using familiar operators like `map`, `filter`, `join`, and `group`. Differential dataflow also includes more exotic operators such as `iterate`, which repeatedly applies a differential dataflow fragment to a collection. The programs are compiled down to [timely dataflow](https://github.com/timelydataflow/timely-dataflow) computations.
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -121,7 +121,7 @@ impl<G: TimelyInput> Input for G where <G as ScopeParent>::Timestamp: Lattice {
     }
     fn new_collection_from<I>(&mut self, data: I) -> (InputSession<<G as ScopeParent>::Timestamp, I::Item, isize>, Collection<G, I::Item, isize>)
     where I: IntoIterator+'static, I::Item: Data {
-        self.new_collection_from_raw(data.into_iter().map(|d| (d, Default::default(), 1)))
+        self.new_collection_from_raw(data.into_iter().map(|d| (d, <G::Timestamp as timely::progress::Timestamp>::minimum(), 1)))
     }
     fn new_collection_from_raw<D,R,I>(&mut self, data: I) -> (InputSession<<G as ScopeParent>::Timestamp, D, R>, Collection<G, D, R>)
     where

--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -5,21 +5,10 @@
 //! `Lattice` trait, and all reasoning in operators are done it terms of `Lattice` methods.
 
 use timely::order::PartialOrder;
+use timely::progress::Timestamp;
 
 /// A bounded partially ordered type supporting joins and meets.
-pub trait Lattice : PartialOrder {
-
-    /// The smallest element of the type.
-    ///
-    /// #Examples
-    ///
-    /// ```
-    /// use differential_dataflow::lattice::Lattice;
-    ///
-    /// let min = <usize as Lattice>::minimum();
-    /// assert_eq!(min, usize::min_value());
-    /// ```
-    fn minimum() -> Self;
+pub trait Lattice : PartialOrder+Timestamp {
 
     /// The smallest element greater than or equal to both arguments.
     ///
@@ -164,8 +153,6 @@ use timely::order::Product;
 
 impl<T1: Lattice, T2: Lattice> Lattice for Product<T1, T2> {
     #[inline]
-    fn minimum() -> Self { Product::new(T1::minimum(), T2::minimum()) }
-    #[inline]
     fn join(&self, other: &Product<T1, T2>) -> Product<T1, T2> {
         Product {
             outer: self.outer.join(&other.outer),
@@ -184,7 +171,6 @@ impl<T1: Lattice, T2: Lattice> Lattice for Product<T1, T2> {
 macro_rules! implement_lattice {
     ($index_type:ty, $minimum:expr) => (
         impl Lattice for $index_type {
-            #[inline] fn minimum() -> Self { $minimum }
             #[inline] fn join(&self, other: &Self) -> Self { ::std::cmp::max(*self, *other) }
             #[inline] fn meet(&self, other: &Self) -> Self { ::std::cmp::min(*self, *other) }
         }

--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -2,7 +2,6 @@
 
 use std::rc::{Rc, Weak};
 use std::cell::RefCell;
-use std::default::Default;
 use std::collections::VecDeque;
 
 use timely::dataflow::Scope;
@@ -106,7 +105,7 @@ where
         };
 
         let writer = TraceWriter::new(
-            vec![Default::default()],
+            vec![<Tr::Time as Timestamp>::minimum()],
             Rc::downgrade(&trace),
             queues,
         );
@@ -120,8 +119,6 @@ where
     /// The queue will be immediately populated with existing historical batches from the trace, and until the reference
     /// is dropped the queue will receive new batches as produced by the source `arrange` operator.
     pub fn new_listener(&mut self, activator: Activator) -> TraceAgentQueueReader<Tr>
-    where
-        Tr::Time: Default
     {
         // create a new queue for progress and batch information.
         let mut new_queue = VecDeque::new();
@@ -132,7 +129,7 @@ where
             .borrow_mut()
             .trace
             .map_batches(|batch| {
-                new_queue.push_back(TraceReplayInstruction::Batch(batch.clone(), Some(Default::default())));
+                new_queue.push_back(TraceReplayInstruction::Batch(batch.clone(), Some(<Tr::Time as Timestamp>::minimum())));
                 upper = Some(batch.upper().to_vec());
             });
 

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -17,8 +17,6 @@
 //! see ill-defined data at times for which the trace is not complete. (All current implementations
 //! commit only completed data to the trace).
 
-use std::default::Default;
-
 use timely::dataflow::operators::{Enter, Map};
 use timely::order::{PartialOrder, TotalOrder};
 use timely::dataflow::{Scope, Stream};
@@ -101,8 +99,8 @@ where
             Tr::Key: 'static,
             Tr::Val: 'static,
             Tr::R: 'static,
-            G::Timestamp: Clone+Default+'static,
-            TInner: Refines<G::Timestamp>+Lattice+Timestamp+Clone+Default+'static,
+            G::Timestamp: Clone+'static,
+            TInner: Refines<G::Timestamp>+Lattice+Timestamp+Clone+'static,
     {
         Arranged {
             stream: self.stream.enter(child).map(|bw| BatchEnter::make_from(bw)),
@@ -120,7 +118,7 @@ where
             Tr::Key: 'static,
             Tr::Val: 'static,
             Tr::R: 'static,
-            G::Timestamp: Clone+Default+'static,
+            G::Timestamp: Clone+'static,
     {
         Arranged {
             stream: self.stream.enter(child),
@@ -139,8 +137,8 @@ where
             Tr::Key: 'static,
             Tr::Val: 'static,
             Tr::R: 'static,
-            G::Timestamp: Clone+Default+'static,
-            TInner: Refines<G::Timestamp>+Lattice+Timestamp+Clone+Default+'static,
+            G::Timestamp: Clone+'static,
+            TInner: Refines<G::Timestamp>+Lattice+Timestamp+Clone+'static,
             F: FnMut(&Tr::Key, &Tr::Val, &G::Timestamp)->TInner+Clone+'static,
     {
         let logic1 = logic.clone();
@@ -188,7 +186,7 @@ where
             Tr::Key: 'static,
             Tr::Val: 'static,
             Tr::R: 'static,
-            G::Timestamp: Clone+Default+'static,
+            G::Timestamp: Clone+'static,
             F: FnMut(&Tr::Key, &Tr::Val)->bool+Clone+'static,
     {
         let logic1 = logic.clone();
@@ -556,7 +554,7 @@ where
                 *reader = Some(reader_local);
 
                 // Initialize to the minimal input frontier.
-                let mut input_frontier = vec![Default::default()];
+                let mut input_frontier = vec![<G::Timestamp as Timestamp>::minimum()];
 
                 move |input, output| {
 

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -76,7 +76,7 @@ where
         self.stream.unary_frontier(Pipeline, "CountTotal", move |_,_| move |input, output| {
 
             // tracks the upper limit of known-complete timestamps.
-            let mut upper_limit = timely::progress::frontier::Antichain::from_elem(<G::Timestamp>::minimum());
+            let mut upper_limit = timely::progress::frontier::Antichain::from_elem(<G::Timestamp as timely::progress::Timestamp>::minimum());
 
             input.for_each(|capability, batches| {
                 batches.swap(&mut buffer);

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -386,12 +386,12 @@ where
                 let mut interesting_times = Vec::<G::Timestamp>::new();
 
                 // Upper and lower frontiers for the pending input and output batches to process.
-                let mut upper_limit = Antichain::from_elem(<G::Timestamp as Lattice>::minimum());
-                let mut lower_limit = Antichain::from_elem(<G::Timestamp as Lattice>::minimum());
+                let mut upper_limit = Antichain::from_elem(<G::Timestamp as timely::progress::Timestamp>::minimum());
+                let mut lower_limit = Antichain::from_elem(<G::Timestamp as timely::progress::Timestamp>::minimum());
 
                 // Output batches may need to be built piecemeal, and these temp storage help there.
-                let mut output_upper = Antichain::from_elem(<G::Timestamp as Lattice>::minimum());
-                let mut output_lower = Antichain::from_elem(<G::Timestamp as Lattice>::minimum());
+                let mut output_upper = Antichain::from_elem(<G::Timestamp as timely::progress::Timestamp>::minimum());
+                let mut output_lower = Antichain::from_elem(<G::Timestamp as timely::progress::Timestamp>::minimum());
 
                 let mut input_buffer = Vec::new();
 

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -123,7 +123,7 @@ where
         self.stream.unary_frontier(Pipeline, "ThresholdTotal", move |_,_| {
 
             // tracks the upper limit of known-complete timestamps.
-            let mut upper_limit = timely::progress::frontier::Antichain::from_elem(<G::Timestamp>::minimum());
+            let mut upper_limit = timely::progress::frontier::Antichain::from_elem(<G::Timestamp as timely::progress::Timestamp>::minimum());
 
             move |input, output| {
 

--- a/src/trace/implementations/spine_fueled_neu.rs
+++ b/src/trace/implementations/spine_fueled_neu.rs
@@ -102,7 +102,7 @@ impl<K, V, T, R, B> TraceReader for Spine<K, V, T, R, B>
 where
     K: Ord+Clone,           // Clone is required by `batch::advance_*` (in-place could remove).
     V: Ord+Clone,           // Clone is required by `batch::advance_*` (in-place could remove).
-    T: Lattice+Ord+Clone+Debug+Default,
+    T: Lattice+Ord+Clone+Debug,
     R: Semigroup,
     B: Batch<K, V, T, R>+Clone+'static,
 {
@@ -239,7 +239,7 @@ impl<K, V, T, R, B> Trace for Spine<K, V, T, R, B>
 where
     K: Ord+Clone,
     V: Ord+Clone,
-    T: Lattice+Ord+Clone+Debug+Default,
+    T: Lattice+Ord+Clone+Debug,
     R: Semigroup,
     B: Batch<K, V, T, R>+Clone+'static,
 {
@@ -373,7 +373,7 @@ impl<K, V, T, R, B> Spine<K, V, T, R, B>
 where
     K: Ord+Clone,
     V: Ord+Clone,
-    T: Lattice+Ord+Clone+Debug+Default,
+    T: Lattice+Ord+Clone+Debug,
     R: Semigroup,
     B: Batch<K, V, T, R>,
 {
@@ -426,11 +426,11 @@ where
             operator,
             logger,
             phantom: ::std::marker::PhantomData,
-            advance_frontier: vec![<T as Lattice>::minimum()],
-            through_frontier: vec![<T as Lattice>::minimum()],
+            advance_frontier: vec![<T as timely::progress::Timestamp>::minimum()],
+            through_frontier: vec![<T as timely::progress::Timestamp>::minimum()],
             merging: Vec::new(),
             pending: Vec::new(),
-            upper: vec![Default::default()],
+            upper: vec![<T as timely::progress::Timestamp>::minimum()],
             effort,
             activator,
         }

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -124,7 +124,7 @@ pub trait TraceReader {
 		Self::Time: Timestamp,
 	{
 		target.clear();
-		target.insert(Default::default());
+		target.insert(<Self::Time as timely::progress::Timestamp>::minimum());
 		self.map_batches(|batch| {
 			target.clear();
 			for time in batch.upper().iter().cloned() {

--- a/src/trace/wrappers/freeze.rs
+++ b/src/trace/wrappers/freeze.rs
@@ -83,7 +83,7 @@ where
     Tr::Batch: Clone,
     Tr::Key: 'static,
     Tr::Val: 'static,
-    Tr::Time: Lattice+Clone+Default+'static,
+    Tr::Time: Lattice+Clone+'static,
     Tr::R: 'static,
     F: Fn(&Tr::Time)->Option<Tr::Time>+'static,
 {
@@ -121,7 +121,7 @@ where
     Tr::Batch: Clone,
     Tr::Key: 'static,
     Tr::Val: 'static,
-    Tr::Time: Lattice+Clone+Default+'static,
+    Tr::Time: Lattice+Clone+'static,
     Tr::R: 'static,
     F: Fn(&Tr::Time)->Option<Tr::Time>,
 {
@@ -155,7 +155,7 @@ impl<K, V, T: Clone, R, B: Clone, F> Clone for BatchFreeze<K, V, T, R, B, F> {
 impl<K, V, T, R, B, F> BatchReader<K, V, T, R> for BatchFreeze<K, V, T, R, B, F>
 where
     B: BatchReader<K, V, T, R>,
-    T: Clone+Default,
+    T: Clone,
     F: Fn(&T)->Option<T>,
 {
     type Cursor = BatchCursorFreeze<K, V, T, R, B, F>;

--- a/src/trace/wrappers/frontier.rs
+++ b/src/trace/wrappers/frontier.rs
@@ -160,7 +160,7 @@ where
     #[inline]
     fn map_times<L: FnMut(&T,&R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let frontier = &self.frontier[..];
-        let mut temp: T = Default::default();
+        let mut temp: T = <T as timely::progress::Timestamp>::minimum();
         self.cursor.map_times(storage, |time, diff| {
             temp.clone_from(time);
             temp.advance_by(frontier);
@@ -212,7 +212,7 @@ where
     #[inline]
     fn map_times<L: FnMut(&T,&R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let frontier = &self.frontier[..];
-        let mut temp: T = Default::default();
+        let mut temp: T = <T as timely::progress::Timestamp>::minimum();
         self.cursor.map_times(&storage.batch, |time, diff| {
             temp.clone_from(time);
             temp.advance_by(frontier);


### PR DESCRIPTION
This PR tracks a recent timely change that provides minimal timestamps through the `Timestamp` trait. This replaces the `Lattice::minimum()` method, which ripples through the code. The main advantage is that we can now more easily use signed integers as timestamps, and fewer assumptions are made about the default values of timestamps.

This is not expected to pass CI until the timely change lands.