### PR TITLE
Require arrangement sharing to communicate frontier changes.

### DIFF
--- a/dogsdogsdogs/examples/delta_query.rs
+++ b/dogsdogsdogs/examples/delta_query.rs
@@ -56,15 +56,15 @@ fn main() {
                 let changes = edges.enter(inner);
 
                 // Each relation we'll need.
-                let forward_key_alt = forward_key.enter_at(inner, |_,_,t| AltNeu::alt(t.clone()));
-                let reverse_key_alt = reverse_key.enter_at(inner, |_,_,t| AltNeu::alt(t.clone()));
-                let forward_key_neu = forward_key.enter_at(inner, |_,_,t| AltNeu::neu(t.clone()));
-                // let reverse_key_neu = reverse_key.enter_at(inner, |_,_,t| AltNeu::neu(t.clone()));
+                let forward_key_alt = forward_key.enter_at(inner, |_,_,t| AltNeu::alt(t.clone()), |t| t.time.saturating_sub(1));
+                let reverse_key_alt = reverse_key.enter_at(inner, |_,_,t| AltNeu::alt(t.clone()), |t| t.time.saturating_sub(1));
+                let forward_key_neu = forward_key.enter_at(inner, |_,_,t| AltNeu::neu(t.clone()), |t| t.time.saturating_sub(1));
+                // let reverse_key_neu = reverse_key.enter_at(inner, |_,_,t| AltNeu::neu(t.clone()), |t| t.time.saturating_sub(1));
 
-                // let forward_self_alt = forward_self.enter_at(inner, |_,_,t| AltNeu::alt(t.clone()));
-                let reverse_self_alt = reverse_self.enter_at(inner, |_,_,t| AltNeu::alt(t.clone()));
-                let forward_self_neu = forward_self.enter_at(inner, |_,_,t| AltNeu::neu(t.clone()));
-                let reverse_self_neu = reverse_self.enter_at(inner, |_,_,t| AltNeu::neu(t.clone()));
+                // let forward_self_alt = forward_self.enter_at(inner, |_,_,t| AltNeu::alt(t.clone()), |t| t.time.saturating_sub(1));
+                let reverse_self_alt = reverse_self.enter_at(inner, |_,_,t| AltNeu::alt(t.clone()), |t| t.time.saturating_sub(1));
+                let forward_self_neu = forward_self.enter_at(inner, |_,_,t| AltNeu::neu(t.clone()), |t| t.time.saturating_sub(1));
+                let reverse_self_neu = reverse_self.enter_at(inner, |_,_,t| AltNeu::neu(t.clone()), |t| t.time.saturating_sub(1));
 
                 // For each relation, we form a delta query driven by changes to that relation.
                 //

--- a/dogsdogsdogs/src/altneu.rs
+++ b/dogsdogsdogs/src/altneu.rs
@@ -54,6 +54,7 @@ impl<T: Timestamp> PathSummary<AltNeu<T>> for () {
 use timely::progress::Timestamp;
 impl<T: Timestamp> Timestamp for AltNeu<T> {
     type Summary = ();
+    fn minimum() -> Self { AltNeu::alt(T::minimum()) }
 }
 
 use timely::progress::timestamp::Refines;
@@ -74,7 +75,6 @@ impl<T: Timestamp> Refines<T> for AltNeu<T> {
 // This extends the `PartialOrder` implementation with additional structure.
 use differential_dataflow::lattice::Lattice;
 impl<T: Lattice> Lattice for AltNeu<T> {
-    fn minimum() -> Self { AltNeu::alt(T::minimum()) }
     fn join(&self, other: &Self) -> Self {
         let time = self.time.join(&other.time);
         let mut neu = false;

--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -112,7 +112,7 @@ pub struct CollectionIndex<K, V, T, R>
 where
     K: ExchangeData,
     V: ExchangeData,
-    T: Lattice+ExchangeData+Default,
+    T: Lattice+ExchangeData,
     R: Monoid+Mul<Output = R>+ExchangeData,
 {
     /// A trace of type (K, ()), used to count extensions for each prefix.
@@ -180,7 +180,7 @@ pub struct CollectionExtender<K, V, T, R, P, F>
 where
     K: ExchangeData,
     V: ExchangeData,
-    T: Lattice+ExchangeData+Default,
+    T: Lattice+ExchangeData,
     R: Monoid+Mul<Output = R>+ExchangeData,
     F: Fn(&P)->K+Clone,
 {

--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -47,7 +47,7 @@ pub trait PrefixExtender<G: Scope, R: Monoid+Mul<Output = R>> {
 
 pub trait ProposeExtensionMethod<G: Scope, P: ExchangeData+Ord, R: Monoid+Mul<Output = R>> {
     fn propose_using<PE: PrefixExtender<G, R, Prefix=P>>(&self, extender: &mut PE) -> Collection<G, (P, PE::Extension), R>;
-    fn extend<E: ExchangeData+Ord>(&self, extenders: &mut [&mut PrefixExtender<G,R,Prefix=P,Extension=E>]) -> Collection<G, (P, E), R>;
+    fn extend<E: ExchangeData+Ord>(&self, extenders: &mut [&mut dyn PrefixExtender<G,R,Prefix=P,Extension=E>]) -> Collection<G, (P, E), R>;
 }
 
 impl<G, P, R> ProposeExtensionMethod<G, P, R> for Collection<G, P, R>
@@ -62,7 +62,7 @@ where
     {
         extender.propose(self)
     }
-    fn extend<E>(&self, extenders: &mut [&mut PrefixExtender<G,R,Prefix=P,Extension=E>]) -> Collection<G, (P, E), R>
+    fn extend<E>(&self, extenders: &mut [&mut dyn PrefixExtender<G,R,Prefix=P,Extension=E>]) -> Collection<G, (P, E), R>
     where
         E: ExchangeData+Ord
     {

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -131,8 +131,8 @@ where
     /// This method produces a proxy trace handle that uses the same backing data, but acts as if the timestamps
     /// have all been extended with an additional coordinate with the default value. The resulting collection does
     /// not vary with the new timestamp coordinate.
-    pub fn enter_at<'a, TInner, F>(&self, child: &Child<'a, G, TInner>, logic: F)
-        -> Arranged<Child<'a, G, TInner>, TraceEnterAt<Tr, TInner, F>>
+    pub fn enter_at<'a, TInner, F, P>(&self, child: &Child<'a, G, TInner>, logic: F, prior: P)
+        -> Arranged<Child<'a, G, TInner>, TraceEnterAt<Tr, TInner, F, P>>
         where
             Tr::Key: 'static,
             Tr::Val: 'static,
@@ -140,11 +140,12 @@ where
             G::Timestamp: Clone+'static,
             TInner: Refines<G::Timestamp>+Lattice+Timestamp+Clone+'static,
             F: FnMut(&Tr::Key, &Tr::Val, &G::Timestamp)->TInner+Clone+'static,
-    {
+            P: FnMut(&TInner)->Tr::Time+Clone+'static,
+        {
         let logic1 = logic.clone();
         let logic2 = logic.clone();
         Arranged {
-            trace: TraceEnterAt::make_from(self.trace.clone(), logic1),
+            trace: TraceEnterAt::make_from(self.trace.clone(), logic1, prior),
             stream: self.stream.enter(child).map(move |bw| BatchEnterAt::make_from(bw, logic2.clone())),
         }
     }


### PR DESCRIPTION
This PR requires that an arrangement's `enter_at` method takes a method to invert timestamps, so that frontier statements about the wrapper trace can be communicated back to the wrapped trace.
This method requires some care, but for the moment you probably shouldn't be using these methods without knowing about what is going on here; we could hope for a future interface that is clearer and less error prone.