### PR TITLE
Remove the `Default` requirement from keys.

### DIFF
--- a/dogsdogsdogs/src/operators/count.rs
+++ b/dogsdogsdogs/src/operators/count.rs
@@ -39,6 +39,9 @@ where
             let s = *s as usize;
             if *c < s { ((p.clone(), *c, *i), r.clone()) }
             else      { ((p.clone(), s, index), r.clone()) }
-        }
+        },
+        Default::default(),
+        Default::default(),
+        Default::default(),
     )
 }

--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -23,12 +23,15 @@ pub fn lookup_map<G, D, R, Tr, F, DOut, ROut, S>(
     arrangement: Arranged<G, Tr>,
     key_selector: F,
     output_func: S,
+    supplied_key0: Tr::Key,
+    supplied_key1: Tr::Key,
+    supplied_key2: Tr::Key,
 ) -> Collection<G, DOut, ROut>
 where
     G: Scope,
     G::Timestamp: Lattice,
     Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
-    Tr::Key: Ord+Hashable+Default,
+    Tr::Key: Ord+Hashable,
     Tr::Val: Clone,
     Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
@@ -50,14 +53,15 @@ where
     let mut buffer1 = Vec::new();
     let mut buffer2 = Vec::new();
 
-    let mut key: Tr::Key = Default::default();
+    let mut key: Tr::Key = supplied_key0;
     let exchange = Exchange::new(move |update: &(D,G::Timestamp,R)| {
         logic1(&update.0, &mut key);
         key.hashed().as_u64()
     });
 
-    let mut key1: Tr::Key = Default::default();
-    let mut key2: Tr::Key = Default::default();
+    let mut key1: Tr::Key = supplied_key1;
+    let mut key2: Tr::Key = supplied_key2;
+
     prefixes.inner.binary_frontier(&propose_stream, exchange, Pipeline, "LookupMap", move |_,_| move |input1, input2, output| {
 
         // drain the first input, stashing requests.

--- a/dogsdogsdogs/src/operators/propose.rs
+++ b/dogsdogsdogs/src/operators/propose.rs
@@ -9,6 +9,13 @@ use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::{Cursor, TraceReader, BatchReader};
 
 /// Proposes extensions to a prefix stream.
+///
+/// This method takes a collection `prefixes` and an arrangement `arrangement` and for each
+/// update in the collection joins with the accumulated arranged records at a time less or
+/// equal to that of the update. Note that this is not a join by itself, but can be used to
+/// create a join if the `prefixes` collection is also arranged and responds to changes that
+/// `arrangement` undergoes. More complicated patterns are also appropriate, as in the case
+/// of delta queries.
 pub fn propose<G, Tr, F, P>(
     prefixes: &Collection<G, P, Tr::R>,
     arrangement: Arranged<G, Tr>,
@@ -30,7 +37,10 @@ where
         prefixes,
         arrangement,
         move |p: &P, k: &mut Tr::Key| { *k = key_selector(p); },
-        |prefix, diff, value, sum| ((prefix.clone(), value.clone()), diff.clone() * sum.clone())
+        |prefix, diff, value, sum| ((prefix.clone(), value.clone()), diff.clone() * sum.clone()),
+        Default::default(),
+        Default::default(),
+        Default::default(),
     )
 }
 
@@ -60,6 +70,9 @@ where
         prefixes,
         arrangement,
         move |p: &P, k: &mut Tr::Key| { *k = key_selector(p); },
-        |prefix, diff, value, _sum| ((prefix.clone(), value.clone()), diff.clone())
+        |prefix, diff, value, _sum| ((prefix.clone(), value.clone()), diff.clone()),
+        Default::default(),
+        Default::default(),
+        Default::default(),
     )
 }

--- a/dogsdogsdogs/src/operators/validate.rs
+++ b/dogsdogsdogs/src/operators/validate.rs
@@ -36,5 +36,8 @@ where
         arrangement,
         move |(pre,val),key| { *key = (key_selector(pre), val.clone()); },
         |(pre,val),r,&(),_| ((pre.clone(), val.clone()), r.clone()),
+        Default::default(),
+        Default::default(),
+        Default::default(),
     )
 }


### PR DESCRIPTION
This PR removes the requirement that keys in `lookup_map` implement the `Default` trait.
The implementation was required to get access to instances to re-use in key extraction, but we can instead ask the caller to supply the instances themselves; when a type implements `Default` this is especially easy.
The constraint is only changed on `lookup_map` and not the `count`, `propose`, or `validate` methods.