### PR TITLE
Add differentiation and integration

### DIFF
--- a/dogsdogsdogs/examples/delta_query.rs
+++ b/dogsdogsdogs/examples/delta_query.rs
@@ -102,23 +102,26 @@ fn main() {
                 let prev_changes = changes1.concat(&changes2).concat(&changes3).leave();
 
                 // New ideas
-                let edges = edges.differentiate(inner);
+                let d_edges = edges.differentiate(inner);
 
                 //   dQ/dE1 := dE1(a,b), E2(b,c), E3(a,c)
                 let changes1 =
-                edges.map(|(x,y)| (y,x))
-                     .join_core(&forward_key_neu, |b,a,c| Some(((*a, *c), *b)))
-                     .join_core(&forward_self_neu, |(a,c), b, &()| Some((*a,*b,*c)));
+                d_edges
+                    .map(|(x,y)| (y,x))
+                    .join_core(&forward_key_neu, |b,a,c| Some(((*a, *c), *b)))
+                    .join_core(&forward_self_neu, |(a,c), b, &()| Some((*a,*b,*c)));
 
                 //   dQ/dE2 := dE2(b,c), E1(a,b), E3(a,c)
                 let changes2 =
-                edges.join_core(&reverse_key_alt, |b,c,a| Some(((*a, *c), *b)))
-                     .join_core(&forward_self_neu, |(a,c), b, &()| Some((*a,*b,*c)));
+                d_edges
+                    .join_core(&reverse_key_alt, |b,c,a| Some(((*a, *c), *b)))
+                    .join_core(&forward_self_neu, |(a,c), b, &()| Some((*a,*b,*c)));
 
                 //   dQ/dE3 := dE3(a,c), E1(a,b), E2(b,c)
                 let changes3 =
-                edges.join_core(&forward_key_alt, |a,c,b| Some(((*c, *b), *a)))
-                     .join_core(&reverse_self_alt, |(c,b), a, &()| Some((*a,*b,*c)));
+                d_edges
+                    .join_core(&forward_key_alt, |a,c,b| Some(((*c, *b), *a)))
+                    .join_core(&reverse_self_alt, |(c,b), a, &()| Some((*a,*b,*c)));
 
                 let next_changes = changes1.concat(&changes2).concat(&changes3).integrate();
 

--- a/dogsdogsdogs/examples/delta_query.rs
+++ b/dogsdogsdogs/examples/delta_query.rs
@@ -7,9 +7,11 @@ extern crate dogsdogsdogs;
 use timely::dataflow::Scope;
 use timely::dataflow::operators::probe::Handle;
 use differential_dataflow::input::Input;
+use differential_dataflow::operators::JoinCore;
 use graph_map::GraphMMap;
 
 use dogsdogsdogs::altneu::AltNeu;
+use dogsdogsdogs::calculus::{Differentiate, Integrate};
 
 fn main() {
 
@@ -50,7 +52,7 @@ fn main() {
             // let reverse_count = edges.map(|(x,y)| y).arrange_by_self();
 
             // Q(a,b,c) :=  E1(a,b),  E2(b,c),  E3(a,c)
-            let triangles = scope.scoped::<AltNeu<usize>,_,_>("DeltaQuery (Triangles)", |inner| {
+            let (triangles_prev, triangles_next) = scope.scoped::<AltNeu<usize>,_,_>("DeltaQuery (Triangles)", |inner| {
 
                 // Grab the stream of changes.
                 let changes = edges.enter(inner);
@@ -81,25 +83,52 @@ fn main() {
                 use dogsdogsdogs::operators::propose;
                 use dogsdogsdogs::operators::validate;
 
+                // Prior technology
                 //   dQ/dE1 := dE1(a,b), E2(b,c), E3(a,c)
                 let changes1 = propose(&changes, forward_key_neu.clone(), key2.clone());
                 let changes1 = validate(&changes1, forward_self_neu.clone(), key1.clone());
                 let changes1 = changes1.map(|((a,b),c)| (a,b,c));
 
                 //   dQ/dE2 := dE2(b,c), E1(a,b), E3(a,c)
-                let changes2 = propose(&changes, reverse_key_alt, key1.clone());
-                let changes2 = validate(&changes2, reverse_self_neu, key2.clone());
+                let changes2 = propose(&changes, reverse_key_alt.clone(), key1.clone());
+                let changes2 = validate(&changes2, reverse_self_neu.clone(), key2.clone());
                 let changes2 = changes2.map(|((b,c),a)| (a,b,c));
 
                 //   dQ/dE3 := dE3(a,c), E1(a,b), E2(b,c)
-                let changes3 = propose(&changes, forward_key_alt, key1.clone());
-                let changes3 = validate(&changes3, reverse_self_alt, key2.clone());
+                let changes3 = propose(&changes, forward_key_alt.clone(), key1.clone());
+                let changes3 = validate(&changes3, reverse_self_alt.clone(), key2.clone());
                 let changes3 = changes3.map(|((a,c),b)| (a,b,c));
 
-                changes1.concat(&changes2).concat(&changes3).leave()
+                let prev_changes = changes1.concat(&changes2).concat(&changes3).leave();
+
+                // New ideas
+                let edges = edges.differentiate(inner);
+
+                //   dQ/dE1 := dE1(a,b), E2(b,c), E3(a,c)
+                let changes1 =
+                edges.map(|(x,y)| (y,x))
+                     .join_core(&forward_key_neu, |b,a,c| Some(((*a, *c), *b)))
+                     .join_core(&forward_self_neu, |(a,c), b, &()| Some((*a,*b,*c)));
+
+                //   dQ/dE2 := dE2(b,c), E1(a,b), E3(a,c)
+                let changes2 =
+                edges.join_core(&reverse_key_alt, |b,c,a| Some(((*a, *c), *b)))
+                     .join_core(&forward_self_neu, |(a,c), b, &()| Some((*a,*b,*c)));
+
+                //   dQ/dE3 := dE3(a,c), E1(a,b), E2(b,c)
+                let changes3 =
+                edges.join_core(&forward_key_alt, |a,c,b| Some(((*c, *b), *a)))
+                     .join_core(&reverse_self_alt, |(c,b), a, &()| Some((*a,*b,*c)));
+
+                let next_changes = changes1.concat(&changes2).concat(&changes3).integrate();
+
+                (prev_changes, next_changes)
             });
 
-            triangles
+            // Test if our two methods do the same thing.
+            triangles_prev.assert_eq(&triangles_next);
+
+            triangles_prev
                 .filter(move |_| inspect)
                 .inspect(|x| println!("\tTriangle: {:?}", x))
                 .probe_with(&mut probe);

--- a/dogsdogsdogs/src/calculus.rs
+++ b/dogsdogsdogs/src/calculus.rs
@@ -1,0 +1,67 @@
+//! Traits and implementations for differentiating and integrating collections.
+//!
+//! The `Differentiate` and `Integrate` traits allow us to move between standard differential
+//! dataflow collections, and collections that describe their instantaneous change. The first
+//! trait converts a collection to one that contains each change at the moment it occurs, but
+//! then immediately retracting it. The second trait takes such a representation are recreates
+//! the collection from its instantaneous changes.
+//!
+//! These two traits together allow us to build dataflows that maintain computates over inputs
+//! that are the instantaneous changes, and then to reconstruct collections from them. The most
+//! clear use case for this are "delta query" implementations of relational joins, where linearity
+//! allows us to write dataflows based on instantaneous changes, whose "accumluated state" is
+//! almost everywhere empty (and so has a low memory footprint, if the system works as planned).
+
+use timely::dataflow::Scope;
+use timely::dataflow::scopes::Child;
+use timely::dataflow::operators::{Filter, Map};
+use differential_dataflow::{AsCollection, Collection, Data};
+use differential_dataflow::difference::Abelian;
+
+use crate::altneu::AltNeu;
+
+/// Produce a collection containing the changes at the moments they happen.
+pub trait Differentiate<G: Scope, D: Data, R: Abelian> {
+    fn differentiate<'a>(&self, child: &Child<'a, G, AltNeu<G::Timestamp>>) -> Collection<Child<'a, G, AltNeu<G::Timestamp>>, D, R>;
+}
+
+/// Collect instantaneous changes back in to a collection.
+pub trait Integrate<G: Scope, D: Data, R: Abelian> {
+    fn integrate(&self) -> Collection<G, D, R>;
+}
+
+impl<G, D, R> Differentiate<G, D, R> for Collection<G, D, R>
+where
+    G: Scope,
+    D: Data,
+    R: Abelian,
+{
+    // For each (data, Alt(time), diff) we add a (data, Neu(time), -diff).
+    fn differentiate<'a>(&self, child: &Child<'a, G, AltNeu<G::Timestamp>>) -> Collection<Child<'a, G, AltNeu<G::Timestamp>>, D, R> {
+        self.enter(child)
+            .inner
+            .flat_map(|mut dtr| {
+                let alt = dtr.clone();
+                dtr.1.neu = true;
+                dtr.2 = dtr.2.neg();
+                let neu = dtr;
+                Some(alt).into_iter().chain(Some(neu))
+            })
+            .as_collection()
+    }
+}
+
+impl<'a, G, D, R> Integrate<G, D, R> for Collection<Child<'a, G, AltNeu<G::Timestamp>>, D, R>
+where
+    G: Scope,
+    D: Data,
+    R: Abelian,
+{
+    // We discard each `neu` variant and strip off the `alt` wrapper.
+    fn integrate(&self) -> Collection<G, D, R> {
+        self.inner
+            .filter(|(_d,t,_r)| !t.neu)
+            .as_collection()
+            .leave()
+    }
+}

--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -24,6 +24,7 @@ use differential_dataflow::operators::arrange::TraceAgent;
 use differential_dataflow::operators::arrange::{ArrangeBySelf, ArrangeByKey};
 
 pub mod altneu;
+pub mod calculus;
 pub mod operators;
 
 /// A type capable of extending a stream of prefixes.


### PR DESCRIPTION
This PR adds an alternate way to perform low-state delta queries, without using custom operators.

The rough idea is that we can differentiate and then integrate differential collections. There are specific and short implementations in `calculus.rs`, but the rough idea is that we form a collection that contains changes for the instant they exist, and then instantly removes them. These two changes almost immediately cancel, but while they exist the can drive differential computation and produce the corresponding impulse outputs. We can then integrate the results to form a differential collection.

The `examples/delta_query.rs` example demonstrates the second implementation, and verifies that they produce the same output.

cc @ryzhyk @comnik 

Also, props to @ruchirk and @wangandi for forcing me to explain this stuff better.