### PR TITLE
Streamline empty batch handling

### DIFF
--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -322,8 +322,10 @@ where
                                 },
                                 TraceReplayInstruction::Batch(batch, hint) => {
                                     if let Some(time) = hint {
-                                        let delayed = capabilities.delayed(&time);
-                                        output.session(&delayed).give(batch);
+                                        if !batch.is_empty() {
+                                            let delayed = capabilities.delayed(&time);
+                                            output.session(&delayed).give(batch);
+                                        }
                                     }
                                 }
                             }
@@ -458,8 +460,10 @@ where
                                 },
                                 TraceReplayInstruction::Batch(batch, hint) => {
                                     if let Some(time) = hint {
-                                        let delayed = capabilities.delayed(&time);
-                                        output.session(&delayed).give(BatchFrontier::make_from(batch, &frontier[..]));
+                                        if !batch.is_empty() {
+                                            let delayed = capabilities.delayed(&time);
+                                            output.session(&delayed).give(BatchFrontier::make_from(batch, &frontier[..]));
+                                        }
                                     }
                                 }
                             }

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -376,7 +376,6 @@ impl<G, T1> JoinCore<G, T1::Key, T1::Val, T1::R> for Arranged<G,T1>
                                     if !batch1.is_empty() {
                                         panic!("Non-empty batch1 upper not beyond acknowledged frontier: {:?}, {:?}", batch1.upper(), acknowledged1);
                                     }
-                                    else { eprintln!("Empty batch1 observed at Join"); }
                                 }
                                 acknowledged1.clear();
                                 acknowledged1.extend(batch1.upper().iter().cloned());
@@ -412,7 +411,6 @@ impl<G, T1> JoinCore<G, T1::Key, T1::Val, T1::R> for Arranged<G,T1>
                                     if !batch2.is_empty() {
                                         panic!("Non-empty batch2 upper not beyond acknowledged frontier: {:?}, {:?}", batch2.upper(), acknowledged2);
                                     }
-                                    else { eprintln!("Empty batch2 observed at Join"); }
                                 }
                                 acknowledged2.clear();
                                 acknowledged2.extend(batch2.upper().iter().cloned());


### PR DESCRIPTION
The various `import` operators on traces would produce empty batches, because they held a capability to do so. This confused some other operators that would fast-forward their acknowledged frontiers across empty regions (using information from the trace) and then apparently receive those empty batches. There is no real error, in that the region of time was already confirmed empty, and the received empty batches do not indicate actual work to do.

fixes #253 