### PR TITLE
Add Lattice impl for Antichain

### DIFF
--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -38,6 +38,7 @@ use std::fmt::Debug;
 use std::collections::BTreeMap;
 
 use timely::dataflow::operators::probe::Handle;
+use timely::progress::frontier::AntichainRef;
 
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::arrange::ArrangeByKey;
@@ -77,8 +78,8 @@ fn main() {
             graph.close();
             for i in 1..rounds + 1 {
                 /* Advance the trace frontier to enable trace compaction. */
-                graph_trace.distinguish_since(&[i]);
-                graph_trace.advance_by(&[i]);
+                graph_trace.distinguish_since(AntichainRef::new(&[i]));
+                graph_trace.advance_by(AntichainRef::new(&[i]));
                 worker.step_while(|| probe.less_than(&i));
                 dump_cursor(i, worker.index(), &mut graph_trace);
             }
@@ -92,8 +93,8 @@ fn main() {
                 }
                 graph.advance_to(i);
                 graph.flush();
-                graph_trace.distinguish_since(&[i]);
-                graph_trace.advance_by(&[i]);
+                graph_trace.distinguish_since(AntichainRef::new(&[i]));
+                graph_trace.advance_by(AntichainRef::new(&[i]));
                 worker.step_while(|| probe.less_than(graph.time()));
                 dump_cursor(i, worker.index(), &mut graph_trace);
             }

--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -118,19 +118,19 @@ pub trait Lattice : PartialOrder {
     /// # use differential_dataflow::lattice::Lattice;
     /// # fn main() {
     ///
-    /// use timely::progress::frontier::AntichainRef;
+    /// use timely::progress::frontier::{Antichain, AntichainRef};
     ///
     /// let time = Product::new(3, 7);
     /// let mut advanced = Product::new(3, 7);
-    /// let frontier = vec![Product::new(4, 8), Product::new(5, 3)];
-    /// advanced.advance_by(AntichainRef::new(&frontier[..]));
+    /// let frontier = Antichain::from(vec![Product::new(4, 8), Product::new(5, 3)]);
+    /// advanced.advance_by(frontier.borrow());
     ///
     /// // `time` and `advanced` are indistinguishable to elements >= an element of `frontier`
     /// for i in 0 .. 10 {
     ///     for j in 0 .. 10 {
     ///         let test = Product::new(i, j);
     ///         // for `test` in the future of `frontier` ..
-    ///         if frontier.iter().any(|t| t.less_equal(&test)) {
+    ///         if frontier.less_equal(&test) {
     ///             assert_eq!(time.less_equal(&test), advanced.less_equal(&test));
     ///         }
     ///     }

--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -55,20 +55,20 @@ where
     type Cursor = Tr::Cursor;
 
     fn advance_by(&mut self, frontier: AntichainRef<Tr::Time>) {
-        self.trace.borrow_mut().adjust_advance_frontier(self.advance.elements(), frontier);
+        self.trace.borrow_mut().adjust_advance_frontier(self.advance.borrow(), frontier);
         self.advance.clear();
         self.advance.extend(frontier.iter().cloned());
     }
     fn advance_frontier(&mut self) -> AntichainRef<Tr::Time> {
-        self.advance.elements()
+        self.advance.borrow()
     }
     fn distinguish_since(&mut self, frontier: AntichainRef<Tr::Time>) {
-        self.trace.borrow_mut().adjust_through_frontier(self.through.elements(), frontier);
+        self.trace.borrow_mut().adjust_through_frontier(self.through.borrow(), frontier);
         self.through.clear();
         self.through.extend(frontier.iter().cloned());
     }
     fn distinguish_frontier(&mut self) -> AntichainRef<Tr::Time> {
-        self.through.elements()
+        self.through.borrow()
     }
     fn cursor_through(&mut self, frontier: AntichainRef<Tr::Time>) -> Option<(Tr::Cursor, <Tr::Cursor as Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>>::Storage)> {
         self.trace.borrow_mut().trace.cursor_through(frontier)
@@ -319,7 +319,7 @@ where
                         for instruction in borrow.drain(..) {
                             match instruction {
                                 TraceReplayInstruction::Frontier(frontier) => {
-                                    capabilities.downgrade(&frontier.elements()[..]);
+                                    capabilities.downgrade(&frontier.borrow()[..]);
                                 },
                                 TraceReplayInstruction::Batch(batch, hint) => {
                                     if let Some(time) = hint {
@@ -458,7 +458,7 @@ where
                         for instruction in borrow.drain(..) {
                             match instruction {
                                 TraceReplayInstruction::Frontier(frontier) => {
-                                    capabilities.downgrade(&frontier.elements()[..]);
+                                    capabilities.downgrade(&frontier.borrow()[..]);
                                 },
                                 TraceReplayInstruction::Batch(batch, hint) => {
                                     if let Some(time) = hint {
@@ -532,8 +532,8 @@ where
         }
 
         // increase counts for wrapped `TraceBox`.
-        self.trace.borrow_mut().adjust_advance_frontier(AntichainRef::new(&[]), self.advance.elements());
-        self.trace.borrow_mut().adjust_through_frontier(AntichainRef::new(&[]), self.through.elements());
+        self.trace.borrow_mut().adjust_advance_frontier(AntichainRef::new(&[]), self.advance.borrow());
+        self.trace.borrow_mut().adjust_through_frontier(AntichainRef::new(&[]), self.through.borrow());
 
         TraceAgent {
             trace: self.trace.clone(),
@@ -560,7 +560,7 @@ where
         }
 
         // decrement borrow counts to remove all holds
-        self.trace.borrow_mut().adjust_advance_frontier(self.advance.elements(), AntichainRef::new(&[]));
-        self.trace.borrow_mut().adjust_through_frontier(self.through.elements(), AntichainRef::new(&[]));
+        self.trace.borrow_mut().adjust_advance_frontier(self.advance.borrow(), AntichainRef::new(&[]));
+        self.trace.borrow_mut().adjust_through_frontier(self.through.borrow(), AntichainRef::new(&[]));
     }
 }

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -263,7 +263,7 @@ where
 
             let mut trace = Some(self.trace.clone());
             // release `distinguish_since` capability.
-            trace.as_mut().unwrap().distinguish_since(AntichainRef::new(&[]));
+            trace.as_mut().unwrap().distinguish_since(Antichain::new().borrow());
 
             let mut stash = Vec::new();
             let mut capability: Option<Capability<G::Timestamp>> = None;

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -23,7 +23,7 @@ use timely::dataflow::{Scope, Stream};
 use timely::dataflow::operators::generic::Operator;
 use timely::dataflow::channels::pact::{ParallelizationContract, Pipeline, Exchange};
 use timely::progress::Timestamp;
-use timely::progress::frontier::Antichain;
+use timely::progress::{Antichain, frontier::AntichainRef};
 use timely::dataflow::operators::Capability;
 
 use timely_sort::Unsigned;
@@ -263,7 +263,7 @@ where
 
             let mut trace = Some(self.trace.clone());
             // release `distinguish_since` capability.
-            trace.as_mut().unwrap().distinguish_since(&[]);
+            trace.as_mut().unwrap().distinguish_since(AntichainRef::new(&[]));
 
             let mut stash = Vec::new();
             let mut capability: Option<Capability<G::Timestamp>> = None;
@@ -390,13 +390,14 @@ where
                 }
 
                 // Determine new frontier on queries that may be issued.
+                // TODO: This code looks very suspect; explain better or fix.
                 let frontier = [
                     capability.as_ref().map(|c| c.time().clone()),
                     input1.frontier().frontier().get(0).cloned(),
                 ].into_iter().cloned().filter_map(|t| t).min();
 
                 if let Some(frontier) = frontier {
-                    trace.as_mut().map(|t| t.advance_by(&[frontier]));
+                    trace.as_mut().map(|t| t.advance_by(AntichainRef::new(&[frontier])));
                 }
                 else {
                     trace = None;
@@ -617,7 +618,7 @@ where
                                     }
 
                                     // Extract updates not in advance of `upper`.
-                                    let batch = batcher.seal(upper.elements());
+                                    let batch = batcher.seal(upper.clone());
 
                                     writer.insert(batch.clone(), Some(capability.time().clone()));
 
@@ -632,7 +633,7 @@ where
                             // in messages with new capabilities.
 
                             let mut new_capabilities = Antichain::new();
-                            for time in batcher.frontier() {
+                            for time in batcher.frontier().iter() {
                                 if let Some(capability) = capabilities.elements().iter().find(|c| c.time().less_equal(time)) {
                                     new_capabilities.insert(capability.delayed(time));
                                 }
@@ -645,8 +646,8 @@ where
                         }
                         else {
                             // Announce progress updates, even without data.
-                            let _batch = batcher.seal(&input.frontier().frontier()[..]);
-                            writer.seal(&input.frontier().frontier());
+                            let _batch = batcher.seal(input.frontier().frontier().to_owned());
+                            writer.seal(input.frontier().frontier().to_owned());
                         }
 
                         input_frontier.clear();

--- a/src/operators/arrange/mod.rs
+++ b/src/operators/arrange/mod.rs
@@ -44,6 +44,7 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 
 use timely::scheduling::Activator;
+use timely::progress::Antichain;
 use trace::TraceReader;
 
 /// Operating instructions on how to replay a trace.
@@ -52,7 +53,7 @@ where
     Tr: TraceReader,
 {
     /// Describes a frontier advance.
-    Frontier(Vec<Tr::Time>),
+    Frontier(Antichain<Tr::Time>),
     /// Describes a batch of data and a capability hint.
     Batch(Tr::Batch, Option<Tr::Time>),
 }

--- a/src/operators/arrange/upsert.rs
+++ b/src/operators/arrange/upsert.rs
@@ -289,7 +289,7 @@ where
                                         builder.push(update);
                                     }
                                 }
-                                let batch = builder.done(input_frontier.elements(), upper.elements(), &[G::Timestamp::minimum()]);
+                                let batch = builder.done(input_frontier.clone(), upper.clone(), Antichain::from_elem(G::Timestamp::minimum()));
                                 input_frontier.clone_from(&upper);
 
                                 // Communicate `batch` to the arrangement and the stream.
@@ -317,7 +317,7 @@ where
                     }
                     else {
                         // Announce progress updates, even without data.
-                        writer.seal(&input.frontier().frontier()[..]);
+                        writer.seal(input.frontier().frontier().to_owned());
                     }
 
                     // Update our view of the input frontier.
@@ -325,8 +325,8 @@ where
                     input_frontier.extend(input.frontier().frontier().iter().cloned());
 
                     // Downgrade capabilities for `reader_local`.
-                    reader_local.advance_by(input_frontier.elements());
-                    reader_local.distinguish_since(input_frontier.elements());
+                    reader_local.advance_by(input_frontier.borrow());
+                    reader_local.distinguish_since(input_frontier.borrow());
                 }
 
                 if let Some(mut fuel) = effort.clone() {

--- a/src/operators/arrange/writer.rs
+++ b/src/operators/arrange/writer.rs
@@ -22,7 +22,7 @@ use super::TraceReplayInstruction;
 pub struct TraceWriter<Tr>
 where
     Tr: Trace,
-    Tr::Time: Lattice+Ord+Clone+std::fmt::Debug+'static,
+    Tr::Time: Lattice+Timestamp+Ord+Clone+std::fmt::Debug+'static,
     Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
 {
     /// Current upper limit.
@@ -36,7 +36,7 @@ where
 impl<Tr> TraceWriter<Tr>
 where
     Tr: Trace,
-    Tr::Time: Lattice+Ord+Clone+std::fmt::Debug+'static,
+    Tr::Time: Lattice+Timestamp+Ord+Clone+std::fmt::Debug+'static,
     Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
 {
     /// Creates a new `TraceWriter`.
@@ -105,7 +105,7 @@ where
 impl<Tr> Drop for TraceWriter<Tr>
 where
     Tr: Trace,
-    Tr::Time: Lattice+Ord+Clone+std::fmt::Debug+'static,
+    Tr::Time: Lattice+Timestamp+Ord+Clone+std::fmt::Debug+'static,
     Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
 {
     fn drop(&mut self) {

--- a/src/operators/arrange/writer.rs
+++ b/src/operators/arrange/writer.rs
@@ -8,7 +8,7 @@ use std::cell::RefCell;
 
 use lattice::Lattice;
 use trace::{Trace, Batch, BatchReader};
-use timely::progress::Timestamp;
+use timely::progress::{Antichain, Timestamp};
 
 use trace::wrappers::rc::TraceBox;
 
@@ -26,7 +26,7 @@ where
     Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
 {
     /// Current upper limit.
-    upper: Vec<Tr::Time>,
+    upper: Antichain<Tr::Time>,
     /// Shared trace, possibly absent (due to weakness).
     trace: Weak<RefCell<TraceBox<Tr>>>,
     /// A sequence of private queues into which batches are written.
@@ -46,7 +46,9 @@ where
         queues: Rc<RefCell<Vec<TraceAgentQueueWriter<Tr>>>>
     ) -> Self
     {
-        Self { upper, trace, queues }
+        let mut temp = Antichain::new();
+        temp.extend(upper.into_iter());
+        Self { upper: temp, trace, queues }
     }
 
     /// Exerts merge effort, even without additional updates.
@@ -64,21 +66,20 @@ where
     pub fn insert(&mut self, batch: Tr::Batch, hint: Option<Tr::Time>) {
 
         // Something is wrong if not a sequence.
-        if !(&self.upper[..] == batch.lower()) {
+        if !(&self.upper == batch.lower()) {
             println!("{:?} vs {:?}", self.upper, batch.lower());
         }
-        assert!(&self.upper[..] == batch.lower());
+        assert!(&self.upper == batch.lower());
         assert!(batch.lower() != batch.upper());
 
-        self.upper.clear();
-        self.upper.extend(batch.upper().iter().cloned());
+        self.upper.clone_from(batch.upper());
 
         // push information to each listener that still exists.
         let mut borrow = self.queues.borrow_mut();
         for queue in borrow.iter_mut() {
             if let Some(pair) = queue.upgrade() {
                 pair.1.borrow_mut().push_back(TraceReplayInstruction::Batch(batch.clone(), hint.clone()));
-                pair.1.borrow_mut().push_back(TraceReplayInstruction::Frontier(batch.upper().to_vec()));
+                pair.1.borrow_mut().push_back(TraceReplayInstruction::Frontier(batch.upper().clone()));
                 pair.0.activate();
             }
         }
@@ -92,11 +93,11 @@ where
     }
 
     /// Inserts an empty batch up to `upper`.
-    pub fn seal(&mut self, upper: &[Tr::Time]) {
-        if &self.upper[..] != upper {
+    pub fn seal(&mut self, upper: Antichain<Tr::Time>) {
+        if self.upper != upper {
             use trace::Builder;
             let builder = <Tr::Batch as Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>>::Builder::new();
-            let batch = builder.done(&self.upper[..], upper, &[Tr::Time::minimum()]);
+            let batch = builder.done(self.upper.clone(), upper, Antichain::from_elem(Tr::Time::minimum()));
             self.insert(batch, None);
         }
     }
@@ -109,6 +110,6 @@ where
     Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
 {
     fn drop(&mut self) {
-        self.seal(&[])
+        self.seal(Antichain::new())
     }
 }

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -84,9 +84,8 @@ where
                 for batch in buffer.drain(..) {
 
                     let mut batch_cursor = batch.cursor();
-                    let (mut trace_cursor, trace_storage) = trace.cursor_through(batch.lower()).unwrap();
-                    upper_limit.clear();
-                    upper_limit.extend(batch.upper().iter().cloned());
+                    let (mut trace_cursor, trace_storage) = trace.cursor_through(batch.lower().elements()).unwrap();
+                    upper_limit.clone_from(batch.upper());
 
                     while batch_cursor.key_valid(&batch) {
 

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -84,7 +84,7 @@ where
                 for batch in buffer.drain(..) {
 
                     let mut batch_cursor = batch.cursor();
-                    let (mut trace_cursor, trace_storage) = trace.cursor_through(batch.lower().elements()).unwrap();
+                    let (mut trace_cursor, trace_storage) = trace.cursor_through(batch.lower().borrow()).unwrap();
                     upper_limit.clone_from(batch.upper());
 
                     while batch_cursor.key_valid(&batch) {
@@ -123,8 +123,8 @@ where
 
             // tidy up the shared input trace.
             trace.advance_upper(&mut upper_limit);
-            trace.advance_by(upper_limit.elements());
-            trace.distinguish_since(upper_limit.elements());
+            trace.advance_by(upper_limit.borrow());
+            trace.distinguish_since(upper_limit.borrow());
         })
         .as_collection()
     }

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -361,7 +361,7 @@ impl<G, T1> JoinCore<G, T1::Key, T1::Val, T1::R> for Arranged<G,T1>
                                     // A trace should provide the contract that whatever its `distinguish_since` capability,
                                     // it is safe (and reasonable) to await delivery of batches up through that frontier.
                                     // In this case, we should be able to await (not block on) the arrival of these batches.
-                                    let (trace2_cursor, trace2_storage) = trace2.cursor_through(acknowledged2.elements()).unwrap();
+                                    let (trace2_cursor, trace2_storage) = trace2.cursor_through(acknowledged2.borrow()).unwrap();
                                     let batch1_cursor = batch1.cursor();
                                     todo1.push_back(Deferred::new(trace2_cursor, trace2_storage, batch1_cursor, batch1.clone(), capability.clone(), |r2,r1| (r1.clone()) * (r2.clone())));
                                 }
@@ -396,7 +396,7 @@ impl<G, T1> JoinCore<G, T1::Key, T1::Val, T1::R> for Arranged<G,T1>
                                     // A trace should provide the contract that whatever its `distinguish_since` capability,
                                     // it is safe (and reasonable) to await delivery of batches up through that frontier.
                                     // In this case, we should be able to await (not block on) the arrival of these batches.
-                                    let (trace1_cursor, trace1_storage) = trace1.cursor_through(acknowledged1.elements()).unwrap();
+                                    let (trace1_cursor, trace1_storage) = trace1.cursor_through(acknowledged1.borrow()).unwrap();
                                     let batch2_cursor = batch2.cursor();
                                     todo2.push_back(Deferred::new(trace1_cursor, trace1_storage, batch2_cursor, batch2.clone(), capability.clone(), |r1,r2| (r1.clone()) * (r2.clone())));
                                 }
@@ -455,7 +455,7 @@ impl<G, T1> JoinCore<G, T1::Key, T1::Val, T1::R> for Arranged<G,T1>
                     }
                     if let Some(acknowledged2) = &mut acknowledged2 {
                         trace2.advance_upper(acknowledged2);
-                        trace2.distinguish_since(acknowledged2.elements());
+                        trace2.distinguish_since(acknowledged2.borrow());
                     }
                 }
 
@@ -469,7 +469,7 @@ impl<G, T1> JoinCore<G, T1::Key, T1::Val, T1::R> for Arranged<G,T1>
                     }
                     if let Some(acknowledged1) = &mut acknowledged1 {
                         trace1.advance_upper(acknowledged1);
-                        trace1.distinguish_since(acknowledged1.elements());
+                        trace1.distinguish_since(acknowledged1.borrow());
                     }
                 }
             }

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -7,6 +7,7 @@ use std::fmt::Debug;
 use std::ops::Mul;
 use std::cmp::Ordering;
 
+use timely::order::PartialOrder;
 use timely::progress::Timestamp;
 use timely::dataflow::Scope;
 use timely::dataflow::operators::generic::{Operator, OutputHandle};
@@ -372,13 +373,12 @@ impl<G, T1> JoinCore<G, T1::Key, T1::Val, T1::R> for Arranged<G,T1>
                             // and the empty batches themselves (which can be sent as part of trace importing).
                             if acknowledged1.is_none() { acknowledged1 = Some(timely::progress::frontier::Antichain::from_elem(<G::Timestamp>::minimum())); }
                             if let Some(acknowledged1) = &mut acknowledged1 {
-                                if !(batch1.upper().iter().all(|t| acknowledged1.less_equal(t))) {
-                                    if !batch1.is_empty() {
+                                if !PartialOrder::less_equal(&*acknowledged1, batch1.upper()) {
+                                        if !batch1.is_empty() {
                                         panic!("Non-empty batch1 upper not beyond acknowledged frontier: {:?}, {:?}", batch1.upper(), acknowledged1);
                                     }
                                 }
-                                acknowledged1.clear();
-                                acknowledged1.extend(batch1.upper().iter().cloned());
+                                acknowledged1.clone_from(batch1.upper());
                             }
                         }
                     }
@@ -407,13 +407,12 @@ impl<G, T1> JoinCore<G, T1::Key, T1::Val, T1::R> for Arranged<G,T1>
                             // and the empty batches themselves (which can be sent as part of trace importing).
                             if acknowledged2.is_none() { acknowledged2 = Some(timely::progress::frontier::Antichain::from_elem(<G::Timestamp>::minimum())); }
                             if let Some(acknowledged2) = &mut acknowledged2 {
-                                if !(batch2.upper().iter().all(|t| acknowledged2.less_equal(t))) {
+                                if !PartialOrder::less_equal(&*acknowledged2, batch2.upper()) {
                                     if !batch2.is_empty() {
                                         panic!("Non-empty batch2 upper not beyond acknowledged frontier: {:?}, {:?}", batch2.upper(), acknowledged2);
                                     }
                                 }
-                                acknowledged2.clear();
-                                acknowledged2.extend(batch2.upper().iter().cloned());
+                                acknowledged2.clone_from(batch2.upper());
                             }
                         }
                     }
@@ -449,7 +448,7 @@ impl<G, T1> JoinCore<G, T1::Key, T1::Val, T1::R> for Arranged<G,T1>
                 // shut down or advance trace2.
                 if trace2.is_some() && input1.frontier().is_empty() { trace2 = None; }
                 if let Some(ref mut trace2) = trace2 {
-                    trace2.advance_by(&input1.frontier().frontier()[..]);
+                    trace2.advance_by(input1.frontier().frontier());
                     // At this point, if we haven't seen any input batches we should establish a frontier anyhow.
                     if acknowledged2.is_none() {
                         acknowledged2 = Some(Antichain::from_elem(<G::Timestamp>::minimum()));
@@ -463,7 +462,7 @@ impl<G, T1> JoinCore<G, T1::Key, T1::Val, T1::R> for Arranged<G,T1>
                 // shut down or advance trace1.
                 if trace1.is_some() && input2.frontier().is_empty() { trace1 = None; }
                 if let Some(ref mut trace1) = trace1 {
-                    trace1.advance_by(&input2.frontier().frontier()[..]);
+                    trace1.advance_by(input2.frontier().frontier());
                     // At this point, if we haven't seen any input batches we should establish a frontier anyhow.
                     if acknowledged1.is_none() {
                         acknowledged1 = Some(Antichain::from_elem(<G::Timestamp>::minimum()));

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -432,8 +432,7 @@ where
 
                         batches.swap(&mut input_buffer);
                         for batch in input_buffer.drain(..) {
-                            upper_limit.clear();
-                            upper_limit.extend(batch.upper().iter().cloned());
+                            upper_limit.clone_from(batch.upper());
                             batch_cursors.push(batch.cursor());
                             batch_storage.push(batch);
                         }
@@ -582,7 +581,7 @@ where
 
                                 if output_upper.elements() != output_lower.elements() {
 
-                                    let batch = builder.done(output_lower.elements(), output_upper.elements(), &[G::Timestamp::minimum()]);
+                                    let batch = builder.done(output_lower.clone(), output_upper.clone(), Antichain::from_elem(G::Timestamp::minimum()));
 
                                     // ship batch to the output, and commit to the output trace.
                                     output.session(&capabilities[index]).give(batch.clone());
@@ -619,10 +618,10 @@ where
                             capabilities = new_capabilities;
 
                             // ensure that observed progres is reflected in the output.
-                            output_writer.seal(upper_limit.elements());
+                            output_writer.seal(upper_limit.clone());
                         }
                         else {
-                            output_writer.seal(upper_limit.elements());
+                            output_writer.seal(upper_limit.clone());
                         }
 
                         // We only anticipate future times in advance of `upper_limit`.

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -133,7 +133,7 @@ where
                     for batch in buffer.drain(..) {
 
                         let mut batch_cursor = batch.cursor();
-                        let (mut trace_cursor, trace_storage) = trace.cursor_through(batch.lower().elements()).unwrap();
+                        let (mut trace_cursor, trace_storage) = trace.cursor_through(batch.lower().borrow()).unwrap();
 
                         upper_limit.clone_from(batch.upper());
 
@@ -186,8 +186,8 @@ where
 
                 // tidy up the shared input trace.
                 trace.advance_upper(&mut upper_limit);
-                trace.advance_by(upper_limit.elements());
-                trace.distinguish_since(upper_limit.elements());
+                trace.advance_by(upper_limit.borrow());
+                trace.distinguish_since(upper_limit.borrow());
             }
         })
         .as_collection()

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -133,10 +133,9 @@ where
                     for batch in buffer.drain(..) {
 
                         let mut batch_cursor = batch.cursor();
-                        let (mut trace_cursor, trace_storage) = trace.cursor_through(batch.lower()).unwrap();
+                        let (mut trace_cursor, trace_storage) = trace.cursor_through(batch.lower().elements()).unwrap();
 
-                        upper_limit.clear();
-                        upper_limit.extend(batch.upper().iter().cloned());
+                        upper_limit.clone_from(batch.upper());
 
                         while batch_cursor.key_valid(&batch) {
                             let key = batch_cursor.key(&batch);

--- a/src/trace/description.rs
+++ b/src/trace/description.rs
@@ -55,6 +55,8 @@
 //! will often be a logic bug, as `since` does not advance without a corresponding advance in
 //! times at which data may possibly be sent.
 
+use timely::{PartialOrder, progress::Antichain};
+
 /// Describes an interval of partially ordered times.
 ///
 /// A `Description` indicates a set of partially ordered times, and a moment at which they are
@@ -65,31 +67,31 @@
 #[derive(Clone, Debug, Abomonation)]
 pub struct Description<Time> {
 	/// lower frontier of contained updates.
-	lower: Vec<Time>,
+	lower: Antichain<Time>,
 	/// upper frontier of contained updates.
-	upper: Vec<Time>,
+	upper: Antichain<Time>,
 	/// frontier used for update compaction.
-	since: Vec<Time>,
+	since: Antichain<Time>,
 }
 
-impl<Time: Clone> Description<Time> {
+impl<Time: PartialOrder+Clone> Description<Time> {
 	/// Returns a new description from its component parts.
-	pub fn new(lower: &[Time], upper: &[Time], since: &[Time]) -> Self {
-		assert!(lower.len() > 0);	// this should always be true.
-		// assert!(upper.len() > 0);	// this may not always be true.
+	pub fn new(lower: Antichain<Time>, upper: Antichain<Time>, since: Antichain<Time>) -> Self {
+		assert!(lower.elements().len() > 0);	// this should always be true.
+		// assert!(upper.len() > 0);			// this may not always be true.
 		Description {
-			lower: lower.to_vec(),
-			upper: upper.to_vec(),
-			since: since.to_vec(),
+			lower,
+			upper,
+			since,
 		}
 	}
 }
 
 impl<Time> Description<Time> {
 	/// The lower envelope for times in the interval.
-	pub fn lower(&self) -> &[Time] { &self.lower[..] }
+	pub fn lower(&self) -> &Antichain<Time> { &self.lower }
 	/// The upper envelope for times in the interval.
-	pub fn upper(&self) -> &[Time] { &self.upper[..] }
+	pub fn upper(&self) -> &Antichain<Time> { &self.upper }
 	/// Times from whose future the interval may be observed.
-	pub fn since(&self) -> &[Time] { &self.since[..] }
+	pub fn since(&self) -> &Antichain<Time> { &self.since }
 }

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -19,7 +19,7 @@ impl<K, V, T, R, B> Batcher<K, V, T, R, B> for MergeBatcher<K, V, T, R, B>
 where
     K: Ord+Clone,
     V: Ord+Clone,
-    T: Lattice+Ord+Clone,
+    T: Lattice+timely::progress::Timestamp+Ord+Clone,
     R: Semigroup,
     B: Batch<K, V, T, R>,
 {

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -104,7 +104,7 @@ where
 
     // the frontier of elements remaining after the most recent call to `self.seal`.
     fn frontier(&mut self) -> timely::progress::frontier::AntichainRef<T> {
-        self.frontier.elements()
+        self.frontier.borrow()
     }
 }
 

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -78,7 +78,7 @@ impl<K, V, T, R, O> Batch<K, V, T, R> for OrdValBatch<K, V, T, R, O>
 where
     K: Ord+Clone+'static,
     V: Ord+Clone+'static,
-    T: Lattice+Ord+Clone+::std::fmt::Debug+'static,
+    T: Lattice+timely::progress::Timestamp+Ord+Clone+::std::fmt::Debug+'static,
     R: Semigroup,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -217,7 +217,7 @@ impl<K, V, T, R, O> Merger<K, V, T, R, OrdValBatch<K, V, T, R, O>> for OrdValMer
 where
     K: Ord+Clone+'static,
     V: Ord+Clone+'static,
-    T: Lattice+Ord+Clone+::std::fmt::Debug+'static,
+    T: Lattice+timely::progress::Timestamp+Ord+Clone+::std::fmt::Debug+'static,
     R: Semigroup,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -360,7 +360,7 @@ impl<K, V, T, R, O> Builder<K, V, T, R, OrdValBatch<K, V, T, R, O>> for OrdValBu
 where
     K: Ord+Clone+'static,
     V: Ord+Clone+'static,
-    T: Lattice+Ord+Clone+::std::fmt::Debug+'static,
+    T: Lattice+timely::progress::Timestamp+Ord+Clone+::std::fmt::Debug+'static,
     R: Semigroup,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -430,7 +430,7 @@ where
 impl<K, T, R, O> Batch<K, (), T, R> for OrdKeyBatch<K, T, R, O>
 where
     K: Ord+Clone+'static,
-    T: Lattice+Ord+Clone+'static,
+    T: Lattice+timely::progress::Timestamp+Ord+Clone+'static,
     R: Semigroup,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -536,7 +536,7 @@ where
 impl<K, T, R, O> Merger<K, (), T, R, OrdKeyBatch<K, T, R, O>> for OrdKeyMerger<K, T, R, O>
 where
     K: Ord+Clone+'static,
-    T: Lattice+Ord+Clone+'static,
+    T: Lattice+timely::progress::Timestamp+Ord+Clone+'static,
     R: Semigroup,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -681,7 +681,7 @@ where
 impl<K, T, R, O> Builder<K, (), T, R, OrdKeyBatch<K, T, R, O>> for OrdKeyBuilder<K, T, R, O>
 where
     K: Ord+Clone+'static,
-    T: Lattice+Ord+Clone+'static,
+    T: Lattice+timely::progress::Timestamp+Ord+Clone+'static,
     R: Semigroup,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -293,7 +293,7 @@ where
 
 		// if we are supplied a frontier, we should compact.
 		if self.should_compact {
-			OrdValBatch::advance_builder_from(&mut self.result, self.description.since().elements(), initial_key_pos);
+			OrdValBatch::advance_builder_from(&mut self.result, self.description.since().borrow(), initial_key_pos);
 		}
 
         *fuel -= effort;
@@ -618,7 +618,7 @@ where
 
 		// if we are supplied a frontier, we should compact.
 		if self.should_compact {
-			OrdKeyBatch::advance_builder_from(&mut self.result, self.description.since().elements(), initial_key_pos);
+			OrdKeyBatch::advance_builder_from(&mut self.result, self.description.since().borrow(), initial_key_pos);
 		}
 
         *fuel -= effort;

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -13,8 +13,10 @@ use std::convert::{TryFrom, TryInto};
 use std::marker::PhantomData;
 use std::fmt::Debug;
 
+use timely::progress::{Antichain, frontier::AntichainRef};
+
 use ::difference::Semigroup;
-use lattice::{Lattice, antichain_join};
+use lattice::Lattice;
 
 use trace::layers::{Trie, TupleBuilder};
 use trace::layers::Builder as TrieBuilder;
@@ -86,7 +88,7 @@ where
 	type Builder = OrdValBuilder<K, V, T, R, O>;
 	type Merger = OrdValMerger<K, V, T, R, O>;
 
-	fn begin_merge(&self, other: &Self, compaction_frontier: Option<&[T]>) -> Self::Merger {
+	fn begin_merge(&self, other: &Self, compaction_frontier: Option<AntichainRef<T>>) -> Self::Merger {
 		OrdValMerger::new(self, other, compaction_frontier)
 	}
 }
@@ -99,7 +101,7 @@ where
     R: Semigroup,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
-	fn advance_builder_from(layer: &mut OrderedBuilder<K, OrderedBuilder<V, OrderedLeafBuilder<T, R>, O>, O>, frontier: &[T], key_pos: usize) {
+	fn advance_builder_from(layer: &mut OrderedBuilder<K, OrderedBuilder<V, OrderedLeafBuilder<T, R>, O>, O>, frontier: AntichainRef<T>, key_pos: usize) {
 
 		let key_start = key_pos;
 		let val_start: usize = layer.offs[key_pos].try_into().unwrap();
@@ -221,16 +223,16 @@ where
     R: Semigroup,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
-	fn new(batch1: &OrdValBatch<K, V, T, R, O>, batch2: &OrdValBatch<K, V, T, R, O>, compaction_frontier: Option<&[T]>) -> Self {
+	fn new(batch1: &OrdValBatch<K, V, T, R, O>, batch2: &OrdValBatch<K, V, T, R, O>, compaction_frontier: Option<AntichainRef<T>>) -> Self {
 
 		assert!(batch1.upper() == batch2.lower());
 
-		let mut since = antichain_join(batch1.description().since(), batch2.description().since());
+		let mut since = batch1.description().since().join(batch2.description().since());
 		if let Some(compaction_frontier) = compaction_frontier {
-			since = antichain_join(since.elements(), compaction_frontier);
+			since = since.join(&compaction_frontier.to_owned());
 		}
 
-		let description = Description::new(batch1.lower(), batch2.upper(), since.elements());
+		let description = Description::new(batch1.lower().clone(), batch2.upper().clone(), since);
 
 		OrdValMerger {
 			lower1: 0,
@@ -291,7 +293,7 @@ where
 
 		// if we are supplied a frontier, we should compact.
 		if self.should_compact {
-			OrdValBatch::advance_builder_from(&mut self.result, self.description.since(), initial_key_pos);
+			OrdValBatch::advance_builder_from(&mut self.result, self.description.since().elements(), initial_key_pos);
 		}
 
         *fuel -= effort;
@@ -382,7 +384,7 @@ where
 	}
 
 	#[inline(never)]
-	fn done(self, lower: &[T], upper: &[T], since: &[T]) -> OrdValBatch<K, V, T, R, O> {
+	fn done(self, lower: Antichain<T>, upper: Antichain<T>, since: Antichain<T>) -> OrdValBatch<K, V, T, R, O> {
 		OrdValBatch {
 			layer: self.builder.done(),
 			desc: Description::new(lower, upper, since)
@@ -438,7 +440,7 @@ where
 	type Builder = OrdKeyBuilder<K, T, R, O>;
 	type Merger = OrdKeyMerger<K, T, R, O>;
 
-	fn begin_merge(&self, other: &Self, compaction_frontier: Option<&[T]>) -> Self::Merger {
+	fn begin_merge(&self, other: &Self, compaction_frontier: Option<AntichainRef<T>>) -> Self::Merger {
 		OrdKeyMerger::new(self, other, compaction_frontier)
 	}
 }
@@ -450,7 +452,7 @@ where
     R: Semigroup,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
-	fn advance_builder_from(layer: &mut OrderedBuilder<K, OrderedLeafBuilder<T, R>, O>, frontier: &[T], key_pos: usize) {
+	fn advance_builder_from(layer: &mut OrderedBuilder<K, OrderedLeafBuilder<T, R>, O>, frontier: AntichainRef<T>, key_pos: usize) {
 
 		let key_start = key_pos;
 		let time_start: usize = layer.offs[key_pos].try_into().unwrap();
@@ -540,16 +542,16 @@ where
     R: Semigroup,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
-	fn new(batch1: &OrdKeyBatch<K, T, R, O>, batch2: &OrdKeyBatch<K, T, R, O>, compaction_frontier: Option<&[T]>) -> Self {
+	fn new(batch1: &OrdKeyBatch<K, T, R, O>, batch2: &OrdKeyBatch<K, T, R, O>, compaction_frontier: Option<AntichainRef<T>>) -> Self {
 
 		assert!(batch1.upper() == batch2.lower());
 
-		let mut since = antichain_join(batch1.description().since(), batch2.description().since());
+		let mut since = batch1.description().since().join(batch2.description().since());
 		if let Some(compaction_frontier) = compaction_frontier {
-			since = antichain_join(since.elements(), compaction_frontier);
+			since = since.join(&compaction_frontier.to_owned());
 		}
 
-		let description = Description::new(batch1.lower(), batch2.upper(), since.elements());
+		let description = Description::new(batch1.lower().clone(), batch2.upper().clone(), since);
 
 		OrdKeyMerger {
 			lower1: 0,
@@ -616,7 +618,7 @@ where
 
 		// if we are supplied a frontier, we should compact.
 		if self.should_compact {
-			OrdKeyBatch::advance_builder_from(&mut self.result, self.description.since(), initial_key_pos);
+			OrdKeyBatch::advance_builder_from(&mut self.result, self.description.since().elements(), initial_key_pos);
 		}
 
         *fuel -= effort;
@@ -704,7 +706,7 @@ where
 	}
 
 	#[inline(never)]
-	fn done(self, lower: &[T], upper: &[T], since: &[T]) -> OrdKeyBatch<K, T, R, O> {
+	fn done(self, lower: Antichain<T>, upper: Antichain<T>, since: Antichain<T>) -> OrdKeyBatch<K, T, R, O> {
 		OrdKeyBatch {
 			layer: self.builder.done(),
 			desc: Description::new(lower, upper, since)

--- a/src/trace/implementations/spine_fueled_neu.rs
+++ b/src/trace/implementations/spine_fueled_neu.rs
@@ -79,6 +79,8 @@ use trace::cursor::{Cursor, CursorList};
 use trace::Merger;
 
 use ::timely::dataflow::operators::generic::OperatorInfo;
+use ::timely::progress::{Antichain, frontier::AntichainRef};
+use ::timely::order::PartialOrder;
 
 /// An append-only collection of update tuples.
 ///
@@ -89,11 +91,11 @@ pub struct Spine<K, V, T: Lattice+Ord, R: Semigroup, B: Batch<K, V, T, R>> {
     operator: OperatorInfo,
     logger: Option<Logger>,
     phantom: ::std::marker::PhantomData<(K, V, R)>,
-    advance_frontier: Vec<T>,                   // Times after which the trace must accumulate correctly.
-    through_frontier: Vec<T>,                   // Times after which the trace must be able to subset its inputs.
+    advance_frontier: Antichain<T>,                   // Times after which the trace must accumulate correctly.
+    through_frontier: Antichain<T>,                   // Times after which the trace must be able to subset its inputs.
     merging: Vec<MergeState<K,V,T,R,B>>,// Several possibly shared collections of updates.
     pending: Vec<B>,                       // Batches at times in advance of `frontier`.
-    upper: Vec<T>,
+    upper: Antichain<T>,
     effort: usize,
     activator: Option<timely::scheduling::activate::Activator>,
 }
@@ -114,7 +116,7 @@ where
     type Batch = B;
     type Cursor = CursorList<K, V, T, R, <B as BatchReader<K, V, T, R>>::Cursor>;
 
-    fn cursor_through(&mut self, upper: &[T]) -> Option<(Self::Cursor, <Self::Cursor as Cursor<K, V, T, R>>::Storage)> {
+    fn cursor_through(&mut self, upper: AntichainRef<T>) -> Option<(Self::Cursor, <Self::Cursor as Cursor<K, V, T, R>>::Storage)> {
 
         // The supplied `upper` should have the property that for each of our
         // batch `lower` and `upper` frontiers, the supplied upper is comparable
@@ -127,11 +129,12 @@ where
         // supplied upper it had better be empty.
 
         // We shouldn't grab a cursor into a closed trace, right?
-        assert!(self.advance_frontier.len() > 0);
+        assert!(self.advance_frontier.elements().len() > 0);
 
         // Check that `upper` is greater or equal to `self.through_frontier`.
         // Otherwise, the cut could be in `self.merging` and it is user error anyhow.
-        assert!(upper.iter().all(|t1| self.through_frontier.iter().any(|t2| t2.less_equal(t1))));
+        // assert!(upper.iter().all(|t1| self.through_frontier.iter().any(|t2| t2.less_equal(t1))));
+        assert!(PartialOrder::less_equal(&self.through_frontier.elements(), &upper));
 
         let mut cursors = Vec::new();
         let mut storage = Vec::new();
@@ -182,10 +185,10 @@ where
                 // TODO: It is not clear if this is the 100% correct logic, due
                 // to the possible non-total-orderedness of the frontiers.
 
-                let include_lower = upper.iter().all(|t1| batch.lower().iter().any(|t2| t2.less_equal(t1)));
-                let include_upper = upper.iter().all(|t1| batch.upper().iter().any(|t2| t2.less_equal(t1)));
+                let include_lower = PartialOrder::less_equal(&batch.lower().elements(), &upper);
+                let include_upper = PartialOrder::less_equal(&batch.upper().elements(), &upper);
 
-                if include_lower != include_upper && upper != batch.lower() {
+                if include_lower != include_upper && upper != batch.lower().elements() {
                     panic!("`cursor_through`: `upper` straddles batch");
                 }
 
@@ -199,24 +202,16 @@ where
 
         Some((CursorList::new(cursors, &storage), storage))
     }
-    fn advance_by(&mut self, frontier: &[T]) {
-        self.advance_frontier = frontier.to_vec();
-
-        // Commenting out for now; causes problems in `read_upper()`.
-        // If one has an urgent need to release these resources, it
-        // is probably best just to drop the trace.
-
-        // if self.advance_frontier.len() == 0 {
-        //     self.pending.clear();
-        //     self.merging.clear();
-        // }
+    fn advance_by(&mut self, frontier: AntichainRef<T>) {
+        // TODO: Re-use allocation
+        self.advance_frontier = frontier.to_owned();
     }
-    fn advance_frontier(&mut self) -> &[T] { &self.advance_frontier[..] }
-    fn distinguish_since(&mut self, frontier: &[T]) {
-        self.through_frontier = frontier.to_vec();
+    fn advance_frontier(&mut self) -> AntichainRef<T> { self.advance_frontier.elements() }
+    fn distinguish_since(&mut self, frontier: AntichainRef<T>) {
+        self.through_frontier = frontier.to_owned();
         self.consider_merges();
     }
-    fn distinguish_frontier(&mut self) -> &[T] { &self.through_frontier[..] }
+    fn distinguish_frontier(&mut self) -> AntichainRef<T> { self.through_frontier.elements() }
 
     fn map_batches<F: FnMut(&Self::Batch)>(&mut self, mut f: F) {
         for batch in self.merging.iter().rev() {
@@ -290,9 +285,9 @@ where
         }));
 
         assert!(batch.lower() != batch.upper());
-        assert_eq!(batch.lower(), &self.upper[..]);
+        assert_eq!(batch.lower(), &self.upper);
 
-        self.upper = batch.upper().to_vec();
+        self.upper.clone_from(batch.upper());
 
         // TODO: Consolidate or discard empty batches.
         self.pending.push(batch);
@@ -301,10 +296,10 @@ where
 
     /// Completes the trace with a final empty batch.
     fn close(&mut self) {
-        if !self.upper.is_empty() {
+        if !self.upper.elements().is_empty() {
             use trace::Builder;
             let builder = B::Builder::new();
-            let batch = builder.done(&self.upper[..], &[], &[T::minimum()]);
+            let batch = builder.done(self.upper.clone(), Antichain::new(), Antichain::from_elem(T::minimum()));
             self.insert(batch);
         }
     }
@@ -426,11 +421,11 @@ where
             operator,
             logger,
             phantom: ::std::marker::PhantomData,
-            advance_frontier: vec![<T as timely::progress::Timestamp>::minimum()],
-            through_frontier: vec![<T as timely::progress::Timestamp>::minimum()],
+            advance_frontier: Antichain::from_elem(<T as timely::progress::Timestamp>::minimum()),
+            through_frontier: Antichain::from_elem(<T as timely::progress::Timestamp>::minimum()),
             merging: Vec::new(),
             pending: Vec::new(),
-            upper: vec![<T as timely::progress::Timestamp>::minimum()],
+            upper: Antichain::from_elem(<T as timely::progress::Timestamp>::minimum()),
             effort,
             activator,
         }
@@ -445,8 +440,8 @@ where
 
         // TODO: Consider merging pending batches before introducing them.
         // TODO: We could use a `VecDeque` here to draw from the front and append to the back.
-        while self.pending.len() > 0 &&
-              self.through_frontier.iter().all(|t1| self.pending[0].upper().iter().any(|t2| t2.less_equal(t1)))
+        while self.pending.len() > 0 && PartialOrder::less_equal(self.pending[0].upper(), &self.through_frontier)
+            //   self.through_frontier.iter().all(|t1| self.pending[0].upper().iter().any(|t2| t2.less_equal(t1)))
         {
             // Batch can be taken in optimized insertion.
             // Otherwise it is inserted normally at the end of the method.
@@ -658,7 +653,7 @@ where
                         complete: None,
                     }
                 ));
-                let compaction_frontier = Some(&self.advance_frontier[..]);
+                let compaction_frontier = Some(self.advance_frontier.elements());
                 self.merging[index] = MergeState::begin_merge(old, batch, compaction_frontier);
             }
             MergeState::Double(_) => {
@@ -852,7 +847,7 @@ impl<K, V, T: Eq, R, B: Batch<K, V, T, R>> MergeState<K, V, T, R, B> {
     /// empty batch whose upper and lower froniers are equal. This
     /// option exists purely for bookkeeping purposes, and no computation
     /// is performed to merge the two batches.
-    fn begin_merge(batch1: Option<B>, batch2: Option<B>, compaction_frontier: Option<&[T]>) -> MergeState<K, V, T, R, B> {
+    fn begin_merge(batch1: Option<B>, batch2: Option<B>, compaction_frontier: Option<AntichainRef<T>>) -> MergeState<K, V, T, R, B> {
         let variant =
         match (batch1, batch2) {
             (Some(batch1), Some(batch2)) => {

--- a/src/trace/implementations/spine_fueled_neu.rs
+++ b/src/trace/implementations/spine_fueled_neu.rs
@@ -102,7 +102,7 @@ impl<K, V, T, R, B> TraceReader for Spine<K, V, T, R, B>
 where
     K: Ord+Clone,           // Clone is required by `batch::advance_*` (in-place could remove).
     V: Ord+Clone,           // Clone is required by `batch::advance_*` (in-place could remove).
-    T: Lattice+Ord+Clone+Debug,
+    T: Lattice+timely::progress::Timestamp+Ord+Clone+Debug,
     R: Semigroup,
     B: Batch<K, V, T, R>+Clone+'static,
 {
@@ -239,7 +239,7 @@ impl<K, V, T, R, B> Trace for Spine<K, V, T, R, B>
 where
     K: Ord+Clone,
     V: Ord+Clone,
-    T: Lattice+Ord+Clone+Debug,
+    T: Lattice+timely::progress::Timestamp+Ord+Clone+Debug,
     R: Semigroup,
     B: Batch<K, V, T, R>+Clone+'static,
 {
@@ -373,7 +373,7 @@ impl<K, V, T, R, B> Spine<K, V, T, R, B>
 where
     K: Ord+Clone,
     V: Ord+Clone,
-    T: Lattice+Ord+Clone+Debug,
+    T: Lattice+timely::progress::Timestamp+Ord+Clone+Debug,
     R: Semigroup,
     B: Batch<K, V, T, R>,
 {

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -59,7 +59,7 @@ pub trait TraceReader {
 
 	/// Provides a cursor over updates contained in the trace.
 	fn cursor(&mut self) -> (Self::Cursor, <Self::Cursor as Cursor<Self::Key, Self::Val, Self::Time, Self::R>>::Storage) {
-		if let Some(cursor) = self.cursor_through(AntichainRef::new(&[])) {
+		if let Some(cursor) = self.cursor_through(Antichain::new().borrow()) {
 			cursor
 		}
 		else {

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -2,6 +2,7 @@
 
 use timely::progress::timestamp::Refines;
 use timely::progress::Timestamp;
+use timely::progress::{Antichain, frontier::AntichainRef};
 
 use lattice::Lattice;
 use trace::{TraceReader, BatchReader, Description};
@@ -71,42 +72,42 @@ where
         })
     }
 
-    fn advance_by(&mut self, frontier: &[TInner]) {
+    fn advance_by(&mut self, frontier: AntichainRef<TInner>) {
         self.stash1.clear();
         for time in frontier.iter() {
             self.stash1.push((self.prior)(time));
         }
-        self.trace.advance_by(&self.stash1[..]);
+        self.trace.advance_by(AntichainRef::new(&self.stash1[..]));
     }
-    fn advance_frontier(&mut self) -> &[TInner] {
+    fn advance_frontier(&mut self) -> AntichainRef<TInner> {
         self.stash2.clear();
         for time in self.trace.advance_frontier().iter() {
             self.stash2.push(TInner::to_inner(time.clone()));
         }
-        &self.stash2[..]
+        AntichainRef::new(&self.stash2[..])
     }
 
-    fn distinguish_since(&mut self, frontier: &[TInner]) {
+    fn distinguish_since(&mut self, frontier: AntichainRef<TInner>) {
         self.stash1.clear();
         for time in frontier.iter() {
             self.stash1.push((self.prior)(time));
         }
-        self.trace.distinguish_since(&self.stash1[..]);
+        self.trace.distinguish_since(AntichainRef::new(&self.stash1[..]));
     }
-    fn distinguish_frontier(&mut self) -> &[TInner] {
+    fn distinguish_frontier(&mut self) -> AntichainRef<TInner> {
         self.stash2.clear();
         for time in self.trace.distinguish_frontier().iter() {
             self.stash2.push(TInner::to_inner(time.clone()));
         }
-        &self.stash2[..]
+        AntichainRef::new(&self.stash2[..])
     }
 
-    fn cursor_through(&mut self, upper: &[TInner]) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Tr::Key, Tr::Val, TInner, Tr::R>>::Storage)> {
+    fn cursor_through(&mut self, upper: AntichainRef<TInner>) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Tr::Key, Tr::Val, TInner, Tr::R>>::Storage)> {
         self.stash1.clear();
         for time in upper.iter() {
             self.stash1.push(time.clone().to_outer());
         }
-        self.trace.cursor_through(&self.stash1[..]).map(|(x,y)| (CursorEnter::new(x, self.logic.clone()), y))
+        self.trace.cursor_through(AntichainRef::new(&self.stash1[..])).map(|(x,y)| (CursorEnter::new(x, self.logic.clone()), y))
     }
 }
 
@@ -172,14 +173,14 @@ where
 {
     /// Makes a new batch wrapper
     pub fn make_from(batch: B, logic: F) -> Self {
-        let lower: Vec<_> = batch.description().lower().iter().map(|x| TInner::to_inner(x.clone())).collect();
-        let upper: Vec<_> = batch.description().upper().iter().map(|x| TInner::to_inner(x.clone())).collect();
-        let since: Vec<_> = batch.description().since().iter().map(|x| TInner::to_inner(x.clone())).collect();
+        let lower: Vec<_> = batch.description().lower().elements().iter().map(|x| TInner::to_inner(x.clone())).collect();
+        let upper: Vec<_> = batch.description().upper().elements().iter().map(|x| TInner::to_inner(x.clone())).collect();
+        let since: Vec<_> = batch.description().since().elements().iter().map(|x| TInner::to_inner(x.clone())).collect();
 
         BatchEnter {
             phantom: ::std::marker::PhantomData,
             batch,
-            description: Description::new(&lower[..], &upper[..], &since[..]),
+            description: Description::new(Antichain::from(lower), Antichain::from(upper), Antichain::from(since)),
             logic,
         }
     }

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -21,8 +21,8 @@ where
     Tr: TraceReader,
 {
     trace: Tr,
-    stash1: Vec<Tr::Time>,
-    stash2: Vec<TInner>,
+    stash1: Antichain<Tr::Time>,
+    stash2: Antichain<TInner>,
     logic: F,
     prior: G,
 }
@@ -36,8 +36,8 @@ where
     fn clone(&self) -> Self {
         TraceEnter {
             trace: self.trace.clone(),
-            stash1: Vec::new(),
-            stash2: Vec::new(),
+            stash1: Antichain::new(),
+            stash2: Antichain::new(),
             logic: self.logic.clone(),
             prior: self.prior.clone(),
         }
@@ -75,39 +75,39 @@ where
     fn advance_by(&mut self, frontier: AntichainRef<TInner>) {
         self.stash1.clear();
         for time in frontier.iter() {
-            self.stash1.push((self.prior)(time));
+            self.stash1.insert((self.prior)(time));
         }
-        self.trace.advance_by(AntichainRef::new(&self.stash1[..]));
+        self.trace.advance_by(self.stash1.borrow());
     }
     fn advance_frontier(&mut self) -> AntichainRef<TInner> {
         self.stash2.clear();
         for time in self.trace.advance_frontier().iter() {
-            self.stash2.push(TInner::to_inner(time.clone()));
+            self.stash2.insert(TInner::to_inner(time.clone()));
         }
-        AntichainRef::new(&self.stash2[..])
+        self.stash2.borrow()
     }
 
     fn distinguish_since(&mut self, frontier: AntichainRef<TInner>) {
         self.stash1.clear();
         for time in frontier.iter() {
-            self.stash1.push((self.prior)(time));
+            self.stash1.insert((self.prior)(time));
         }
-        self.trace.distinguish_since(AntichainRef::new(&self.stash1[..]));
+        self.trace.distinguish_since(self.stash1.borrow());
     }
     fn distinguish_frontier(&mut self) -> AntichainRef<TInner> {
         self.stash2.clear();
         for time in self.trace.distinguish_frontier().iter() {
-            self.stash2.push(TInner::to_inner(time.clone()));
+            self.stash2.insert(TInner::to_inner(time.clone()));
         }
-        AntichainRef::new(&self.stash2[..])
+        self.stash2.borrow()
     }
 
     fn cursor_through(&mut self, upper: AntichainRef<TInner>) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Tr::Key, Tr::Val, TInner, Tr::R>>::Storage)> {
         self.stash1.clear();
         for time in upper.iter() {
-            self.stash1.push(time.clone().to_outer());
+            self.stash1.insert(time.clone().to_outer());
         }
-        self.trace.cursor_through(AntichainRef::new(&self.stash1[..])).map(|(x,y)| (CursorEnter::new(x, self.logic.clone()), y))
+        self.trace.cursor_through(self.stash1.borrow()).map(|(x,y)| (CursorEnter::new(x, self.logic.clone()), y))
     }
 }
 
@@ -121,8 +121,8 @@ where
     pub fn make_from(trace: Tr, logic: F, prior: G) -> Self {
         TraceEnter {
             trace: trace,
-            stash1: Vec::new(),
-            stash2: Vec::new(),
+            stash1: Antichain::new(),
+            stash2: Antichain::new(),
             logic,
             prior,
         }

--- a/src/trace/wrappers/filter.rs
+++ b/src/trace/wrappers/filter.rs
@@ -1,6 +1,7 @@
 //! Wrapper for filtered trace.
 
 use timely::progress::Timestamp;
+use timely::progress::frontier::AntichainRef;
 
 use trace::{TraceReader, BatchReader, Description};
 use trace::cursor::Cursor;
@@ -48,13 +49,13 @@ where
             .map_batches(|batch| f(&Self::Batch::make_from(batch.clone(), logic.clone())))
     }
 
-    fn advance_by(&mut self, frontier: &[Tr::Time]) { self.trace.advance_by(frontier) }
-    fn advance_frontier(&mut self) -> &[Tr::Time] { self.trace.advance_frontier() }
+    fn advance_by(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.advance_by(frontier) }
+    fn advance_frontier(&mut self) -> AntichainRef<Tr::Time> { self.trace.advance_frontier() }
 
-    fn distinguish_since(&mut self, frontier: &[Tr::Time]) { self.trace.distinguish_since(frontier) }
-    fn distinguish_frontier(&mut self) -> &[Tr::Time] { self.trace.distinguish_frontier() }
+    fn distinguish_since(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.distinguish_since(frontier) }
+    fn distinguish_frontier(&mut self) -> AntichainRef<Tr::Time> { self.trace.distinguish_frontier() }
 
-    fn cursor_through(&mut self, upper: &[Tr::Time]) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>>::Storage)> {
+    fn cursor_through(&mut self, upper: AntichainRef<Tr::Time>) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>>::Storage)> {
         self.trace.cursor_through(upper).map(|(x,y)| (CursorFilter::new(x, self.logic.clone()), y))
     }
 }

--- a/src/trace/wrappers/freeze.rs
+++ b/src/trace/wrappers/freeze.rs
@@ -21,6 +21,7 @@ use std::rc::Rc;
 
 use timely::dataflow::Scope;
 use timely::dataflow::operators::Map;
+use timely::progress::frontier::AntichainRef;
 
 use operators::arrange::Arranged;
 use lattice::Lattice;
@@ -102,13 +103,13 @@ where
         })
     }
 
-    fn advance_by(&mut self, frontier: &[Tr::Time]) { self.trace.advance_by(frontier) }
-    fn advance_frontier(&mut self) -> &[Tr::Time] { self.trace.advance_frontier() }
+    fn advance_by(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.advance_by(frontier) }
+    fn advance_frontier(&mut self) -> AntichainRef<Tr::Time> { self.trace.advance_frontier() }
 
-    fn distinguish_since(&mut self, frontier: &[Tr::Time]) { self.trace.distinguish_since(frontier) }
-    fn distinguish_frontier(&mut self) -> &[Tr::Time] { self.trace.distinguish_frontier() }
+    fn distinguish_since(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.distinguish_since(frontier) }
+    fn distinguish_frontier(&mut self) -> AntichainRef<Tr::Time> { self.trace.distinguish_frontier() }
 
-    fn cursor_through(&mut self, upper: &[Tr::Time]) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>>::Storage)> {
+    fn cursor_through(&mut self, upper: AntichainRef<Tr::Time>) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>>::Storage)> {
         let func = &self.func;
         self.trace.cursor_through(upper)
             .map(|(cursor, storage)| (CursorFreeze::new(cursor, func.clone()), storage))

--- a/src/trace/wrappers/frontier.rs
+++ b/src/trace/wrappers/frontier.rs
@@ -5,6 +5,7 @@
 //! present deterministic times, independent of the compaction strategy.
 
 use timely::progress::Timestamp;
+use timely::progress::{Antichain, frontier::AntichainRef};
 
 use trace::{TraceReader, BatchReader, Description};
 use trace::cursor::Cursor;
@@ -16,7 +17,7 @@ where
     Tr: TraceReader,
 {
     trace: Tr,
-    frontier: Vec<Tr::Time>,
+    frontier: Antichain<Tr::Time>,
 }
 
 impl<Tr> Clone for TraceFrontier<Tr>
@@ -50,18 +51,18 @@ where
     type Cursor = CursorFrontier<Tr::Key, Tr::Val, Tr::Time, Tr::R, Tr::Cursor>;
 
     fn map_batches<F: FnMut(&Self::Batch)>(&mut self, mut f: F) {
-        let frontier = &self.frontier[..];
+        let frontier = self.frontier.elements();
         self.trace.map_batches(|batch| f(&Self::Batch::make_from(batch.clone(), frontier)))
     }
 
-    fn advance_by(&mut self, frontier: &[Tr::Time]) { self.trace.advance_by(frontier) }
-    fn advance_frontier(&mut self) -> &[Tr::Time] { self.trace.advance_frontier() }
+    fn advance_by(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.advance_by(frontier) }
+    fn advance_frontier(&mut self) -> AntichainRef<Tr::Time> { self.trace.advance_frontier() }
 
-    fn distinguish_since(&mut self, frontier: &[Tr::Time]) { self.trace.distinguish_since(frontier) }
-    fn distinguish_frontier(&mut self) -> &[Tr::Time] { self.trace.distinguish_frontier() }
+    fn distinguish_since(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.distinguish_since(frontier) }
+    fn distinguish_frontier(&mut self) -> AntichainRef<Tr::Time> { self.trace.distinguish_frontier() }
 
-    fn cursor_through(&mut self, upper: &[Tr::Time]) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>>::Storage)> {
-        let frontier = &self.frontier[..];
+    fn cursor_through(&mut self, upper: AntichainRef<Tr::Time>) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>>::Storage)> {
+        let frontier = self.frontier.elements();
         self.trace.cursor_through(upper).map(|(x,y)| (CursorFrontier::new(x, frontier), y))
     }
 }
@@ -72,10 +73,10 @@ where
     Tr::Time: Timestamp,
 {
     /// Makes a new trace wrapper
-    pub fn make_from(trace: Tr, frontier: &[Tr::Time]) -> Self {
+    pub fn make_from(trace: Tr, frontier: AntichainRef<Tr::Time>) -> Self {
         TraceFrontier {
             trace,
-            frontier: frontier.to_vec(),
+            frontier: frontier.to_owned(),
         }
     }
 }
@@ -85,7 +86,7 @@ where
 pub struct BatchFrontier<K, V, T, R, B> {
     phantom: ::std::marker::PhantomData<(K, V, T, R)>,
     batch: B,
-    frontier: Vec<T>,
+    frontier: Antichain<T>,
 }
 
 impl<K, V, T: Clone, R, B: Clone> Clone for BatchFrontier<K, V, T, R, B> {
@@ -93,7 +94,7 @@ impl<K, V, T: Clone, R, B: Clone> Clone for BatchFrontier<K, V, T, R, B> {
         BatchFrontier {
             phantom: ::std::marker::PhantomData,
             batch: self.batch.clone(),
-            frontier: self.frontier.clone(),
+            frontier: self.frontier.to_owned(),
         }
     }
 }
@@ -106,7 +107,7 @@ where
     type Cursor = BatchCursorFrontier<K, V, T, R, B>;
 
     fn cursor(&self) -> Self::Cursor {
-        BatchCursorFrontier::new(self.batch.cursor(), &self.frontier[..])
+        BatchCursorFrontier::new(self.batch.cursor(), self.frontier.elements())
     }
     fn len(&self) -> usize { self.batch.len() }
     fn description(&self) -> &Description<T> { &self.batch.description() }
@@ -118,11 +119,11 @@ where
     T: Timestamp+Lattice,
 {
     /// Makes a new batch wrapper
-    pub fn make_from(batch: B, frontier: &[T]) -> Self {
+    pub fn make_from(batch: B, frontier: AntichainRef<T>) -> Self {
         BatchFrontier {
             phantom: ::std::marker::PhantomData,
             batch,
-            frontier: frontier.to_vec(),
+            frontier: frontier.to_owned(),
         }
     }
 }
@@ -131,15 +132,15 @@ where
 pub struct CursorFrontier<K, V, T, R, C: Cursor<K, V, T, R>> {
     phantom: ::std::marker::PhantomData<(K, V, T, R)>,
     cursor: C,
-    frontier: Vec<T>,
+    frontier: Antichain<T>,
 }
 
 impl<K, V, T: Clone, R, C: Cursor<K, V, T, R>> CursorFrontier<K, V, T, R, C> {
-    fn new(cursor: C, frontier: &[T]) -> Self {
+    fn new(cursor: C, frontier: AntichainRef<T>) -> Self {
         CursorFrontier {
             phantom: ::std::marker::PhantomData,
             cursor,
-            frontier: frontier.to_vec(),
+            frontier: frontier.to_owned(),
         }
     }
 }
@@ -159,7 +160,7 @@ where
 
     #[inline]
     fn map_times<L: FnMut(&T,&R)>(&mut self, storage: &Self::Storage, mut logic: L) {
-        let frontier = &self.frontier[..];
+        let frontier = self.frontier.elements();
         let mut temp: T = <T as timely::progress::Timestamp>::minimum();
         self.cursor.map_times(storage, |time, diff| {
             temp.clone_from(time);
@@ -184,15 +185,15 @@ where
 pub struct BatchCursorFrontier<K, V, T, R, B: BatchReader<K, V, T, R>> {
     phantom: ::std::marker::PhantomData<(K, V, R)>,
     cursor: B::Cursor,
-    frontier: Vec<T>,
+    frontier: Antichain<T>,
 }
 
 impl<K, V, T: Clone, R, B: BatchReader<K, V, T, R>> BatchCursorFrontier<K, V, T, R, B> {
-    fn new(cursor: B::Cursor, frontier: &[T]) -> Self {
+    fn new(cursor: B::Cursor, frontier: AntichainRef<T>) -> Self {
         BatchCursorFrontier {
             phantom: ::std::marker::PhantomData,
             cursor,
-            frontier: frontier.to_vec(),
+            frontier: frontier.to_owned(),
         }
     }
 }
@@ -211,7 +212,7 @@ where
 
     #[inline]
     fn map_times<L: FnMut(&T,&R)>(&mut self, storage: &Self::Storage, mut logic: L) {
-        let frontier = &self.frontier[..];
+        let frontier = self.frontier.elements();
         let mut temp: T = <T as timely::progress::Timestamp>::minimum();
         self.cursor.map_times(&storage.batch, |time, diff| {
             temp.clone_from(time);

--- a/src/trace/wrappers/rc.rs
+++ b/src/trace/wrappers/rc.rs
@@ -163,8 +163,8 @@ where
 {
     fn clone(&self) -> Self {
         // increase ref counts for this frontier
-        self.wrapper.borrow_mut().adjust_advance_frontier(AntichainRef::new(&[]), self.advance_frontier.borrow());
-        self.wrapper.borrow_mut().adjust_through_frontier(AntichainRef::new(&[]), self.through_frontier.borrow());
+        self.wrapper.borrow_mut().adjust_advance_frontier(Antichain::new().borrow(), self.advance_frontier.borrow());
+        self.wrapper.borrow_mut().adjust_through_frontier(Antichain::new().borrow(), self.through_frontier.borrow());
         TraceRc {
             advance_frontier: self.advance_frontier.clone(),
             through_frontier: self.through_frontier.clone(),
@@ -179,8 +179,8 @@ where
     Tr: TraceReader,
 {
     fn drop(&mut self) {
-        self.wrapper.borrow_mut().adjust_advance_frontier(self.advance_frontier.borrow(), AntichainRef::new(&[]));
-        self.wrapper.borrow_mut().adjust_through_frontier(self.through_frontier.borrow(), AntichainRef::new(&[]));
+        self.wrapper.borrow_mut().adjust_advance_frontier(self.advance_frontier.borrow(), Antichain::new().borrow());
+        self.wrapper.borrow_mut().adjust_through_frontier(self.through_frontier.borrow(), Antichain::new().borrow());
         self.advance_frontier = Antichain::new();
         self.through_frontier = Antichain::new();
     }

--- a/src/trace/wrappers/rc.rs
+++ b/src/trace/wrappers/rc.rs
@@ -116,16 +116,16 @@ where
     /// handle no longer requires access to times other than those in the future of `frontier`, but if
     /// there are other handles to the same trace, it may not yet be able to compact.
     fn advance_by(&mut self, frontier: AntichainRef<Tr::Time>) {
-        self.wrapper.borrow_mut().adjust_advance_frontier(self.advance_frontier.elements(), frontier);
+        self.wrapper.borrow_mut().adjust_advance_frontier(self.advance_frontier.borrow(), frontier);
         self.advance_frontier = frontier.to_owned();
     }
-    fn advance_frontier(&mut self) -> AntichainRef<Tr::Time> { self.advance_frontier.elements() }
+    fn advance_frontier(&mut self) -> AntichainRef<Tr::Time> { self.advance_frontier.borrow() }
     /// Allows the trace to compact batches of times before `frontier`.
     fn distinguish_since(&mut self, frontier: AntichainRef<Tr::Time>) {
-        self.wrapper.borrow_mut().adjust_through_frontier(self.through_frontier.elements(), frontier);
+        self.wrapper.borrow_mut().adjust_through_frontier(self.through_frontier.borrow(), frontier);
         self.through_frontier = frontier.to_owned();
     }
-    fn distinguish_frontier(&mut self) -> AntichainRef<Tr::Time> { self.through_frontier.elements() }
+    fn distinguish_frontier(&mut self) -> AntichainRef<Tr::Time> { self.through_frontier.borrow() }
     /// Creates a new cursor over the wrapped trace.
     fn cursor_through(&mut self, frontier: AntichainRef<Tr::Time>) -> Option<(Tr::Cursor, <Tr::Cursor as Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>>::Storage)> {
         ::std::cell::RefCell::borrow_mut(&self.wrapper).trace.cursor_through(frontier)
@@ -163,8 +163,8 @@ where
 {
     fn clone(&self) -> Self {
         // increase ref counts for this frontier
-        self.wrapper.borrow_mut().adjust_advance_frontier(AntichainRef::new(&[]), self.advance_frontier.elements());
-        self.wrapper.borrow_mut().adjust_through_frontier(AntichainRef::new(&[]), self.through_frontier.elements());
+        self.wrapper.borrow_mut().adjust_advance_frontier(AntichainRef::new(&[]), self.advance_frontier.borrow());
+        self.wrapper.borrow_mut().adjust_through_frontier(AntichainRef::new(&[]), self.through_frontier.borrow());
         TraceRc {
             advance_frontier: self.advance_frontier.clone(),
             through_frontier: self.through_frontier.clone(),
@@ -179,8 +179,8 @@ where
     Tr: TraceReader,
 {
     fn drop(&mut self) {
-        self.wrapper.borrow_mut().adjust_advance_frontier(self.advance_frontier.elements(), AntichainRef::new(&[]));
-        self.wrapper.borrow_mut().adjust_through_frontier(self.through_frontier.elements(), AntichainRef::new(&[]));
+        self.wrapper.borrow_mut().adjust_advance_frontier(self.advance_frontier.borrow(), AntichainRef::new(&[]));
+        self.wrapper.borrow_mut().adjust_through_frontier(self.through_frontier.borrow(), AntichainRef::new(&[]));
         self.advance_frontier = Antichain::new();
         self.through_frontier = Antichain::new();
     }

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -4,6 +4,7 @@ extern crate differential_dataflow;
 
 use timely::dataflow::operators::*;
 use timely::dataflow::operators::capture::Extract;
+use timely::progress::frontier::AntichainRef;
 
 use differential_dataflow::input::InputSession;
 use differential_dataflow::collection::AsCollection;
@@ -221,7 +222,7 @@ fn import_skewed() {
             input.send(((index as u64, 1), index, 1));
             input.close();
 
-            trace.advance_by(&[peers - index]);
+            trace.advance_by(AntichainRef::new(&[peers - index]));
 
             let (captured,) = worker.dataflow(move |scope| {
                 let imported = trace.import(scope);


### PR DESCRIPTION
This PR adds an implementation of `Lattice` for timely's `Antichain` type. We are unable to add one for `AntichainRef` as we cannot produce `Self` types for it without borrowed data. Perhaps a more exotic implementation would unify this stuff, but for the moment just trying out this limited form.

The `Timestamp` trait is removed from `Lattice`. It existed in order to inherit the `minimum()` method, though `Lattice` itself does not require this. This could break some external code, but the change was relatively recent (post 0.11, I believe).

The PR only introduces the implementation, and does not tidy anything in the code yet. There should probably be a few passes of that, and potentially conversion of some `Vec<T>` types into `Antichain<T>` types where it is known that they should be such (e.g. probably in `Description`?).

Note: this will be broken until https://github.com/TimelyDataflow/timely-dataflow/pull/322 lands in the timely repo.

cc @LorenzSelv 