### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For example, here is a differential dataflow fragment to compute the out-degree 
 ```rust
 let out_degr_dist =
 edges.map(|(src, _dst)| src)    // extract source
-     .count();                  // count occurrences of source
+     .count().                  // count occurrences of source
      .map(|(_src, deg)| deg)    // extract degree
      .count();                  // count occurrences of degree
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For example, here is a differential dataflow fragment to compute the out-degree 
 ```rust
 let out_degr_dist =
 edges.map(|(src, _dst)| src)    // extract source
-     .count()                  // count occurrences of source
+     .count()                   // count occurrences of source
      .map(|(_src, deg)| deg)    // extract degree
      .count();                  // count occurrences of degree
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ let (mut input, probe) = worker.dataflow(|scope| {
 
     let out_degr_distr =
     edges.map(|(src, _dst)| src)    // extract source
-         .count();                  // count occurrences of source
+         .count()                   // count occurrences of source
          .map(|(_src, deg)| deg)    // extract degree
          .count();                  // count occurrences of degree
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For example, here is a differential dataflow fragment to compute the out-degree 
 ```rust
 let out_degr_dist =
 edges.map(|(src, _dst)| src)    // extract source
-     .count().                  // count occurrences of source
+     .count()                  // count occurrences of source
      .map(|(_src, deg)| deg)    // extract degree
      .count();                  // count occurrences of degree
 ```


### PR DESCRIPTION
Code example was incorrect - has semi-colon instead of a dot.