### PR TITLE
Permit cursor requests through empty initial frontiers

### DIFF
--- a/src/trace/implementations/spine_fueled_neu.rs
+++ b/src/trace/implementations/spine_fueled_neu.rs
@@ -118,6 +118,15 @@ where
 
     fn cursor_through(&mut self, upper: AntichainRef<T>) -> Option<(Self::Cursor, <Self::Cursor as Cursor<K, V, T, R>>::Storage)> {
 
+        // If `upper` is the minimum frontier, we can return an empty cursor.
+        // This can happen with operators that are written to expect the ability to acquire cursors
+        // for their prior frontiers, and which start at `[T::minimum()]`, such as `Reduce`, sadly.
+        if upper.less_equal(&T::minimum()) {
+            let mut cursors = Vec::new();
+            let mut storage = Vec::new();
+            return Some((CursorList::new(cursors, &storage), storage));
+        }
+
         // The supplied `upper` should have the property that for each of our
         // batch `lower` and `upper` frontiers, the supplied upper is comparable
         // to the frontier; it should not be incomparable, because the frontiers


### PR DESCRIPTION
The `cursor_through(&self, frontier)` method is meant to provide a cursor of all updates at times not greater than or equal to `frontier`. For reasons, `Reduce` calls this with frontier `{ 0 }` to get things started (it could instead maintain an `Option<Antichain<T>>`). This previously errored out if you supply `Reduce` some flavor of compacted traces (observed on *closed* traces only, where `distinguish_frontier()` was `{ }`).

The sloppy fix here is just to permit `cursor_through` on empty frontiers, returning an empty cursor.