### PR TITLE
Generalize arrangements to Containers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ abomonation_derive = "0.5"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
 #timely = { path = "../timely-dataflow/timely/", default-features = false }
 fnv="1.0.2"
+columnation = { git = "http://github.com/frankmcsherry/columnation" }
 
 [features]
 default = ["timely/getopts"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ abomonation_derive = "0.5"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
 #timely = { path = "../timely-dataflow/timely/", default-features = false }
 fnv="1.0.2"
-columnation = { git = "http://github.com/frankmcsherry/columnation" }
 
 [features]
 default = ["timely/getopts"]

--- a/examples/columnation.rs
+++ b/examples/columnation.rs
@@ -1,0 +1,101 @@
+extern crate timely;
+extern crate differential_dataflow;
+
+use timely::dataflow::operators::probe::Handle;
+
+use differential_dataflow::input::Input;
+
+fn main() {
+
+    let keys: usize = std::env::args().nth(1).unwrap().parse().unwrap();
+    let size: usize = std::env::args().nth(2).unwrap().parse().unwrap();
+
+    let mode = std::env::args().any(|a| a == "new");
+
+    if mode {
+        println!("Running NEW arrangement");
+    }
+    else {
+        println!("Running OLD arrangement");
+    }
+
+    let timer1 = ::std::time::Instant::now();
+    let timer2 = timer1.clone();
+
+    // define a new computational scope, in which to run BFS
+    timely::execute_from_args(std::env::args(), move |worker| {
+
+        // define BFS dataflow; return handles to roots and edges inputs
+        let mut probe = Handle::new();
+        let (mut data_input, mut keys_input) = worker.dataflow(|scope| {
+
+            use differential_dataflow::operators::{arrange::Arrange, JoinCore};
+            use differential_dataflow::trace::implementations::ord::{OrdKeySpine, ColKeySpine};
+
+            let (data_input, data) = scope.new_collection::<String, isize>();
+            let (keys_input, keys) = scope.new_collection::<String, isize>();
+
+            if mode {
+                let data = data.arrange::<ColKeySpine<_,_,_>>();
+                let keys = keys.arrange::<ColKeySpine<_,_,_>>();
+                keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
+                    .probe_with(&mut probe);
+            }
+            else {
+                let data = data.arrange::<OrdKeySpine<_,_,_>>();
+                let keys = keys.arrange::<OrdKeySpine<_,_,_>>();
+                keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
+                    .probe_with(&mut probe);
+            }
+
+            (data_input, keys_input)
+        });
+
+        // Load up data in batches.
+        let mut counter = 0;
+        while counter < 10 * keys {
+            let mut i = worker.index();
+            while i < size {
+                let val = (counter + i) % keys;
+                data_input.insert(format!("{:?}", val));
+                i += worker.peers();
+            }
+            counter += size;
+            data_input.advance_to(data_input.time() + 1);
+            data_input.flush();
+            keys_input.advance_to(keys_input.time() + 1);
+            keys_input.flush();
+            while probe.less_than(data_input.time()) {
+                worker.step();
+            }
+        }
+        println!("{:?}\tloading complete", timer1.elapsed());
+
+        let mut queries = 0;
+
+        while queries < 10 * keys {
+            let mut i = worker.index();
+            while i < size {
+                let val = (queries + i) % keys;
+                keys_input.insert(format!("{:?}", val));
+                i += worker.peers();
+            }
+            queries += size;
+            data_input.advance_to(data_input.time() + 1);
+            data_input.flush();
+            keys_input.advance_to(keys_input.time() + 1);
+            keys_input.flush();
+            while probe.less_than(data_input.time()) {
+                worker.step();
+            }
+        }
+
+        println!("{:?}\tqueries complete", timer1.elapsed());
+
+        // loop { }
+
+    }).unwrap();
+
+    println!("{:?}\tshut down", timer2.elapsed());
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,6 @@ impl<T: timely::ExchangeData + Ord + Debug> ExchangeData for T { }
 
 extern crate fnv;
 extern crate timely;
-extern crate columnation;
 
 #[macro_use]
 extern crate abomonation_derive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,8 @@
 //! of the new and old counts of the old and new degrees of the affected node).
 
 #![forbid(missing_docs)]
+#![allow(array_into_iter)]
+
 
 use std::fmt::Debug;
 
@@ -92,6 +94,7 @@ impl<T: timely::ExchangeData + Ord + Debug> ExchangeData for T { }
 
 extern crate fnv;
 extern crate timely;
+extern crate columnation;
 
 #[macro_use]
 extern crate abomonation_derive;

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -542,9 +542,6 @@ where
                 // Capabilities for the lower envelope of updates in `batcher`.
                 let mut capabilities = Antichain::<Capability<G::Timestamp>>::new();
 
-                let mut buffer = Vec::new();
-
-
                 let (activator, effort) =
                 if let Some(effort) = self.inner.scope().config().get::<isize>("differential/idle_merge_effort").cloned() {
                     (Some(self.scope().activator_for(&info.address[..])), Some(effort))
@@ -569,8 +566,7 @@ where
 
                     input.for_each(|cap, data| {
                         capabilities.insert(cap.retain());
-                        data.swap(&mut buffer);
-                        batcher.push_batch(&mut buffer);
+                        batcher.push_batch(data);
                     });
 
                     // The frontier may have advanced by multiple elements, which is an issue because

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -1,5 +1,6 @@
 //! A general purpose `Batcher` implementation based on radix sort.
 
+use timely::communication::message::RefOrMut;
 use timely::progress::frontier::Antichain;
 
 use ::difference::Semigroup;
@@ -33,8 +34,20 @@ where
     }
 
     #[inline(never)]
-    fn push_batch(&mut self, batch: &mut Vec<((B::Key,B::Val),B::Time,B::R)>) {
-        self.sorter.push(batch);
+    fn push_batch(&mut self, batch: RefOrMut<Vec<((B::Key,B::Val),B::Time,B::R)>>) {
+        // `batch` is either a shared reference or an owned allocations.
+        match batch {
+            RefOrMut::Ref(reference) => {
+                // This is a moment at which we could capture the allocations backing
+                // `batch` into a different form of region, rather than just  cloning.
+                let mut owned: Vec<_> = self.sorter.empty();
+                owned.clone_from(reference);
+                self.sorter.push(&mut owned);
+            },
+            RefOrMut::Mut(reference) => {
+                self.sorter.push(reference);
+            }
+        }
     }
 
     // Sealing a batch means finding those updates with times not greater or equal to any time
@@ -58,7 +71,6 @@ where
         for mut buffer in merged.drain(..) {
             for ((key, val), time, diff) in buffer.drain(..) {
                 if upper.less_equal(&time) {
-                    // keep_count += 1;
                     self.frontier.insert(time.clone());
                     if keep.len() == keep.capacity() {
                         if keep.len() > 0 {
@@ -69,7 +81,6 @@ where
                     keep.push(((key, val), time, diff));
                 }
                 else {
-                    // seal_count += 1;
                     builder.push((key, val, time, diff));
                 }
             }

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -66,7 +66,6 @@ impl<T> RetainFrom<T> for Vec<T> {
         let mut write_position = index;
         for position in index .. self.len() {
             if predicate(position, &self[position]) {
-                // TODO: compact the inner region and update pointers.
                 self.swap(position, write_position);
                 write_position += 1;
             }
@@ -212,7 +211,7 @@ where
                 keys_pos += 1;
             }
             let lower = vals_off[index].try_into().unwrap();
-            let upper =    vals_off[index+1].try_into().unwrap();
+            let upper = vals_off[index+1].try_into().unwrap();
             if lower < upper {
                 vals_off[write_position+1] = vals_off[index+1];
                 write_position += 1;
@@ -228,8 +227,8 @@ where
         let offs = &mut layer.offs;
         let mut write_position = key_start;
         layer.keys.retain_from(key_start, |index, _item| {
-            let lower =    offs[index].try_into().unwrap();
-            let upper =    offs[index+1].try_into().unwrap();
+            let lower = offs[index].try_into().unwrap();
+            let upper = offs[index+1].try_into().unwrap();
             if lower < upper {
                 offs[write_position+1] = offs[index+1];
                 write_position += 1;
@@ -575,8 +574,8 @@ where
         let offs = &mut layer.offs;
         let mut write_position = key_start;
         layer.keys.retain_from(key_start, |index, _item| {
-            let lower =    offs[index].try_into().unwrap();
-            let upper =    offs[index+1].try_into().unwrap();
+            let lower = offs[index].try_into().unwrap();
+            let upper = offs[index+1].try_into().unwrap();
             if lower < upper {
                 offs[write_position+1] = offs[index+1];
                 write_position += 1;

--- a/src/trace/layers/mod.rs
+++ b/src/trace/layers/mod.rs
@@ -106,6 +106,79 @@ pub trait Cursor<Storage> {
     fn reposition(&mut self, storage: &Storage, lower: usize, upper: usize);
 }
 
+/// A general-purpose container resembling `Vec<T>`.
+pub trait Container {
+    /// The type of contained item.
+    type Item;
+    /// Inserts an owned item.
+    fn push(&mut self, item: Self::Item);
+    /// Inserts a borrowed item.
+    fn copy(&mut self, item: &Self::Item);
+    /// Extends from a slice of items.
+    fn copy_slice(&mut self, slice: &[Self::Item]);
+    /// Creates a new container.
+    fn new() -> Self;
+    /// Creates a new container with sufficient capacity.
+    fn with_capacity(size: usize) -> Self;
+    /// Reserves additional capacity.
+    fn reserve(&mut self, additional: usize);
+    /// Creates a new container with sufficient capacity.
+    fn merge_capacity(cont1: &Self, cont2: &Self) -> Self;
+}
+
+impl<T: Clone> Container for Vec<T> {
+    type Item = T;
+    fn push(&mut self, item: T) {
+        self.push(item);
+    }
+    fn copy(&mut self, item: &T) {
+        self.push(item.clone());
+    }
+    fn copy_slice(&mut self, slice: &[T]) {
+        self.extend_from_slice(slice);
+    }
+    fn new() -> Self {
+        Vec::new()
+    }
+    fn with_capacity(size: usize) -> Self {
+        Vec::with_capacity(size)
+    }
+    fn reserve(&mut self, additional: usize) {
+        self.reserve(additional);
+    }
+    fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
+        Vec::with_capacity(cont1.len() + cont2.len())
+    }
+}
+
+use columnation::{Columnation, ColumnStack};
+impl<T: Columnation> Container for ColumnStack<T> {
+    type Item = T;
+    fn push(&mut self, item: T) {
+        self.copy(&item);
+    }
+    fn copy(&mut self, item: &T) {
+        self.copy(item);
+    }
+    fn copy_slice(&mut self, slice: &[T]) {
+        for item in slice.iter() {
+            self.copy(item);
+        }
+    }
+    fn new() -> Self {
+        Self::default()
+    }
+    fn with_capacity(_size: usize) -> Self {
+        Self::default()
+    }
+    fn reserve(&mut self, _additional: usize) {
+    }
+    fn merge_capacity(_cont1: &Self, _cont2: &Self) -> Self {
+        Self::default()
+    }
+}
+
+
 /// Reports the number of elements satisfing the predicate.
 ///
 /// This methods *relies strongly* on the assumption that the predicate

--- a/src/trace/layers/ordered.rs
+++ b/src/trace/layers/ordered.rs
@@ -1,6 +1,6 @@
 //! Implementation using ordered keys and exponential search.
 
-use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, Container, advance};
+use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, BatchContainer, advance};
 use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
 use std::ops::{Sub,Add,Deref};
@@ -23,7 +23,7 @@ where
 pub struct OrderedLayer<K, L, O=usize, C=Vec<K>>
 where
     K: Ord,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
     /// The keys of the layer.
@@ -40,7 +40,7 @@ where
 impl<K, L, O, C> Trie for OrderedLayer<K, L, O, C>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     L: Trie,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -77,7 +77,7 @@ where
 pub struct OrderedBuilder<K, L, O=usize, C=Vec<K>>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
     /// Keys
@@ -91,7 +91,7 @@ where
 impl<K, L, O, C> Builder for OrderedBuilder<K, L, O, C>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     L: Builder,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -115,7 +115,7 @@ where
 impl<K, L, O, C> MergeBuilder for OrderedBuilder<K, L, O, C>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     L: MergeBuilder,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -162,7 +162,7 @@ where
 impl<K, L, O, C> OrderedBuilder<K, L, O, C>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     L: MergeBuilder,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -210,12 +210,12 @@ where
 impl<K, L, O, C> TupleBuilder for OrderedBuilder<K, L, O, C>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     L: TupleBuilder,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
     type Item = (K, L::Item);
-    fn new() -> Self { OrderedBuilder { keys: C::new(), offs: vec![O::try_from(0).unwrap()], vals: L::new() } }
+    fn new() -> Self { OrderedBuilder { keys: C::default(), offs: vec![O::try_from(0).unwrap()], vals: L::new() } }
     fn with_capacity(cap: usize) -> Self {
         let mut offs = Vec::with_capacity(cap + 1);
         offs.push(O::try_from(0).unwrap());
@@ -252,7 +252,7 @@ pub struct OrderedCursor<L: Trie> {
 impl<K, L, O, C> Cursor<OrderedLayer<K, L, O, C>> for OrderedCursor<L>
 where
     K: Ord+Clone,
-    C: Container<Item=K>+Deref<Target=[K]>,
+    C: BatchContainer<Item=K>+Deref<Target=[K]>,
     L: Trie,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {

--- a/src/trace/layers/ordered.rs
+++ b/src/trace/layers/ordered.rs
@@ -1,9 +1,9 @@
 //! Implementation using ordered keys and exponential search.
 
-use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, advance};
+use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, Container, advance};
 use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
-use std::ops::{Sub,Add};
+use std::ops::{Sub,Add,Deref};
 
 /// Trait for types used as offsets into an ordered layer.
 /// This is usually `usize`, but `u32` can also be used in applications
@@ -20,13 +20,14 @@ where
 ///
 /// In this representation, the values for `keys[i]` are found at `vals[offs[i] .. offs[i+1]]`.
 #[derive(Debug, Eq, PartialEq, Clone, Abomonation)]
-pub struct OrderedLayer<K, L, O=usize>
+pub struct OrderedLayer<K, L, O=usize, C=Vec<K>>
 where
     K: Ord,
+    C: Container<Item=K>+Deref<Target=[K]>,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
     /// The keys of the layer.
-    pub keys: Vec<K>,
+    pub keys: C,
     /// The offsets associate with each key.
     ///
     /// The bounds for `keys[i]` are `(offs[i], offs[i+1]`). The offset array is guaranteed to be one
@@ -36,16 +37,17 @@ where
     pub vals: L,
 }
 
-impl<K, L, O> Trie for OrderedLayer<K, L, O>
+impl<K, L, O, C> Trie for OrderedLayer<K, L, O, C>
 where
     K: Ord+Clone,
+    C: Container<Item=K>+Deref<Target=[K]>,
     L: Trie,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
     type Item = (K, L::Item);
     type Cursor = OrderedCursor<L>;
-    type MergeBuilder = OrderedBuilder<K, L::MergeBuilder, O>;
-    type TupleBuilder = OrderedBuilder<K, L::TupleBuilder, O>;
+    type MergeBuilder = OrderedBuilder<K, L::MergeBuilder, O, C>;
+    type TupleBuilder = OrderedBuilder<K, L::TupleBuilder, O, C>;
 
     fn keys(&self) -> usize { self.keys.len() }
     fn tuples(&self) -> usize { self.vals.tuples() }
@@ -72,26 +74,28 @@ where
 }
 
 /// Assembles a layer of this
-pub struct OrderedBuilder<K, L, O=usize>
+pub struct OrderedBuilder<K, L, O=usize, C=Vec<K>>
 where
-    K: Ord,
+    K: Ord+Clone,
+    C: Container<Item=K>+Deref<Target=[K]>,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
     /// Keys
-    pub keys: Vec<K>,
+    pub keys: C,
     /// Offsets
     pub offs: Vec<O>,
     /// The next layer down
     pub vals: L,
 }
 
-impl<K, L, O> Builder for OrderedBuilder<K, L, O>
+impl<K, L, O, C> Builder for OrderedBuilder<K, L, O, C>
 where
     K: Ord+Clone,
+    C: Container<Item=K>+Deref<Target=[K]>,
     L: Builder,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
-    type Trie = OrderedLayer<K, L::Trie, O>;
+    type Trie = OrderedLayer<K, L::Trie, O, C>;
     fn boundary(&mut self) -> usize {
         self.offs[self.keys.len()] = O::try_from(self.vals.boundary()).unwrap();
         self.keys.len()
@@ -108,9 +112,10 @@ where
     }
 }
 
-impl<K, L, O> MergeBuilder for OrderedBuilder<K, L, O>
+impl<K, L, O, C> MergeBuilder for OrderedBuilder<K, L, O, C>
 where
     K: Ord+Clone,
+    C: Container<Item=K>+Deref<Target=[K]>,
     L: MergeBuilder,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -118,7 +123,7 @@ where
         let mut offs = Vec::with_capacity(other1.keys() + other2.keys() + 1);
         offs.push(O::try_from(0 as usize).unwrap());
         OrderedBuilder {
-            keys: Vec::with_capacity(other1.keys() + other2.keys()),
+            keys: C::merge_capacity(&other1.keys, &other2.keys),
             offs: offs,
             vals: L::with_capacity(&other1.vals, &other2.vals),
         }
@@ -129,7 +134,7 @@ where
         let other_basis = other.offs[lower];
         let self_basis = self.offs.last().map(|&x| x).unwrap_or(O::try_from(0).unwrap());
 
-        self.keys.extend_from_slice(&other.keys[lower .. upper]);
+        self.keys.copy_slice(&other.keys[lower .. upper]);
         for index in lower .. upper {
             self.offs.push((other.offs[index + 1] + self_basis) - other_basis);
         }
@@ -154,9 +159,10 @@ where
     }
 }
 
-impl<K, L, O> OrderedBuilder<K, L, O>
+impl<K, L, O, C> OrderedBuilder<K, L, O, C>
 where
     K: Ord+Clone,
+    C: Container<Item=K>+Deref<Target=[K]>,
     L: MergeBuilder,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
@@ -183,7 +189,7 @@ where
                     (&trie2.vals, trie2.offs[*lower2].try_into().unwrap(), trie2.offs[*lower2 + 1].try_into().unwrap())
                 );
                 if upper > lower {
-                    self.keys.push(trie1.keys[*lower1].clone());
+                    self.keys.copy(&trie1.keys[*lower1]);
                     self.offs.push(O::try_from(upper).unwrap());
                 }
 
@@ -201,19 +207,20 @@ where
     }
 }
 
-impl<K, L, O> TupleBuilder for OrderedBuilder<K, L, O>
+impl<K, L, O, C> TupleBuilder for OrderedBuilder<K, L, O, C>
 where
     K: Ord+Clone,
+    C: Container<Item=K>+Deref<Target=[K]>,
     L: TupleBuilder,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
     type Item = (K, L::Item);
-    fn new() -> Self { OrderedBuilder { keys: Vec::new(), offs: vec![O::try_from(0).unwrap()], vals: L::new() } }
+    fn new() -> Self { OrderedBuilder { keys: C::new(), offs: vec![O::try_from(0).unwrap()], vals: L::new() } }
     fn with_capacity(cap: usize) -> Self {
         let mut offs = Vec::with_capacity(cap + 1);
         offs.push(O::try_from(0).unwrap());
         OrderedBuilder{
-            keys: Vec::with_capacity(cap),
+            keys: C::with_capacity(cap),
             offs: offs,
             vals: L::with_capacity(cap),
         }
@@ -236,23 +243,22 @@ where
 /// A cursor with a child cursor that is updated as we move.
 #[derive(Debug)]
 pub struct OrderedCursor<L: Trie> {
-    // keys: OwningRef<Rc<Erased>, [K]>,
-    // offs: OwningRef<Rc<Erased>, [usize]>,
     pos: usize,
     bounds: (usize, usize),
     /// The cursor for the trie layer below this one.
     pub child: L::Cursor,
 }
 
-impl<K, L, O> Cursor<OrderedLayer<K, L, O>> for OrderedCursor<L>
+impl<K, L, O, C> Cursor<OrderedLayer<K, L, O, C>> for OrderedCursor<L>
 where
-    K: Ord,
+    K: Ord+Clone,
+    C: Container<Item=K>+Deref<Target=[K]>,
     L: Trie,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
     type Key = K;
-    fn key<'a>(&self, storage: &'a OrderedLayer<K, L, O>) -> &'a Self::Key { &storage.keys[self.pos] }
-    fn step(&mut self, storage: &OrderedLayer<K, L, O>) {
+    fn key<'a>(&self, storage: &'a OrderedLayer<K, L, O, C>) -> &'a Self::Key { &storage.keys[self.pos] }
+    fn step(&mut self, storage: &OrderedLayer<K, L, O, C>) {
         self.pos += 1;
         if self.valid(storage) {
             self.child.reposition(&storage.vals, storage.offs[self.pos].try_into().unwrap(), storage.offs[self.pos + 1].try_into().unwrap());
@@ -261,21 +267,21 @@ where
             self.pos = self.bounds.1;
         }
     }
-    fn seek(&mut self, storage: &OrderedLayer<K, L, O>, key: &Self::Key) {
+    fn seek(&mut self, storage: &OrderedLayer<K, L, O, C>, key: &Self::Key) {
         self.pos += advance(&storage.keys[self.pos .. self.bounds.1], |k| k.lt(key));
         if self.valid(storage) {
             self.child.reposition(&storage.vals, storage.offs[self.pos].try_into().unwrap(), storage.offs[self.pos + 1].try_into().unwrap());
         }
     }
     // fn size(&self) -> usize { self.bounds.1 - self.bounds.0 }
-    fn valid(&self, _storage: &OrderedLayer<K, L, O>) -> bool { self.pos < self.bounds.1 }
-    fn rewind(&mut self, storage: &OrderedLayer<K, L, O>) {
+    fn valid(&self, _storage: &OrderedLayer<K, L, O, C>) -> bool { self.pos < self.bounds.1 }
+    fn rewind(&mut self, storage: &OrderedLayer<K, L, O, C>) {
         self.pos = self.bounds.0;
         if self.valid(storage) {
             self.child.reposition(&storage.vals, storage.offs[self.pos].try_into().unwrap(), storage.offs[self.pos + 1].try_into().unwrap());
         }
     }
-    fn reposition(&mut self, storage: &OrderedLayer<K, L, O>, lower: usize, upper: usize) {
+    fn reposition(&mut self, storage: &OrderedLayer<K, L, O, C>, lower: usize, upper: usize) {
         self.pos = lower;
         self.bounds = (lower, upper);
         if self.valid(storage) {

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -2,22 +2,29 @@
 
 use ::difference::Semigroup;
 
-use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, advance};
+use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, Container, advance};
+use std::ops::Deref;
 
 /// A layer of unordered values.
 #[derive(Debug, Eq, PartialEq, Clone, Abomonation)]
-pub struct OrderedLeaf<K, R> {
+pub struct OrderedLeaf<K, R, C=Vec<(K,R)>>
+where
+    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+{
     /// Unordered values.
-    pub vals: Vec<(K, R)>,
+    pub vals: C,
 }
 
-impl<K: Ord+Clone, R: Semigroup+Clone> Trie for OrderedLeaf<K, R> {
+impl<K: Ord+Clone, R: Semigroup+Clone, C> Trie for OrderedLeaf<K, R, C>
+where
+    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+{
     type Item = (K, R);
     type Cursor = OrderedLeafCursor;
-    type MergeBuilder = OrderedLeafBuilder<K, R>;
-    type TupleBuilder = OrderedLeafBuilder<K, R>;
+    type MergeBuilder = OrderedLeafBuilder<K, R, C>;
+    type TupleBuilder = OrderedLeafBuilder<K, R, C>;
     fn keys(&self) -> usize { self.vals.len() }
-    fn tuples(&self) -> usize { <OrderedLeaf<K, R> as Trie>::keys(&self) }
+    fn tuples(&self) -> usize { <OrderedLeaf<K, R, C> as Trie>::keys(&self) }
     fn cursor_from(&self, lower: usize, upper: usize) -> Self::Cursor {
         OrderedLeafCursor {
             bounds: (lower, upper),
@@ -27,26 +34,35 @@ impl<K: Ord+Clone, R: Semigroup+Clone> Trie for OrderedLeaf<K, R> {
 }
 
 /// A builder for unordered values.
-pub struct OrderedLeafBuilder<K, R> {
+pub struct OrderedLeafBuilder<K, R, C=Vec<(K,R)>>
+where
+    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+{
     /// Unordered values.
-    pub vals: Vec<(K, R)>,
+    pub vals: C,
 }
 
-impl<K: Ord+Clone, R: Semigroup+Clone> Builder for OrderedLeafBuilder<K, R> {
-    type Trie = OrderedLeaf<K, R>;
+impl<K: Ord+Clone, R: Semigroup+Clone, C> Builder for OrderedLeafBuilder<K, R, C>
+where
+    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+{
+    type Trie = OrderedLeaf<K, R, C>;
     fn boundary(&mut self) -> usize { self.vals.len() }
     fn done(self) -> Self::Trie { OrderedLeaf { vals: self.vals } }
 }
 
-impl<K: Ord+Clone, R: Semigroup+Clone> MergeBuilder for OrderedLeafBuilder<K, R> {
+impl<K: Ord+Clone, R: Semigroup+Clone, C> MergeBuilder for OrderedLeafBuilder<K, R, C>
+where
+    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+{
     fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
         OrderedLeafBuilder {
-            vals: Vec::with_capacity(<OrderedLeaf<K, R> as Trie>::keys(other1) + <OrderedLeaf<K, R> as Trie>::keys(other2)),
+            vals: C::merge_capacity(&other1.vals, &other2.vals),
         }
     }
     #[inline]
     fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
-        self.vals.extend_from_slice(&other.vals[lower .. upper]);
+        self.vals.copy_slice(&other.vals[lower .. upper]);
     }
     fn push_merge(&mut self, other1: (&Self::Trie, usize, usize), other2: (&Self::Trie, usize, usize)) -> usize {
 
@@ -63,7 +79,7 @@ impl<K: Ord+Clone, R: Semigroup+Clone> MergeBuilder for OrderedLeafBuilder<K, R>
                     // determine how far we can advance lower1 until we reach/pass lower2
                     let step = 1 + advance(&trie1.vals[(1+lower1)..upper1], |x| x.0 < trie2.vals[lower2].0);
                     let step = std::cmp::min(step, 1000);
-                    <OrderedLeafBuilder<K, R> as MergeBuilder>::copy_range(self, trie1, lower1, lower1 + step);
+                    <OrderedLeafBuilder<K, R, C> as MergeBuilder>::copy_range(self, trie1, lower1, lower1 + step);
                     lower1 += step;
                 }
                 ::std::cmp::Ordering::Equal => {
@@ -81,23 +97,26 @@ impl<K: Ord+Clone, R: Semigroup+Clone> MergeBuilder for OrderedLeafBuilder<K, R>
                     // determine how far we can advance lower2 until we reach/pass lower1
                     let step = 1 + advance(&trie2.vals[(1+lower2)..upper2], |x| x.0 < trie1.vals[lower1].0);
                     let step = std::cmp::min(step, 1000);
-                    <OrderedLeafBuilder<K, R> as MergeBuilder>::copy_range(self, trie2, lower2, lower2 + step);
+                    <OrderedLeafBuilder<K, R, C> as MergeBuilder>::copy_range(self, trie2, lower2, lower2 + step);
                     lower2 += step;
                 }
             }
         }
 
-        if lower1 < upper1 { <OrderedLeafBuilder<K, R> as MergeBuilder>::copy_range(self, trie1, lower1, upper1); }
-        if lower2 < upper2 { <OrderedLeafBuilder<K, R> as MergeBuilder>::copy_range(self, trie2, lower2, upper2); }
+        if lower1 < upper1 { <OrderedLeafBuilder<K, R, C> as MergeBuilder>::copy_range(self, trie1, lower1, upper1); }
+        if lower2 < upper2 { <OrderedLeafBuilder<K, R, C> as MergeBuilder>::copy_range(self, trie2, lower2, upper2); }
 
         self.vals.len()
     }
 }
 
-impl<K: Ord+Clone, R: Semigroup+Clone> TupleBuilder for OrderedLeafBuilder<K, R> {
+impl<K: Ord+Clone, R: Semigroup+Clone, C> TupleBuilder for OrderedLeafBuilder<K, R, C>
+where
+    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+{
     type Item = (K, R);
-    fn new() -> Self { OrderedLeafBuilder { vals: Vec::new() } }
-    fn with_capacity(cap: usize) -> Self { OrderedLeafBuilder { vals: Vec::with_capacity(cap) } }
+    fn new() -> Self { OrderedLeafBuilder { vals: C::new() } }
+    fn with_capacity(cap: usize) -> Self { OrderedLeafBuilder { vals: C::with_capacity(cap) } }
     #[inline] fn push_tuple(&mut self, tuple: (K, R)) { self.vals.push(tuple) }
 }
 
@@ -110,23 +129,26 @@ pub struct OrderedLeafCursor {
     bounds: (usize, usize),
 }
 
-impl<K: Clone, R: Clone> Cursor<OrderedLeaf<K, R>> for OrderedLeafCursor {
+impl<K: Clone, R: Clone, C> Cursor<OrderedLeaf<K, R, C>> for OrderedLeafCursor
+where
+    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+{
     type Key = (K, R);
-    fn key<'a>(&self, storage: &'a OrderedLeaf<K, R>) -> &'a Self::Key { &storage.vals[self.pos] }
-    fn step(&mut self, storage: &OrderedLeaf<K, R>) {
+    fn key<'a>(&self, storage: &'a OrderedLeaf<K, R, C>) -> &'a Self::Key { &storage.vals[self.pos] }
+    fn step(&mut self, storage: &OrderedLeaf<K, R, C>) {
         self.pos += 1;
         if !self.valid(storage) {
             self.pos = self.bounds.1;
         }
     }
-    fn seek(&mut self, _storage: &OrderedLeaf<K, R>, _key: &Self::Key) {
+    fn seek(&mut self, _storage: &OrderedLeaf<K, R, C>, _key: &Self::Key) {
         panic!("seeking in an OrderedLeafCursor; should be fine, panic is wrong.");
     }
-    fn valid(&self, _storage: &OrderedLeaf<K, R>) -> bool { self.pos < self.bounds.1 }
-    fn rewind(&mut self, _storage: &OrderedLeaf<K, R>) {
+    fn valid(&self, _storage: &OrderedLeaf<K, R, C>) -> bool { self.pos < self.bounds.1 }
+    fn rewind(&mut self, _storage: &OrderedLeaf<K, R, C>) {
         self.pos = self.bounds.0;
     }
-    fn reposition(&mut self, _storage: &OrderedLeaf<K, R>, lower: usize, upper: usize) {
+    fn reposition(&mut self, _storage: &OrderedLeaf<K, R, C>, lower: usize, upper: usize) {
         self.pos = lower;
         self.bounds = (lower, upper);
     }

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -2,14 +2,14 @@
 
 use ::difference::Semigroup;
 
-use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, Container, advance};
+use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, BatchContainer, advance};
 use std::ops::Deref;
 
 /// A layer of unordered values.
 #[derive(Debug, Eq, PartialEq, Clone, Abomonation)]
 pub struct OrderedLeaf<K, R, C=Vec<(K,R)>>
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     /// Unordered values.
     pub vals: C,
@@ -17,7 +17,7 @@ where
 
 impl<K: Ord+Clone, R: Semigroup+Clone, C> Trie for OrderedLeaf<K, R, C>
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     type Item = (K, R);
     type Cursor = OrderedLeafCursor;
@@ -36,7 +36,7 @@ where
 /// A builder for unordered values.
 pub struct OrderedLeafBuilder<K, R, C=Vec<(K,R)>>
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     /// Unordered values.
     pub vals: C,
@@ -44,7 +44,7 @@ where
 
 impl<K: Ord+Clone, R: Semigroup+Clone, C> Builder for OrderedLeafBuilder<K, R, C>
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     type Trie = OrderedLeaf<K, R, C>;
     fn boundary(&mut self) -> usize { self.vals.len() }
@@ -53,7 +53,7 @@ where
 
 impl<K: Ord+Clone, R: Semigroup+Clone, C> MergeBuilder for OrderedLeafBuilder<K, R, C>
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     fn with_capacity(other1: &Self::Trie, other2: &Self::Trie) -> Self {
         OrderedLeafBuilder {
@@ -112,10 +112,10 @@ where
 
 impl<K: Ord+Clone, R: Semigroup+Clone, C> TupleBuilder for OrderedLeafBuilder<K, R, C>
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     type Item = (K, R);
-    fn new() -> Self { OrderedLeafBuilder { vals: C::new() } }
+    fn new() -> Self { OrderedLeafBuilder { vals: C::default() } }
     fn with_capacity(cap: usize) -> Self { OrderedLeafBuilder { vals: C::with_capacity(cap) } }
     #[inline] fn push_tuple(&mut self, tuple: (K, R)) { self.vals.push(tuple) }
 }
@@ -131,7 +131,7 @@ pub struct OrderedLeafCursor {
 
 impl<K: Clone, R: Clone, C> Cursor<OrderedLeaf<K, R, C>> for OrderedLeafCursor
 where
-    C: Container<Item=(K,R)>+Deref<Target=[(K,R)]>,
+    C: BatchContainer<Item=(K, R)>+Deref<Target=[(K, R)]>,
 {
     type Key = (K, R);
     fn key<'a>(&self, storage: &'a OrderedLeaf<K, R, C>) -> &'a Self::Key { &storage.vals[self.pos] }

--- a/tests/trace.rs
+++ b/tests/trace.rs
@@ -21,11 +21,12 @@ fn get_trace() -> Spine<Rc<OrdValBatch<u64, u64, usize, i64>>> {
     {
         let mut batcher = <<IntegerTrace as TraceReader>::Batch as Batch>::Batcher::new();
 
-        batcher.push_batch(&mut vec![
+        use timely::communication::message::RefOrMut;
+        batcher.push_batch(RefOrMut::Mut(&mut vec![
             ((1, 2), 0, 1),
             ((2, 3), 1, 1),
             ((2, 3), 2, -1),
-        ]);
+        ]));
 
         let batch_ts = &[1, 2, 3];
         let batches = batch_ts.iter().map(move |i| batcher.seal(Antichain::from_elem(*i)));


### PR DESCRIPTION
This PR-in-progress generalizes the storage used for arrangement batches to a `Container` trait that informally looks like a `Vec` but is not obliged to have that implementation. In particular, we are interested in the `Columnation` implementation, which maintains a `Vec`-like storage but whose items can arrange their owned members in contiguous memory.