### PR TITLE
Add `histogram` method

### DIFF
--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -4,7 +4,7 @@
 //! operators have specialized implementations to make them work efficiently, and are in addition
 //! to several operations defined directly on the `Collection` type (e.g. `map` and `filter`).
 
-pub use self::reduce::{Reduce, Threshold, Count};
+pub use self::reduce::{Reduce, Threshold, Count, Histogram};
 pub use self::consolidate::Consolidate;
 pub use self::iterate::Iterate;
 pub use self::join::{Join, JoinCore};

--- a/tests/reduce.rs
+++ b/tests/reduce.rs
@@ -4,7 +4,7 @@ extern crate differential_dataflow;
 use timely::dataflow::operators::{ToStream, Capture, Map};
 use timely::dataflow::operators::capture::Extract;
 use differential_dataflow::AsCollection;
-use differential_dataflow::operators::{Reduce, Count};
+use differential_dataflow::operators::{Consolidate, Reduce, Count, Histogram};
 
 #[test]
 fn reduce() {
@@ -42,4 +42,34 @@ fn reduce_scaling() {
 
     let extracted = data.extract();
     assert_eq!(extracted.len(), 1);
+}
+
+#[test]
+fn histogram() {
+    let data = timely::example(|scope| {
+        let col1 = vec![0, 1, 1, 2, 2, 2]
+            .into_iter()
+            .map(|x| (x, Default::default(), 1))
+            .to_stream(scope)
+            .as_collection();
+        let keys = vec![0, 2, 3]
+            .into_iter()
+            .map(|x| (x, Default::default(), 1))
+            .to_stream(scope)
+            .as_collection();
+
+        col1.histogram(&keys).consolidate().inner.capture()
+    });
+
+    let extracted = data.extract();
+    assert_eq!(extracted.len(), 1);
+    assert_eq!(
+        extracted[0].1,
+        vec![
+            ((0, 1), Default::default(), 1),
+            // 1 is not present because it wasn't in the key set
+            ((2, 3), Default::default(), 1),
+            ((3, 0), Default::default(), 1)
+        ]
+    );
 }


### PR DESCRIPTION
I'm finding in general that I consistently have to add special-case logic to get 0-counts to show up when calling `count`. This method would make that unnecessary.