### PR TITLE
operators/join.rs: fix documentation for `join`

### DIFF
--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -28,7 +28,9 @@ use trace::TraceReader;
 /// Join implementations for `(key,val)` data.
 pub trait Join<G: Scope, K: Data, V: Data, R: Semigroup> {
 
-    /// Matches pairs `(key,val1)` and `(key,val2)` based on `key` and then applies a function.
+    /// Matches pairs `(key,val1)` and `(key,val2)` based on `key` and yields pairs `(key, (val1, val2))`.
+    ///
+    /// The [`join_map`](Join::join_map) method may be more convenient for non-trivial processing pipelines.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The copy/paste from join_map was a bit too eager.