### PR TITLE
Disable timely's default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,13 @@ serde_derive = "1.0"
 abomonation = "0.7"
 abomonation_derive = "0.5"
 timely_sort="0.1.6"
-#timely = "0.11"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
-#timely = { path = "../timely-dataflow/timely/" }
+#timely = { version = "0.11", default-features = false }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
+#timely = { path = "../timely-dataflow/timely/", default-features = false }
 fnv="1.0.2"
+
+[features]
+default = ["timely/getopts"]
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
Allowing disabling timely's default features (i.e., getopts), though they are still enabled by default.