### PR TITLE
Disable timely's default features in dogsdogsdogs, too

### DIFF
--- a/dogsdogsdogs/Cargo.toml
+++ b/dogsdogsdogs/Cargo.toml
@@ -7,11 +7,14 @@ license = "MIT"
 [dependencies]
 abomonation = "0.7"
 abomonation_derive = "0.5"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
 timely_sort = "0.1.6"
-differential-dataflow = { path = "../" }
+differential-dataflow = { path = "../", default-features = false }
 serde = "1"
 serde_derive = "1"
 
 [dev-dependencies]
 graph_map = "0.1"
+
+[features]
+default = ["timely/getopts"]


### PR DESCRIPTION
As in #297, this makes it possible to use dogsdogsdogs without depending
on getopts.