### PR TITLE
Robust join implementation

### DIFF
--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -63,6 +63,7 @@ where
         self.advance.borrow()
     }
     fn set_physical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) {
+        debug_assert!(timely::PartialOrder::less_equal(&self.through.borrow(), &frontier));
         self.trace.borrow_mut().adjust_through_frontier(self.through.borrow(), frontier);
         self.through.clear();
         self.through.extend(frontier.iter().cloned());

--- a/src/trace/implementations/spine_fueled_neu.rs
+++ b/src/trace/implementations/spine_fueled_neu.rs
@@ -217,6 +217,8 @@ where
     }
     fn get_logical_compaction(&mut self) -> AntichainRef<T> { self.logical_frontier.borrow() }
     fn set_physical_compaction(&mut self, frontier: AntichainRef<T>) {
+        // We should never request to rewind the frontier.
+        debug_assert!(PartialOrder::less_equal(&self.physical_frontier.borrow(), &frontier), "FAIL\tthrough frontier !<= new frontier {:?} {:?}\n", self.physical_frontier, frontier);
         self.physical_frontier = frontier.to_owned();
         self.consider_merges();
     }


### PR DESCRIPTION
This PR changes the implementation of `join` to be more robust in the presence of pre-compacted arrangements.

In particular, https://github.com/MaterializeInc/materialize/issues/5774 was at its core about `join` receiving pre-compacted arrangements, misunderstanding the physical compaction frontier, mis-*SETTING* the physical compaction frontier, and then believing it was getting results that it was not correctly receiving. A giant tire fire, really.

The problem was that it was not carefully tracking the relationship between received batches and the physical compaction frontier. This PR attempts to fix that by being substantially more clear about the invariants that should be checked at operator construction time, and then maintained as the operator executes. They are not very complicated, and boil down to:

> for each trace, the physical compaction frontier should be less or equal to the completed trace frontier.

That is, we shouldn't physically compact *past* the timestamps we have completed, which makes some sense because such a handle to a trace is not especially useful (you cannot subset out any of the existing data, under the current rules for extracting out subsets of data). Join in particular wants to be able to subset out from a trace the data that it has received in batches, and if it cannot reliably do that .. well the implementation we have now doesn't work, nor will this new one (just, it will more aggressively not work).

cc @ruchirK 
