### PR TITLE
Clarify `Trace` capability nomenclature

### DIFF
--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -45,7 +45,7 @@ where
     S: FnMut(&D, &R, &Tr::Val, &Tr::R)->(DOut, ROut)+'static,
 {
     // No need to block physical merging for this operator.
-    arrangement.trace.distinguish_since(Antichain::new().borrow());
+    arrangement.trace.set_physical_compaction(Antichain::new().borrow());
     let mut propose_trace = Some(arrangement.trace);
     let propose_stream = arrangement.stream;
 
@@ -138,7 +138,7 @@ where
         for key in stash.keys() {
             frontier.insert(key.time().clone());
         }
-        propose_trace.as_mut().map(|trace| trace.advance_by(frontier.borrow()));
+        propose_trace.as_mut().map(|trace| trace.set_logical_compaction(frontier.borrow()));
 
         if input1.frontier().is_empty() && stash.is_empty() {
             propose_trace = None;

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -78,8 +78,8 @@ fn main() {
             graph.close();
             for i in 1..rounds + 1 {
                 /* Advance the trace frontier to enable trace compaction. */
-                graph_trace.distinguish_since(AntichainRef::new(&[i]));
-                graph_trace.advance_by(AntichainRef::new(&[i]));
+                graph_trace.set_physical_compaction(AntichainRef::new(&[i]));
+                graph_trace.set_logical_compaction(AntichainRef::new(&[i]));
                 worker.step_while(|| probe.less_than(&i));
                 dump_cursor(i, worker.index(), &mut graph_trace);
             }
@@ -93,8 +93,8 @@ fn main() {
                 }
                 graph.advance_to(i);
                 graph.flush();
-                graph_trace.distinguish_since(AntichainRef::new(&[i]));
-                graph_trace.advance_by(AntichainRef::new(&[i]));
+                graph_trace.set_physical_compaction(AntichainRef::new(&[i]));
+                graph_trace.set_logical_compaction(AntichainRef::new(&[i]));
                 worker.step_while(|| probe.less_than(graph.time()));
                 dump_cursor(i, worker.index(), &mut graph_trace);
             }

--- a/interactive/src/manager.rs
+++ b/interactive/src/manager.rs
@@ -187,13 +187,13 @@ impl<V: ExchangeData+Hash+Datum> TraceManager<V> {
         use timely::progress::frontier::Antichain;
         let frontier = Antichain::from_elem(time.clone());
         for trace in self.inputs.values_mut() {
-            trace.advance_by(frontier.borrow());
-            trace.distinguish_since(frontier.borrow());
+            trace.set_logical_compaction(frontier.borrow());
+            trace.set_physical_compaction(frontier.borrow());
         }
         for map in self.arrangements.values_mut() {
             for trace in map.values_mut() {
-                trace.advance_by(frontier.borrow());
-                trace.distinguish_since(frontier.borrow());
+                trace.set_logical_compaction(frontier.borrow());
+                trace.set_physical_compaction(frontier.borrow());
             }
         }
     }

--- a/mdbook/src/chapter_5/chapter_5_3.md
+++ b/mdbook/src/chapter_5/chapter_5_3.md
@@ -94,6 +94,6 @@ When we extract a trace from an arrangement, we acquire the ability to replay th
 
 A `TraceHandle` (the type of `trace`) has two important methods. Their names are not great, and subject to change in the future. Their idioms may also change as more information flows in about users and use cases.
 
-1. `advance_by(frontier)`. This method informs `trace` that it will no longer be called upon to handle queries for times not in advance of `frontier`, a set of timestamps. This gives the arrangement permission to coalesce otherwise indistinguishable timestamps, which it will start to do once all handles have advanced.
+1. `set_logical_compaction(frontier)`. This method informs `trace` that it will no longer be called upon to handle queries for times not in advance of `frontier`, a set of timestamps. This gives the arrangement permission to coalesce otherwise indistinguishable timestamps, which it will start to do once all handles have advanced.
 
-2. `distinguish_since(frontier)`. This method unblocks the merging of physical batches. It is very rare that a user wants to do anything with this other than call `trace.distinguish_since(&[])`, which unblocks all merging. Certain operators, namely `join`, do need to carefully manipulate this method.
+2. `set_physical_compaction(frontier)`. This method unblocks the merging of physical batches. It is very rare that a user wants to do anything with this other than call `trace.set_physical_compaction(&[])`, which unblocks all merging. Certain operators, namely `join`, do need to carefully manipulate this method.

--- a/server/dataflows/random_graph/src/lib.rs
+++ b/server/dataflows/random_graph/src/lib.rs
@@ -46,7 +46,7 @@ pub fn build((dataflow, handles, probe, timer, args): Environment) -> Result<(),
     // operator holds only a weak reference to it.
     //
     // The operator also holds an `Weak<RefCell<Option<TraceHandle>>>` which it will
-    // attempt to borrow and call `advance_by` in order to advance the capability
+    // attempt to borrow and call `set_logical_compaction` in order to advance the capability
     // as it runs, to allow compaction and the maintenance of bounded state.
 
     if args.len() != 4 { return Err(format!("expected four arguments, instead: {:?}", args)); }
@@ -134,7 +134,7 @@ pub fn build((dataflow, handles, probe, timer, args): Environment) -> Result<(),
                 if let Some(trace_handle) = trace_handle_weak.upgrade() {
                     let mut borrow = trace_handle.borrow_mut();
                     if let Some(ref mut trace_handle) = borrow.as_mut() {
-                        trace_handle.advance_by(&[elapsed_ns]);
+                        trace_handle.set_logical_compaction(&[elapsed_ns]);
                     }
                 }
 
@@ -191,7 +191,7 @@ pub fn build((dataflow, handles, probe, timer, args): Environment) -> Result<(),
         .trace;
 
     // release all blocks on merging.
-    trace.distinguish_since(&[]);
+    trace.set_physical_compaction(&[]);
     *trace_handle.borrow_mut() = Some(trace);
 
     handles.set::<Rc<RefCell<Option<TraceHandle>>>>(name.to_owned(), trace_handle);

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -278,8 +278,8 @@ where
         queries.binary_frontier(&self.stream, exchange, Pipeline, "TraceQuery", move |_capability, _info| {
 
             let mut trace = Some(self.trace.clone());
-            // release `distinguish_since` capability.
-            trace.as_mut().unwrap().distinguish_since(Antichain::new().borrow());
+            // release `set_physical_compaction` capability.
+            trace.as_mut().unwrap().set_physical_compaction(Antichain::new().borrow());
 
             let mut stash = Vec::new();
             let mut capability: Option<Capability<G::Timestamp>> = None;
@@ -413,7 +413,7 @@ where
                 ].into_iter().cloned().filter_map(|t| t).min();
 
                 if let Some(frontier) = frontier {
-                    trace.as_mut().map(|t| t.advance_by(AntichainRef::new(&[frontier])));
+                    trace.as_mut().map(|t| t.set_logical_compaction(AntichainRef::new(&[frontier])));
                 }
                 else {
                     trace = None;

--- a/src/operators/arrange/upsert.rs
+++ b/src/operators/arrange/upsert.rs
@@ -331,8 +331,8 @@ where
                     input_frontier.extend(input.frontier().frontier().iter().cloned());
 
                     // Downgrade capabilities for `reader_local`.
-                    reader_local.advance_by(input_frontier.borrow());
-                    reader_local.distinguish_since(input_frontier.borrow());
+                    reader_local.set_logical_compaction(input_frontier.borrow());
+                    reader_local.set_physical_compaction(input_frontier.borrow());
                 }
 
                 if let Some(mut fuel) = effort.clone() {

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -124,8 +124,8 @@ where
 
                 // tidy up the shared input trace.
                 trace.advance_upper(&mut upper_limit);
-                trace.advance_by(upper_limit.borrow());
-                trace.distinguish_since(upper_limit.borrow());
+                trace.set_logical_compaction(upper_limit.borrow());
+                trace.set_physical_compaction(upper_limit.borrow());
             }
         })
         .as_collection()

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -624,12 +624,12 @@ where
                         }
 
                         // We only anticipate future times in advance of `upper_limit`.
-                        source_trace.advance_by(upper_limit.borrow());
-                        output_reader.advance_by(upper_limit.borrow());
+                        source_trace.set_logical_compaction(upper_limit.borrow());
+                        output_reader.set_logical_compaction(upper_limit.borrow());
 
                         // We will only slice the data between future batches.
-                        source_trace.distinguish_since(upper_limit.borrow());
-                        output_reader.distinguish_since(upper_limit.borrow());
+                        source_trace.set_physical_compaction(upper_limit.borrow());
+                        output_reader.set_physical_compaction(upper_limit.borrow());
                     }
 
                     // Exert trace maintenance if we have been so requested.

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -186,8 +186,8 @@ where
 
                 // tidy up the shared input trace.
                 trace.advance_upper(&mut upper_limit);
-                trace.advance_by(upper_limit.borrow());
-                trace.distinguish_since(upper_limit.borrow());
+                trace.set_logical_compaction(upper_limit.borrow());
+                trace.set_physical_compaction(upper_limit.borrow());
             }
         })
         .as_collection()

--- a/src/trace/implementations/graph.rs
+++ b/src/trace/implementations/graph.rs
@@ -51,14 +51,14 @@ where
         }
         else { None }
     }
-    fn advance_by(&mut self, frontier: &[Product<RootTimestamp,()>]) {
-        self.spine.advance_by(frontier)
+    fn set_logical_compaction(&mut self, frontier: &[Product<RootTimestamp,()>]) {
+        self.spine.set_logical_compaction(frontier)
     }
-    fn advance_frontier(&mut self) -> &[Product<RootTimestamp,()>] { self.spine.advance_frontier() }
-    fn distinguish_since(&mut self, frontier: &[Product<RootTimestamp,()>]) {
-        self.spine.distinguish_since(frontier)
+    fn get_logical_compaction(&mut self) -> &[Product<RootTimestamp,()>] { self.spine.get_logical_compaction() }
+    fn set_physical_compaction(&mut self, frontier: &[Product<RootTimestamp,()>]) {
+        self.spine.set_physical_compaction(frontier)
     }
-    fn distinguish_frontier(&mut self) -> &[Product<RootTimestamp,()>] { &self.spine.distinguish_frontier() }
+    fn get_physical_compaction(&mut self) -> &[Product<RootTimestamp,()>] { &self.spine.get_physical_compaction() }
 
     fn map_batches<F: FnMut(&Self::Batch)>(&mut self, f: F) {
         self.spine.map_batches(f)

--- a/src/trace/implementations/spine_fueled.rs
+++ b/src/trace/implementations/spine_fueled.rs
@@ -99,7 +99,7 @@ pub struct Spine<K, V, T: Lattice+Ord, R: Semigroup, B: Batch<K, V, T, R>> {
     operator: OperatorInfo,
     logger: Option<::logging::Logger>,
     phantom: ::std::marker::PhantomData<(K, V, R)>,
-    advance_frontier: Vec<T>,                   // Times after which the trace must accumulate correctly.
+    get_logical_compaction: Vec<T>,                   // Times after which the trace must accumulate correctly.
     through_frontier: Vec<T>,                   // Times after which the trace must be able to subset its inputs.
     merging: Vec<Option<MergeState<K,V,T,R,B>>>,// Several possibly shared collections of updates.
     pending: Vec<B>,                       // Batches at times in advance of `frontier`.
@@ -137,7 +137,7 @@ where
         // supplied upper it had better be empty.
 
         // We shouldn't grab a cursor into a closed trace, right?
-        assert!(self.advance_frontier.len() > 0, "cursor_through({:?}) called for closed trace", upper);
+        assert!(self.get_logical_compaction.len() > 0, "cursor_through({:?}) called for closed trace", upper);
 
         // Check that `upper` is greater or equal to `self.through_frontier`.
         // Otherwise, the cut could be in `self.merging` and it is user error anyhow.
@@ -197,23 +197,23 @@ where
 
         Some((CursorList::new(cursors, &storage), storage))
     }
-    fn advance_by(&mut self, frontier: &[T]) {
-        self.advance_frontier = frontier.to_vec();
+    fn set_logical_compaction(&mut self, frontier: &[T]) {
+        self.get_logical_compaction = frontier.to_vec();
 
         // Commenting out for now; causes problems in `read_upper()`.
         // If one has an urgent need to release these resources, it
         // is probably best just to drop the trace.
 
-        // if self.advance_frontier.len() == 0 {
+        // if self.get_logical_compaction.len() == 0 {
         //     self.drop_batches();
         // }
     }
-    fn advance_frontier(&mut self) -> &[T] { &self.advance_frontier[..] }
-    fn distinguish_since(&mut self, frontier: &[T]) {
+    fn get_logical_compaction(&mut self) -> &[T] { &self.get_logical_compaction[..] }
+    fn set_physical_compaction(&mut self, frontier: &[T]) {
         self.through_frontier = frontier.to_vec();
         self.consider_merges();
     }
-    fn distinguish_frontier(&mut self) -> &[T] { &self.through_frontier[..] }
+    fn get_physical_compaction(&mut self) -> &[T] { &self.through_frontier[..] }
 
     fn map_batches<F: FnMut(&Self::Batch)>(&mut self, mut f: F) {
         for batch in self.merging.iter().rev() {
@@ -303,7 +303,7 @@ where
     R: Semigroup,
     B: Batch<K, V, T, R>,
 {
-    /// Drops and logs batches. Used in advance_by and drop.
+    /// Drops and logs batches. Used in `set_logical_compaction` and drop.
     fn drop_batches(&mut self) {
         if let Some(logger) = &self.logger {
             for batch in self.merging.drain(..) {
@@ -351,7 +351,7 @@ where
             operator,
             logger,
             phantom: ::std::marker::PhantomData,
-            advance_frontier: vec![<T as Lattice>::minimum()],
+            get_logical_compaction: vec![<T as Lattice>::minimum()],
             through_frontier: vec![<T as Lattice>::minimum()],
             merging: Vec::new(),
             pending: Vec::new(),
@@ -445,7 +445,7 @@ where
             // Step 2: Insert new batch at target position
             if let Some(batch2) = self.merging[batch_index].take() {
                 let batch2 = batch2.complete(&mut self.logger, self.operator.global_id, batch_index);
-                let frontier = if batch_index == self.merging.len()-1 { Some(self.advance_frontier.clone()) } else { None };
+                let frontier = if batch_index == self.merging.len()-1 { Some(self.get_logical_compaction.clone()) } else { None };
                 self.logger.as_ref().map(|l| l.log(
                     ::logging::MergeEvent {
                         operator: self.operator.global_id,
@@ -513,7 +513,7 @@ where
                             let batch1 = batch.complete(&mut self.logger, self.operator.global_id, position);
                             let batch2 = batch2.complete(&mut self.logger, self.operator.global_id, position);
                             // if this is the last position, engage compaction.
-                            let frontier = if new_position+1 == self.merging.len() { Some(self.advance_frontier.clone()) } else { None };
+                            let frontier = if new_position+1 == self.merging.len() { Some(self.get_logical_compaction.clone()) } else { None };
                             self.logger.as_ref().map(|l| l.log(
                                 ::logging::MergeEvent {
                                     operator: self.operator.global_id,

--- a/src/trace/implementations/spine_fueled.rs
+++ b/src/trace/implementations/spine_fueled.rs
@@ -99,8 +99,8 @@ pub struct Spine<K, V, T: Lattice+Ord, R: Semigroup, B: Batch<K, V, T, R>> {
     operator: OperatorInfo,
     logger: Option<::logging::Logger>,
     phantom: ::std::marker::PhantomData<(K, V, R)>,
-    get_logical_compaction: Vec<T>,                   // Times after which the trace must accumulate correctly.
-    through_frontier: Vec<T>,                   // Times after which the trace must be able to subset its inputs.
+    logical_frontier: Vec<T>,                   // Times after which the trace must accumulate correctly.
+    physical_frontier: Vec<T>,                   // Times after which the trace must be able to subset its inputs.
     merging: Vec<Option<MergeState<K,V,T,R,B>>>,// Several possibly shared collections of updates.
     pending: Vec<B>,                       // Batches at times in advance of `frontier`.
     upper: Vec<T>,
@@ -137,11 +137,11 @@ where
         // supplied upper it had better be empty.
 
         // We shouldn't grab a cursor into a closed trace, right?
-        assert!(self.get_logical_compaction.len() > 0, "cursor_through({:?}) called for closed trace", upper);
+        assert!(self.logical_frontier.len() > 0, "cursor_through({:?}) called for closed trace", upper);
 
-        // Check that `upper` is greater or equal to `self.through_frontier`.
+        // Check that `upper` is greater or equal to `self.physical_frontier`.
         // Otherwise, the cut could be in `self.merging` and it is user error anyhow.
-        assert!(upper.iter().all(|t1| self.through_frontier.iter().any(|t2| t2.less_equal(t1))));
+        assert!(upper.iter().all(|t1| self.physical_frontier.iter().any(|t2| t2.less_equal(t1))));
 
         let mut cursors = Vec::new();
         let mut storage = Vec::new();
@@ -198,22 +198,22 @@ where
         Some((CursorList::new(cursors, &storage), storage))
     }
     fn set_logical_compaction(&mut self, frontier: &[T]) {
-        self.get_logical_compaction = frontier.to_vec();
+        self.logical_frontier = frontier.to_vec();
 
         // Commenting out for now; causes problems in `read_upper()`.
         // If one has an urgent need to release these resources, it
         // is probably best just to drop the trace.
 
-        // if self.get_logical_compaction.len() == 0 {
+        // if self.logical_frontier.len() == 0 {
         //     self.drop_batches();
         // }
     }
-    fn get_logical_compaction(&mut self) -> &[T] { &self.get_logical_compaction[..] }
+    fn get_logical_compaction(&mut self) -> &[T] { &self.logical_frontier[..] }
     fn set_physical_compaction(&mut self, frontier: &[T]) {
-        self.through_frontier = frontier.to_vec();
+        self.physical_frontier = frontier.to_vec();
         self.consider_merges();
     }
-    fn get_physical_compaction(&mut self) -> &[T] { &self.through_frontier[..] }
+    fn get_physical_compaction(&mut self) -> &[T] { &self.physical_frontier[..] }
 
     fn map_batches<F: FnMut(&Self::Batch)>(&mut self, mut f: F) {
         for batch in self.merging.iter().rev() {
@@ -351,8 +351,8 @@ where
             operator,
             logger,
             phantom: ::std::marker::PhantomData,
-            get_logical_compaction: vec![<T as Lattice>::minimum()],
-            through_frontier: vec![<T as Lattice>::minimum()],
+            logical_frontier: vec![<T as Lattice>::minimum()],
+            physical_frontier: vec![<T as Lattice>::minimum()],
             merging: Vec::new(),
             pending: Vec::new(),
             upper: vec![Default::default()],
@@ -407,7 +407,7 @@ where
         //     2. large batches never have small indices.
 
         while self.pending.len() > 0 &&
-              self.through_frontier.iter().all(|t1| self.pending[0].upper().iter().any(|t2| t2.less_equal(t1)))
+              self.physical_frontier.iter().all(|t1| self.pending[0].upper().iter().any(|t2| t2.less_equal(t1)))
         {
             // this could be a VecDeque, if we ever notice this.
             let batch = self.pending.remove(0);

--- a/src/trace/implementations/spine_fueled_neu.rs
+++ b/src/trace/implementations/spine_fueled_neu.rs
@@ -91,8 +91,8 @@ pub struct Spine<K, V, T: Lattice+Ord, R: Semigroup, B: Batch<K, V, T, R>> {
     operator: OperatorInfo,
     logger: Option<Logger>,
     phantom: ::std::marker::PhantomData<(K, V, R)>,
-    get_logical_compaction: Antichain<T>,                   // Times after which the trace must accumulate correctly.
-    through_frontier: Antichain<T>,                   // Times after which the trace must be able to subset its inputs.
+    logical_frontier: Antichain<T>,                   // Times after which the trace must accumulate correctly.
+    physical_frontier: Antichain<T>,                   // Times after which the trace must be able to subset its inputs.
     merging: Vec<MergeState<K,V,T,R,B>>,// Several possibly shared collections of updates.
     pending: Vec<B>,                       // Batches at times in advance of `frontier`.
     upper: Antichain<T>,
@@ -138,12 +138,12 @@ where
         // supplied upper it had better be empty.
 
         // We shouldn't grab a cursor into a closed trace, right?
-        assert!(self.get_logical_compaction.borrow().len() > 0);
+        assert!(self.logical_frontier.borrow().len() > 0);
 
-        // Check that `upper` is greater or equal to `self.through_frontier`.
+        // Check that `upper` is greater or equal to `self.physical_frontier`.
         // Otherwise, the cut could be in `self.merging` and it is user error anyhow.
-        // assert!(upper.iter().all(|t1| self.through_frontier.iter().any(|t2| t2.less_equal(t1))));
-        assert!(PartialOrder::less_equal(&self.through_frontier.borrow(), &upper));
+        // assert!(upper.iter().all(|t1| self.physical_frontier.iter().any(|t2| t2.less_equal(t1))));
+        assert!(PartialOrder::less_equal(&self.physical_frontier.borrow(), &upper));
 
         let mut cursors = Vec::new();
         let mut storage = Vec::new();
@@ -213,14 +213,14 @@ where
     }
     fn set_logical_compaction(&mut self, frontier: AntichainRef<T>) {
         // TODO: Re-use allocation
-        self.get_logical_compaction = frontier.to_owned();
+        self.logical_frontier = frontier.to_owned();
     }
-    fn get_logical_compaction(&mut self) -> AntichainRef<T> { self.get_logical_compaction.borrow() }
+    fn get_logical_compaction(&mut self) -> AntichainRef<T> { self.logical_frontier.borrow() }
     fn set_physical_compaction(&mut self, frontier: AntichainRef<T>) {
-        self.through_frontier = frontier.to_owned();
+        self.physical_frontier = frontier.to_owned();
         self.consider_merges();
     }
-    fn get_physical_compaction(&mut self) -> AntichainRef<T> { self.through_frontier.borrow() }
+    fn get_physical_compaction(&mut self) -> AntichainRef<T> { self.physical_frontier.borrow() }
 
     fn map_batches<F: FnMut(&Self::Batch)>(&mut self, mut f: F) {
         for batch in self.merging.iter().rev() {
@@ -430,8 +430,8 @@ where
             operator,
             logger,
             phantom: ::std::marker::PhantomData,
-            get_logical_compaction: Antichain::from_elem(<T as timely::progress::Timestamp>::minimum()),
-            through_frontier: Antichain::from_elem(<T as timely::progress::Timestamp>::minimum()),
+            logical_frontier: Antichain::from_elem(<T as timely::progress::Timestamp>::minimum()),
+            physical_frontier: Antichain::from_elem(<T as timely::progress::Timestamp>::minimum()),
             merging: Vec::new(),
             pending: Vec::new(),
             upper: Antichain::from_elem(<T as timely::progress::Timestamp>::minimum()),
@@ -449,8 +449,8 @@ where
 
         // TODO: Consider merging pending batches before introducing them.
         // TODO: We could use a `VecDeque` here to draw from the front and append to the back.
-        while self.pending.len() > 0 && PartialOrder::less_equal(self.pending[0].upper(), &self.through_frontier)
-            //   self.through_frontier.iter().all(|t1| self.pending[0].upper().iter().any(|t2| t2.less_equal(t1)))
+        while self.pending.len() > 0 && PartialOrder::less_equal(self.pending[0].upper(), &self.physical_frontier)
+            //   self.physical_frontier.iter().all(|t1| self.pending[0].upper().iter().any(|t2| t2.less_equal(t1)))
         {
             // Batch can be taken in optimized insertion.
             // Otherwise it is inserted normally at the end of the method.
@@ -662,7 +662,7 @@ where
                         complete: None,
                     }
                 ));
-                let compaction_frontier = Some(self.get_logical_compaction.borrow());
+                let compaction_frontier = Some(self.logical_frontier.borrow());
                 self.merging[index] = MergeState::begin_merge(old, batch, compaction_frontier);
             }
             MergeState::Double(_) => {

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -88,6 +88,9 @@ pub trait TraceReader {
     ///
     /// By advancing the logical compaction frontier, the caller unblocks merging of otherwise equivalent udates,
     /// but loses the ability to observe historical detail that is not beyond `frontier`.
+    ///
+    /// It is an error to call this method with a frontier not beyond the most recent arguments to this method,
+    /// or the initial value of `get_logical_compaction()` if this method has not yet been called.
 	fn set_logical_compaction(&mut self, frontier: AntichainRef<Self::Time>);
 
     /// Deprecated form of `set_logical_compaction`.
@@ -121,6 +124,9 @@ pub trait TraceReader {
     ///
     /// By advancing the physical compaction frontier, the caller unblocks the merging of batches of updates,
     /// but loses the ability to create a cursor through any frontier not beyond `frontier`.
+    ///
+    /// It is an error to call this method with a frontier not beyond the most recent arguments to this method,
+    /// or the initial value of `get_physical_compaction()` if this method has not yet been called.
 	fn set_physical_compaction(&mut self, frontier: AntichainRef<Self::Time>);
 
     /// Deprecated form of `set_physical_compaction`.

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -90,6 +90,12 @@ pub trait TraceReader {
     /// but loses the ability to observe historical detail that is not beyond `frontier`.
 	fn set_logical_compaction(&mut self, frontier: AntichainRef<Self::Time>);
 
+    /// Deprecated form of `set_logical_compaction`.
+    #[deprecated(since = "0.11", note = "please use `set_logical_compaction`")]
+	fn advance_by(&mut self, frontier: AntichainRef<Self::Time>) {
+        self.set_logical_compaction(frontier);
+    }
+
     /// Reports the logical compaction frontier.
 	///
     /// All update times beyond this frontier will be presented with their original times, and all update times
@@ -97,6 +103,12 @@ pub trait TraceReader {
     /// this frontier. Practically, update times not beyond this frontier should not be taken to be accurate as
     /// presented, and should be used carefully, only in accumulation to times that are beyond the frontier.
 	fn get_logical_compaction(&mut self) -> AntichainRef<Self::Time>;
+
+    /// Deprecated form of `get_logical_compaction`.
+    #[deprecated(since = "0.11", note = "please use `get_logical_compaction`")]
+	fn advance_frontier(&mut self) -> AntichainRef<Self::Time> {
+        self.get_logical_compaction()
+    }
 
     /// Advances the frontier that constrains physical compaction.
     ///
@@ -111,6 +123,12 @@ pub trait TraceReader {
     /// but loses the ability to create a cursor through any frontier not beyond `frontier`.
 	fn set_physical_compaction(&mut self, frontier: AntichainRef<Self::Time>);
 
+    /// Deprecated form of `set_physical_compaction`.
+    #[deprecated(since = "0.11", note = "please use `set_physical_compaction`")]
+	fn distinguish_since(&mut self, frontier: AntichainRef<Self::Time>) {
+        self.set_physical_compaction(frontier);
+    }
+
 	/// Reports the physical compaction frontier.
 	///
     /// All batches containing updates beyond this frontier will not be merged with ohter batches. This allows
@@ -118,6 +136,12 @@ pub trait TraceReader {
     /// `cursor_through()` method. This functionality is primarily of interest to the `join` operator, and any
     /// other operators who need to take notice of the physical structure of update batches.
     fn get_physical_compaction(&mut self) -> AntichainRef<Self::Time>;
+
+    /// Deprecated form of `get_physical_compaction`.
+    #[deprecated(since = "0.11", note = "please use `get_physical_compaction`")]
+	fn distinguish_frontier(&mut self) -> AntichainRef<Self::Time> {
+        self.get_physical_compaction()
+    }
 
 	/// Maps logic across the non-empty sequence of batches in the trace.
 	///

--- a/src/trace/wrappers/enter.rs
+++ b/src/trace/wrappers/enter.rs
@@ -56,31 +56,31 @@ where
         })
     }
 
-    fn advance_by(&mut self, frontier: AntichainRef<TInner>) {
+    fn set_logical_compaction(&mut self, frontier: AntichainRef<TInner>) {
         self.stash1.clear();
         for time in frontier.iter() {
             self.stash1.insert(time.clone().to_outer());
         }
-        self.trace.advance_by(self.stash1.borrow());
+        self.trace.set_logical_compaction(self.stash1.borrow());
     }
-    fn advance_frontier(&mut self) -> AntichainRef<TInner> {
+    fn get_logical_compaction(&mut self) -> AntichainRef<TInner> {
         self.stash2.clear();
-        for time in self.trace.advance_frontier().iter() {
+        for time in self.trace.get_logical_compaction().iter() {
             self.stash2.insert(TInner::to_inner(time.clone()));
         }
         self.stash2.borrow()
     }
 
-    fn distinguish_since(&mut self, frontier: AntichainRef<TInner>) {
+    fn set_physical_compaction(&mut self, frontier: AntichainRef<TInner>) {
         self.stash1.clear();
         for time in frontier.iter() {
             self.stash1.insert(time.clone().to_outer());
         }
-        self.trace.distinguish_since(self.stash1.borrow());
+        self.trace.set_physical_compaction(self.stash1.borrow());
     }
-    fn distinguish_frontier(&mut self) -> AntichainRef<TInner> {
+    fn get_physical_compaction(&mut self) -> AntichainRef<TInner> {
         self.stash2.clear();
-        for time in self.trace.distinguish_frontier().iter() {
+        for time in self.trace.get_physical_compaction().iter() {
             self.stash2.insert(TInner::to_inner(time.clone()));
         }
         self.stash2.borrow()

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -72,31 +72,31 @@ where
         })
     }
 
-    fn advance_by(&mut self, frontier: AntichainRef<TInner>) {
+    fn set_logical_compaction(&mut self, frontier: AntichainRef<TInner>) {
         self.stash1.clear();
         for time in frontier.iter() {
             self.stash1.insert((self.prior)(time));
         }
-        self.trace.advance_by(self.stash1.borrow());
+        self.trace.set_logical_compaction(self.stash1.borrow());
     }
-    fn advance_frontier(&mut self) -> AntichainRef<TInner> {
+    fn get_logical_compaction(&mut self) -> AntichainRef<TInner> {
         self.stash2.clear();
-        for time in self.trace.advance_frontier().iter() {
+        for time in self.trace.get_logical_compaction().iter() {
             self.stash2.insert(TInner::to_inner(time.clone()));
         }
         self.stash2.borrow()
     }
 
-    fn distinguish_since(&mut self, frontier: AntichainRef<TInner>) {
+    fn set_physical_compaction(&mut self, frontier: AntichainRef<TInner>) {
         self.stash1.clear();
         for time in frontier.iter() {
             self.stash1.insert((self.prior)(time));
         }
-        self.trace.distinguish_since(self.stash1.borrow());
+        self.trace.set_physical_compaction(self.stash1.borrow());
     }
-    fn distinguish_frontier(&mut self) -> AntichainRef<TInner> {
+    fn get_physical_compaction(&mut self) -> AntichainRef<TInner> {
         self.stash2.clear();
-        for time in self.trace.distinguish_frontier().iter() {
+        for time in self.trace.get_physical_compaction().iter() {
             self.stash2.insert(TInner::to_inner(time.clone()));
         }
         self.stash2.borrow()

--- a/src/trace/wrappers/filter.rs
+++ b/src/trace/wrappers/filter.rs
@@ -49,11 +49,11 @@ where
             .map_batches(|batch| f(&Self::Batch::make_from(batch.clone(), logic.clone())))
     }
 
-    fn advance_by(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.advance_by(frontier) }
-    fn advance_frontier(&mut self) -> AntichainRef<Tr::Time> { self.trace.advance_frontier() }
+    fn set_logical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.set_logical_compaction(frontier) }
+    fn get_logical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.trace.get_logical_compaction() }
 
-    fn distinguish_since(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.distinguish_since(frontier) }
-    fn distinguish_frontier(&mut self) -> AntichainRef<Tr::Time> { self.trace.distinguish_frontier() }
+    fn set_physical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.set_physical_compaction(frontier) }
+    fn get_physical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.trace.get_physical_compaction() }
 
     fn cursor_through(&mut self, upper: AntichainRef<Tr::Time>) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>>::Storage)> {
         self.trace.cursor_through(upper).map(|(x,y)| (CursorFilter::new(x, self.logic.clone()), y))

--- a/src/trace/wrappers/freeze.rs
+++ b/src/trace/wrappers/freeze.rs
@@ -103,11 +103,11 @@ where
         })
     }
 
-    fn advance_by(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.advance_by(frontier) }
-    fn advance_frontier(&mut self) -> AntichainRef<Tr::Time> { self.trace.advance_frontier() }
+    fn set_logical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.set_logical_compaction(frontier) }
+    fn get_logical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.trace.get_logical_compaction() }
 
-    fn distinguish_since(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.distinguish_since(frontier) }
-    fn distinguish_frontier(&mut self) -> AntichainRef<Tr::Time> { self.trace.distinguish_frontier() }
+    fn set_physical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.set_physical_compaction(frontier) }
+    fn get_physical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.trace.get_physical_compaction() }
 
     fn cursor_through(&mut self, upper: AntichainRef<Tr::Time>) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>>::Storage)> {
         let func = &self.func;

--- a/src/trace/wrappers/frontier.rs
+++ b/src/trace/wrappers/frontier.rs
@@ -55,11 +55,11 @@ where
         self.trace.map_batches(|batch| f(&Self::Batch::make_from(batch.clone(), frontier)))
     }
 
-    fn advance_by(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.advance_by(frontier) }
-    fn advance_frontier(&mut self) -> AntichainRef<Tr::Time> { self.trace.advance_frontier() }
+    fn set_logical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.set_logical_compaction(frontier) }
+    fn get_logical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.trace.get_logical_compaction() }
 
-    fn distinguish_since(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.distinguish_since(frontier) }
-    fn distinguish_frontier(&mut self) -> AntichainRef<Tr::Time> { self.trace.distinguish_frontier() }
+    fn set_physical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.set_physical_compaction(frontier) }
+    fn get_physical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.trace.get_physical_compaction() }
 
     fn cursor_through(&mut self, upper: AntichainRef<Tr::Time>) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>>::Storage)> {
         let frontier = self.frontier.borrow();

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -222,7 +222,7 @@ fn import_skewed() {
             input.send(((index as u64, 1), index, 1));
             input.close();
 
-            trace.advance_by(AntichainRef::new(&[peers - index]));
+            trace.set_logical_compaction(AntichainRef::new(&[peers - index]));
 
             let (captured,) = worker.dataflow(move |scope| {
                 let imported = trace.import(scope);

--- a/tests/trace.rs
+++ b/tests/trace.rs
@@ -65,25 +65,3 @@ fn test_trace() {
     let vec_4 = cursor4.to_vec(&storage4);
     assert_eq!(vec_4, vec_3);
 }
-
-// #[test]
-// fn test_advance() {
-//     let mut trace = get_trace();
-
-//     trace.advance_by(&[2]);
-//     trace.distinguish_since(&[2]);
-
-//     let (mut cursor1, storage1) = trace.cursor_through(&[2]).unwrap();
-
-//     assert_eq!(
-//         cursor1.to_vec(&storage1),
-//         vec![((1.into(), 2), vec![(2, 1)]), ((2.into(), 3), vec![(2, 1)])]);
-
-//     trace.distinguish_since(&[3]);
-
-//     let (mut cursor2, storage2) = trace.cursor_through(&[3]).unwrap();
-
-//     assert_eq!(
-//         cursor2.to_vec(&storage2),
-//         vec![((1.into(), 2), vec![(2, 1)]), ((2.into(), 3), vec![(2, 1), (2, -1)])]);
-// }

--- a/tpchlike/src/bin/arrange.rs
+++ b/tpchlike/src/bin/arrange.rs
@@ -166,7 +166,7 @@ fn main() {
 
             let time = next_round;
 
-            traces.advance_by(&[next_round]);
+            traces.set_logical_compaction(&[next_round]);
 
             worker.step_while(|| probe.less_than(&time));
             round += 1;

--- a/tpchlike/src/bin/just-arrange.rs
+++ b/tpchlike/src/bin/just-arrange.rs
@@ -143,7 +143,7 @@ fn main() {
 
             let time = next_round;
 
-            traces.advance_by(&[next_round]);
+            traces.set_logical_compaction(&[next_round]);
 
             worker.step_while(|| probe.less_than(&time));
             round += 1;

--- a/tpchlike/src/bin/sosp.rs
+++ b/tpchlike/src/bin/sosp.rs
@@ -139,7 +139,7 @@ fn main() {
             if let Some(mut data) = suppliers.pop() { inputs.supplier.send_batch(&mut data); }
 
             inputs.advance_to(next_round);
-            traces.advance_by(&[next_round]);
+            traces.set_logical_compaction(&[next_round]);
 
             let start = timer.elapsed();
             worker.step_while(|| probe.less_than(&next_round));

--- a/tpchlike/src/lib.rs
+++ b/tpchlike/src/lib.rs
@@ -157,37 +157,37 @@ impl Arrangements {
         let empty_frontier = empty_frontier.borrow();
         let mut arranged = scope.input_from(&mut inputs.customer).as_collection().map(|x| (x.cust_key, x)).arrange_by_key();
         arranged.stream.probe_with(probe);
-        arranged.trace.distinguish_since(empty_frontier);
+        arranged.trace.set_physical_compaction(empty_frontier);
         let customer = arranged.trace;
 
         let mut arranged = scope.input_from(&mut inputs.nation).as_collection().map(|x| (x.nation_key, x)).arrange_by_key();
         arranged.stream.probe_with(probe);
-        arranged.trace.distinguish_since(empty_frontier);
+        arranged.trace.set_physical_compaction(empty_frontier);
         let nation = arranged.trace;
 
         let mut arranged = scope.input_from(&mut inputs.order).as_collection().map(|x| (x.order_key, x)).arrange_by_key();
         arranged.stream.probe_with(probe);
-        arranged.trace.distinguish_since(empty_frontier);
+        arranged.trace.set_physical_compaction(empty_frontier);
         let order = arranged.trace;
 
         let mut arranged = scope.input_from(&mut inputs.part).as_collection().map(|x| (x.part_key, x)).arrange_by_key();
         arranged.stream.probe_with(probe);
-        arranged.trace.distinguish_since(empty_frontier);
+        arranged.trace.set_physical_compaction(empty_frontier);
         let part = arranged.trace;
 
         let mut arranged = scope.input_from(&mut inputs.partsupp).as_collection().map(|x| ((x.part_key, x.supp_key), x)).arrange_by_key();
         arranged.stream.probe_with(probe);
-        arranged.trace.distinguish_since(empty_frontier);
+        arranged.trace.set_physical_compaction(empty_frontier);
         let partsupp = arranged.trace;
 
         let mut arranged = scope.input_from(&mut inputs.region).as_collection().map(|x| (x.region_key, x)).arrange_by_key();
         arranged.stream.probe_with(probe);
-        arranged.trace.distinguish_since(empty_frontier);
+        arranged.trace.set_physical_compaction(empty_frontier);
         let region = arranged.trace;
 
         let mut arranged = scope.input_from(&mut inputs.supplier).as_collection().map(|x| (x.supp_key, x)).arrange_by_key();
         arranged.stream.probe_with(probe);
-        arranged.trace.distinguish_since(empty_frontier);
+        arranged.trace.set_physical_compaction(empty_frontier);
         let supplier = arranged.trace;
 
         Arrangements {
@@ -236,18 +236,18 @@ impl Arrangements {
         }
     }
 
-    pub fn advance_by(&mut self, frontier: &[usize]) {
+    pub fn set_logical_compaction(&mut self, frontier: &[usize]) {
 
         use differential_dataflow::trace::TraceReader;
         use timely::progress::frontier::AntichainRef;
         let frontier = AntichainRef::new(frontier);
-        self.customer.advance_by(frontier);
-        self.nation.advance_by(frontier);
-        self.order.advance_by(frontier);
-        self.part.advance_by(frontier);
-        self.partsupp.advance_by(frontier);
-        self.region.advance_by(frontier);
-        self.supplier.advance_by(frontier);
+        self.customer.set_logical_compaction(frontier);
+        self.nation.set_logical_compaction(frontier);
+        self.order.set_logical_compaction(frontier);
+        self.part.set_logical_compaction(frontier);
+        self.partsupp.set_logical_compaction(frontier);
+        self.region.set_logical_compaction(frontier);
+        self.supplier.set_logical_compaction(frontier);
     }
 }
 


### PR DESCRIPTION
This PR changes `TraceReader` methods `advance_by` and `distinguish_since`, and their read counterparts, to more clearly named methods:
```rust
    fn set_logical_compaction(&mut self, frontier: AntichainRef<Self::Time>);
    fn get_logical_compaction(&mut self) -> AntichainRef<Self::Time>;
    fn set_physical_compaction(&mut self, frontier: AntichainRef<Self::Time>);
    fn get_physical_compaction(&mut self) -> AntichainRef<Self::Time>;
````
The documentation means to be a bit more clear about what these abilities entail.