### PR TITLE
Use bespoke traits in place of std::ops traits

### DIFF
--- a/dogsdogsdogs/src/calculus.rs
+++ b/dogsdogsdogs/src/calculus.rs
@@ -41,7 +41,7 @@ where
         self.enter(child)
             .inner
             .flat_map(|(data, time, diff)| {
-                let neu = (data.clone(), AltNeu::neu(time.time.clone()), diff.clone().neg());
+                let neu = (data.clone(), AltNeu::neu(time.time.clone()), diff.clone().negate());
                 let alt = (data, time, diff);
                 Some(alt).into_iter().chain(Some(neu))
             })

--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -8,7 +8,6 @@ extern crate serde_derive;
 extern crate serde;
 
 use std::hash::Hash;
-use std::ops::Mul;
 
 use timely::dataflow::Scope;
 use timely::progress::Timestamp;
@@ -17,7 +16,7 @@ use timely::dataflow::operators::Concatenate;
 
 use differential_dataflow::{ExchangeData, Collection, AsCollection};
 use differential_dataflow::operators::Threshold;
-use differential_dataflow::difference::Monoid;
+use differential_dataflow::difference::{Monoid, Multiply};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::TraceAgent;
 use differential_dataflow::operators::arrange::{ArrangeBySelf, ArrangeByKey};
@@ -32,7 +31,7 @@ pub mod operators;
     Implementors of `PrefixExtension` provide types and methods for extending a differential dataflow collection,
     via the three methods `count`, `propose`, and `validate`.
 **/
-pub trait PrefixExtender<G: Scope, R: Monoid+Mul<Output = R>> {
+pub trait PrefixExtender<G: Scope, R: Monoid+Multiply<Output = R>> {
     /// The required type of prefix to extend.
     type Prefix;
     /// The type to be produced as extension.
@@ -45,7 +44,7 @@ pub trait PrefixExtender<G: Scope, R: Monoid+Mul<Output = R>> {
     fn validate(&mut self, &Collection<G, (Self::Prefix, Self::Extension), R>) -> Collection<G, (Self::Prefix, Self::Extension), R>;
 }
 
-pub trait ProposeExtensionMethod<G: Scope, P: ExchangeData+Ord, R: Monoid+Mul<Output = R>> {
+pub trait ProposeExtensionMethod<G: Scope, P: ExchangeData+Ord, R: Monoid+Multiply<Output = R>> {
     fn propose_using<PE: PrefixExtender<G, R, Prefix=P>>(&self, extender: &mut PE) -> Collection<G, (P, PE::Extension), R>;
     fn extend<E: ExchangeData+Ord>(&self, extenders: &mut [&mut dyn PrefixExtender<G,R,Prefix=P,Extension=E>]) -> Collection<G, (P, E), R>;
 }
@@ -54,7 +53,7 @@ impl<G, P, R> ProposeExtensionMethod<G, P, R> for Collection<G, P, R>
 where
     G: Scope,
     P: ExchangeData+Ord,
-    R: Monoid+Mul<Output = R>,
+    R: Monoid+Multiply<Output = R>,
 {
     fn propose_using<PE>(&self, extender: &mut PE) -> Collection<G, (P, PE::Extension), R>
     where
@@ -93,11 +92,11 @@ where
     }
 }
 
-pub trait ValidateExtensionMethod<G: Scope, R: Monoid+Mul<Output = R>, P, E> {
+pub trait ValidateExtensionMethod<G: Scope, R: Monoid+Multiply<Output = R>, P, E> {
     fn validate_using<PE: PrefixExtender<G, R, Prefix=P, Extension=E>>(&self, extender: &mut PE) -> Collection<G, (P, E), R>;
 }
 
-impl<G: Scope, R: Monoid+Mul<Output = R>, P, E> ValidateExtensionMethod<G, R, P, E> for Collection<G, (P, E), R> {
+impl<G: Scope, R: Monoid+Multiply<Output = R>, P, E> ValidateExtensionMethod<G, R, P, E> for Collection<G, (P, E), R> {
     fn validate_using<PE: PrefixExtender<G, R, Prefix=P, Extension=E>>(&self, extender: &mut PE) -> Collection<G, (P, E), R> {
         extender.validate(self)
     }
@@ -113,7 +112,7 @@ where
     K: ExchangeData,
     V: ExchangeData,
     T: Lattice+ExchangeData+Timestamp,
-    R: Monoid+Mul<Output = R>+ExchangeData,
+    R: Monoid+Multiply<Output = R>+ExchangeData,
 {
     /// A trace of type (K, ()), used to count extensions for each prefix.
     count_trace: TraceKeyHandle<K, T, isize>,
@@ -130,7 +129,7 @@ where
     K: ExchangeData+Hash,
     V: ExchangeData+Hash,
     T: Lattice+ExchangeData+Timestamp,
-    R: Monoid+Mul<Output = R>+ExchangeData,
+    R: Monoid+Multiply<Output = R>+ExchangeData,
 {
     fn clone(&self) -> Self {
         CollectionIndex {
@@ -146,7 +145,7 @@ where
     K: ExchangeData+Hash,
     V: ExchangeData+Hash,
     T: Lattice+ExchangeData+Timestamp,
-    R: Monoid+Mul<Output = R>+ExchangeData,
+    R: Monoid+Multiply<Output = R>+ExchangeData,
 {
 
     pub fn index<G: Scope<Timestamp = T>>(collection: &Collection<G, (K, V), R>) -> Self {
@@ -181,7 +180,7 @@ where
     K: ExchangeData,
     V: ExchangeData,
     T: Lattice+ExchangeData+Timestamp,
-    R: Monoid+Mul<Output = R>+ExchangeData,
+    R: Monoid+Multiply<Output = R>+ExchangeData,
     F: Fn(&P)->K+Clone,
 {
     phantom: std::marker::PhantomData<P>,
@@ -196,7 +195,7 @@ where
     V: ExchangeData+Hash+Default,
     P: ExchangeData,
     G::Timestamp: Lattice+ExchangeData,
-    R: Monoid+Mul<Output = R>+ExchangeData,
+    R: Monoid+Multiply<Output = R>+ExchangeData,
     F: Fn(&P)->K+Clone+'static,
 {
     type Prefix = P;

--- a/dogsdogsdogs/src/operators/count.rs
+++ b/dogsdogsdogs/src/operators/count.rs
@@ -1,9 +1,7 @@
-use std::ops::Mul;
-
 use timely::dataflow::Scope;
 
 use differential_dataflow::{ExchangeData, Collection, Hashable};
-use differential_dataflow::difference::Monoid;
+use differential_dataflow::difference::{Monoid, Multiply};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::{Cursor, TraceReader, BatchReader};
@@ -27,7 +25,7 @@ where
     Tr::Key: Ord+Hashable+Default,
     Tr::Batch: BatchReader<Tr::Key, (), Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, (), Tr::Time, Tr::R>,
-    R: Monoid+Mul<Output = R>+ExchangeData,
+    R: Monoid+Multiply<Output = R>+ExchangeData,
     F: Fn(&P)->Tr::Key+Clone+'static,
     P: ExchangeData,
 {

--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -103,7 +103,7 @@ where
                                 while let Some(value) = cursor.get_val(&storage) {
                                     let mut count = Tr::R::zero();
                                     cursor.map_times(&storage, |t, d| {
-                                        if t.less_equal(time) { count += d; }
+                                        if t.less_equal(time) { count.plus_equals(d); }
                                     });
                                     if !count.is_zero() {
                                         let (dout, rout) = output_func(prefix, diff, value, &count);

--- a/dogsdogsdogs/src/operators/propose.rs
+++ b/dogsdogsdogs/src/operators/propose.rs
@@ -1,9 +1,7 @@
-use std::ops::Mul;
-
 use timely::dataflow::Scope;
 
 use differential_dataflow::{ExchangeData, Collection, Hashable};
-use differential_dataflow::difference::Monoid;
+use differential_dataflow::difference::{Monoid, Multiply};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::{Cursor, TraceReader, BatchReader};
@@ -29,7 +27,7 @@ where
     Tr::Val: Clone,
     Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
-    Tr::R: Monoid+Mul<Output = Tr::R>+ExchangeData,
+    Tr::R: Monoid+Multiply<Output = Tr::R>+ExchangeData,
     F: Fn(&P)->Tr::Key+Clone+'static,
     P: ExchangeData,
 {
@@ -37,7 +35,7 @@ where
         prefixes,
         arrangement,
         move |p: &P, k: &mut Tr::Key| { *k = key_selector(p); },
-        |prefix, diff, value, sum| ((prefix.clone(), value.clone()), diff.clone() * sum.clone()),
+        |prefix, diff, value, sum| ((prefix.clone(), value.clone()), diff.clone().multiply(sum)),
         Default::default(),
         Default::default(),
         Default::default(),
@@ -62,7 +60,7 @@ where
     Tr::Val: Clone,
     Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
-    Tr::R: Monoid+Mul<Output = Tr::R>+ExchangeData,
+    Tr::R: Monoid+Multiply<Output = Tr::R>+ExchangeData,
     F: Fn(&P)->Tr::Key+Clone+'static,
     P: ExchangeData,
 {

--- a/dogsdogsdogs/src/operators/validate.rs
+++ b/dogsdogsdogs/src/operators/validate.rs
@@ -1,10 +1,9 @@
-use std::ops::Mul;
 use std::hash::Hash;
 
 use timely::dataflow::Scope;
 
 use differential_dataflow::{ExchangeData, Collection};
-use differential_dataflow::difference::Monoid;
+use differential_dataflow::difference::{Monoid, Multiply};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::{Cursor, TraceReader, BatchReader};
@@ -27,7 +26,7 @@ where
     V: ExchangeData+Hash+Default,
     Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
-    Tr::R: Monoid+Mul<Output = Tr::R>+ExchangeData,
+    Tr::R: Monoid+Multiply<Output = Tr::R>+ExchangeData,
     F: Fn(&P)->K+Clone+'static,
     P: ExchangeData,
 {

--- a/examples/monoid-bfs.rs
+++ b/examples/monoid-bfs.rs
@@ -28,24 +28,20 @@ pub struct MinSum {
     value: u32,
 }
 
-use std::ops::{AddAssign, Mul};
-use differential_dataflow::difference::Semigroup;
-
-impl<'a> AddAssign<&'a Self> for MinSum {
-    fn add_assign(&mut self, rhs: &'a Self) {
-        self.value = std::cmp::min(self.value, rhs.value);
-    }
-}
-
-impl Mul<Self> for MinSum {
-    type Output = Self;
-    fn mul(self, rhs: Self) -> Self {
-        MinSum { value: self.value + rhs.value }
-    }
-}
+use differential_dataflow::difference::{Semigroup, Multiply};
 
 impl Semigroup for MinSum {
+    fn plus_equals(&mut self, rhs: &Self) {
+        self.value = std::cmp::min(self.value, rhs.value);
+    }
     fn is_zero(&self) -> bool { false }
+}
+
+impl Multiply<Self> for MinSum {
+    type Output = Self;
+    fn multiply(self, rhs: &Self) -> Self {
+        MinSum { value: self.value + rhs.value }
+    }
 }
 
 fn main() {

--- a/experiments/src/bin/attend.rs
+++ b/experiments/src/bin/attend.rs
@@ -8,8 +8,6 @@ use std::time::Instant;
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::*;
 
-use differential_dataflow::difference::DiffPair;
-
 fn main() {
 
     // snag a filename to use for the input graph.
@@ -24,8 +22,8 @@ fn main() {
 
             let (input, graph) = scope.new_collection();
 
-            let organizers = graph.explode(|(x,y)| Some((x, DiffPair::new(1,0))).into_iter().chain(Some((y, DiffPair::new(0,1))).into_iter()))
-                                  .threshold_total(|_,w| if w.element2 == 0 { 1 } else { 0 });
+            let organizers = graph.explode(|(x,y)| Some((x, (1,0))).into_iter().chain(Some((y, (0,1))).into_iter()))
+                                  .threshold_total(|_,w| if w.1 == 0 { 1 } else { 0 });
 
             organizers
                 .iterate(|attend| {

--- a/src/algorithms/graphs/propagate.rs
+++ b/src/algorithms/graphs/propagate.rs
@@ -1,14 +1,13 @@
 //! Directed label reachability.
 
 use std::hash::Hash;
-use std::ops::Mul;
 
 use timely::dataflow::*;
 
 use ::{Collection, ExchangeData};
 use ::operators::*;
 use ::lattice::Lattice;
-use ::difference::Abelian;
+use ::difference::{Abelian, Multiply};
 use ::operators::arrange::arrangement::ArrangeByKey;
 
 /// Propagates labels forward, retaining the minimum label.
@@ -22,7 +21,7 @@ where
     G::Timestamp: Lattice+Ord,
     N: ExchangeData+Hash,
     R: ExchangeData+Abelian,
-    R: Mul<R, Output=R>,
+    R: Multiply<R, Output=R>,
     R: From<i8>,
     L: ExchangeData,
 {
@@ -40,7 +39,7 @@ where
     G::Timestamp: Lattice+Ord,
     N: ExchangeData+Hash,
     R: ExchangeData+Abelian,
-    R: Mul<R, Output=R>,
+    R: Multiply<R, Output=R>,
     R: From<i8>,
     L: ExchangeData,
     F: Fn(&L)->u64+Clone+'static,
@@ -62,7 +61,7 @@ where
     G::Timestamp: Lattice+Ord,
     N: ExchangeData+Hash,
     R: ExchangeData+Abelian,
-    R: Mul<R, Output=R>,
+    R: Multiply<R, Output=R>,
     R: From<i8>,
     L: ExchangeData,
     Tr: TraceReader<Key=N, Val=N, Time=G::Timestamp, R=R>+Clone+'static,

--- a/src/algorithms/graphs/scc.rs
+++ b/src/algorithms/graphs/scc.rs
@@ -2,14 +2,13 @@
 
 use std::mem;
 use std::hash::Hash;
-use std::ops::Mul;
 
 use timely::dataflow::*;
 
 use ::{Collection, ExchangeData};
 use ::operators::*;
 use ::lattice::Lattice;
-use ::difference::Abelian;
+use ::difference::{Abelian, Multiply};
 
 use super::propagate::propagate;
 
@@ -20,7 +19,7 @@ where
     G::Timestamp: Lattice+Ord,
     N: ExchangeData+Hash,
     R: ExchangeData + Abelian,
-    R: Mul<R, Output=R>,
+    R: Multiply<R, Output=R>,
     R: From<i8>,
 {
     graph.iterate(|edges| {
@@ -41,7 +40,7 @@ where
     G::Timestamp: Lattice+Ord,
     N: ExchangeData+Hash,
     R: ExchangeData + Abelian,
-    R: Mul<R, Output=R>,
+    R: Multiply<R, Output=R>,
     R: From<i8>
 {
     graph.iterate(|inner| {
@@ -58,7 +57,7 @@ where
     G::Timestamp: Lattice+Ord,
     N: ExchangeData+Hash,
     R: ExchangeData + Abelian,
-    R: Mul<R, Output=R>,
+    R: Multiply<R, Output=R>,
     R: From<i8>
 {
     let nodes = edges.map_in_place(|x| x.0 = x.1.clone())

--- a/src/algorithms/identifiers.rs
+++ b/src/algorithms/identifiers.rs
@@ -72,12 +72,12 @@ where
                         // keep round-positive records as changes.
                         let ((round, record), count) = &input[0];
                         if *round > 0 {
-                            output.push(((0, record.clone()), -count.clone()));
+                            output.push(((0, record.clone()), count.clone().negate()));
                             output.push(((*round, record.clone()), count.clone()));
                         }
                         // if any losers, increment their rounds.
                         for ((round, record), count) in input[1..].iter() {
-                            output.push(((0, record.clone()), -count.clone()));
+                            output.push(((0, record.clone()), count.clone().negate()));
                             output.push(((*round+1, record.clone()), count.clone()));
                         }
                     })

--- a/src/consolidation.rs
+++ b/src/consolidation.rs
@@ -59,7 +59,7 @@ pub fn consolidate_slice<T: Ord, R: Semigroup>(slice: &mut [(T, R)]) -> usize {
             let ptr2 = slice.as_mut_ptr().offset(index as isize);
 
             if (*ptr1).0 == (*ptr2).0 {
-                (*ptr1).1 += &(*ptr2).1;
+                (*ptr1).1.plus_equals(&(*ptr2).1);
             }
             else {
                 if !(*ptr1).1.is_zero() {
@@ -122,7 +122,7 @@ pub fn consolidate_updates_slice<D: Ord, T: Ord, R: Semigroup>(slice: &mut [(D, 
             let ptr2 = slice.as_mut_ptr().offset(index as isize);
 
             if (*ptr1).0 == (*ptr2).0 && (*ptr1).1 == (*ptr2).1 {
-                (*ptr1).2 += &(*ptr2).2;
+                (*ptr1).2.plus_equals(&(*ptr2).2);
             }
             else {
                 if !(*ptr1).2.is_zero() {

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -91,12 +91,12 @@ where
                         while batch_cursor.key_valid(&batch) {
 
                             let key = batch_cursor.key(&batch);
-                            let mut count = None;
+                            let mut count: Option<T1::R> = None;
 
                             trace_cursor.seek_key(&trace_storage, key);
                             if trace_cursor.get_key(&trace_storage) == Some(key) {
                                 trace_cursor.map_times(&trace_storage, |_, diff| {
-                                    count.as_mut().map(|c| *c += diff);
+                                    count.as_mut().map(|c| c.plus_equals(diff));
                                     if count.is_none() { count = Some(diff.clone()); }
                                 });
                             }
@@ -108,7 +108,7 @@ where
                                         session.give(((key.clone(), count.clone()), time.clone(), -1));
                                     }
                                 }
-                                count.as_mut().map(|c| *c += diff);
+                                count.as_mut().map(|c| c.plus_equals(diff));
                                 if count.is_none() { count = Some(diff.clone()); }
                                 if let Some(count) = count.as_ref() {
                                     if !count.is_zero() {

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -281,7 +281,7 @@ pub trait ReduceCore<G: Scope, K: Data, V: Data, R: Semigroup> where G::Timestam
                 if !input.is_empty() {
                     logic(key, input, change);
                 }
-                change.extend(output.drain(..).map(|(x,d)| (x,-d)));
+                change.extend(output.drain(..).map(|(x,d)| (x, d.negate())));
                 crate::consolidation::consolidate(change);
             })
         }

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -275,7 +275,7 @@ impl<D: Ord, T: Ord, R: Semigroup> MergeSorter<D, T, R> {
                     Ordering::Equal   => {
                         let (data1, time1, mut diff1) = head1.pop();
                         let (_data2, _time2, diff2) = head2.pop();
-                        diff1 += &diff2;
+                        diff1.plus_equals(&diff2);
                         if !diff1.is_zero() {
                             unsafe { push_unchecked(&mut result, (data1, time1, diff1)); }
                         }

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -69,7 +69,7 @@ impl<K: Ord+Clone, R: Semigroup+Clone> MergeBuilder for OrderedLeafBuilder<K, R>
                 ::std::cmp::Ordering::Equal => {
 
                     let mut sum = trie1.vals[lower1].1.clone();
-                    sum += &trie2.vals[lower2].1;
+                    sum.plus_equals(&trie2.vals[lower2].1);
                     if !sum.is_zero() {
                         self.vals.push((trie1.vals[lower1].0.clone(), sum));
                     }


### PR DESCRIPTION
Previously, `difference.rs` built its group-theoretic traits out of `std::ops` traits like `AddAssign`, `Neg`, and `Mul`. These traits are not implemented for many common types that you might want, like tuples, arrays, and vectors. To use these types, custom structs were implemented, but with "miserable ergonomics".

This PR replaces the reliance on `std::ops` traits by moving the methods in to local traits with similar names, and expanded implementations.