### PR TITLE
join, half_join: add lower-level interfaces

### DIFF
--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -117,13 +117,13 @@ where
 ///
 /// for each `((key, val2), time2, diff2)` present in `arrangement`, where
 /// `time2` is less than `initial_time` *UNDER THE TOTAL ORDER ON TIMES*.
-pub fn half_join_internal_unsafe<G, V, Tr, FF, CF, DOut, I, S>(
+pub fn half_join_internal_unsafe<G, V, Tr, FF, CF, DOut, ROut, I, S>(
     stream: &Collection<G, (Tr::Key, V, G::Timestamp), Tr::R>,
     mut arrangement: Arranged<G, Tr>,
     frontier_func: FF,
     comparison: CF,
     mut output_func: S,
-) -> Collection<G, DOut, Tr::R>
+) -> Collection<G, DOut, ROut>
 where
     G: Scope,
     G::Timestamp: Lattice,
@@ -137,7 +137,8 @@ where
     FF: Fn(&G::Timestamp) -> G::Timestamp + 'static,
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
     DOut: Clone+'static,
-    I: IntoIterator<Item=(DOut, G::Timestamp, Tr::R)>,
+    ROut: Monoid,
+    I: IntoIterator<Item=(DOut, G::Timestamp, ROut)>,
     S: FnMut(&Tr::Key, &V, &Tr::Val, &G::Timestamp, &G::Timestamp, &Tr::R, &Tr::R)-> I + 'static,
 {
     // No need to block physical merging for this operator.

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -53,20 +53,20 @@ use differential_dataflow::consolidation::{consolidate, consolidate_updates};
 /// ((key, val1, time1), initial_time, diff1)
 /// ```
 ///
-/// where `initial_time` is less or equal to `time`, and produces as output
+/// where `initial_time` is less or equal to `time1`, and produces as output
 ///
 /// ```ignore
-/// ((key, (val1, val2), lub(time1, time2)), initial_time, diff1 * diff2)
+/// ((output_func(key, val1, val2), lub(time1, time2)), initial_time, diff1 * diff2)
 /// ```
 ///
-/// for each `((key, val2), time2, diff2)` present in `arrangement, where
+/// for each `((key, val2), time2, diff2)` present in `arrangement`, where
 /// `time2` is less than `initial_time` *UNDER THE TOTAL ORDER ON TIMES*.
 /// This last constraint is important to ensure that we correctly produce
 /// all pairs of output updates across multiple `half_join` operators.
 ///
 /// Notice that the time is hoisted up into data. The expectation is that
-/// once out of the dataflow, the updates will be `delay`d to the times
-/// specified in the payloads.
+/// once out of the "delta flow region", the updates will be `delay`d to the
+/// times specified in the payloads.
 pub fn half_join<G, V, Tr, FF, CF, DOut, S>(
     stream: &Collection<G, (Tr::Key, V, G::Timestamp), Tr::R>,
     mut arrangement: Arranged<G, Tr>,

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -93,7 +93,7 @@ where
     let output_func = move |k: &Tr::Key, v1: &V, v2: &Tr::Val, initial: &G::Timestamp, time: &G::Timestamp, diff1: &Tr::R, diff2: &Tr::R| {
         let diff = diff1.clone() * diff2.clone();
         let dout = (output_func(k, v1, v2), time.clone());
-        Some((dout, initial.clone(), diff)).into_iter()
+        Some((dout, initial.clone(), diff))
     };
     half_join_internal_unsafe(stream, arrangement, frontier_func, comparison, output_func)
 }


### PR DESCRIPTION
@frankmcsherry I'm unsure whether the params of the "unsafe" closure make sense this way for the usages you have in mind.

Some alternatives could be:
1. Provide `time1` and `lub(time1, time2)` separately
2. Provide `diff1` and `diff2` separately

I'm happy to move things around after some input.

If the general direction looks good, I can follow-up with the other operators.