### PR TITLE
Fix compiler warning on Rust 1.53

### DIFF
--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -29,7 +29,7 @@ pub trait Lattice : PartialOrder {
     /// assert_eq!(join, Product::new(4, 7));
     /// # }
     /// ```
-    fn join(&self, &Self) -> Self;
+    fn join(&self, other: &Self) -> Self;
 
     /// Updates `self` to the smallest element greater than or equal to both arguments.
     ///
@@ -73,7 +73,7 @@ pub trait Lattice : PartialOrder {
     /// assert_eq!(meet, Product::new(3, 6));
     /// # }
     /// ```
-    fn meet(&self, &Self) -> Self;
+    fn meet(&self, other: &Self) -> Self;
 
     /// Updates `self` to the largest element less than or equal to both arguments.
     ///


### PR DESCRIPTION
From the warning:

anonymous parameters are deprecated and will be removed in the next edition.
this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
for more information, see issue #41686 <https://github.com/rust-lang/rust/issues/41686>


Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>