### PR TITLE
Extract arrangement's exchange fn, pass pact as parameter

### DIFF
--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -465,7 +465,7 @@ where
         Tr::Batch: Batch<K, V, G::Timestamp, R>,
         Tr::Cursor: Cursor<K, V, G::Timestamp, R>,
     {
-        self.arrange_named("Arrange")
+        self.arrange_core(arrange_pact(), "Arrange")
     }
 
     /// Arranges a stream of `(Key, Val)` updates by `Key`. Accepts an empty instance of the trace type.
@@ -482,8 +482,7 @@ where
         Tr::Batch: Batch<K, V, G::Timestamp, R>,
         Tr::Cursor: Cursor<K, V, G::Timestamp, R>,
     {
-        let exchange = Exchange::new(arrange_exchange_fn);
-        self.arrange_core(exchange, name)
+        self.arrange_core(arrange_pact(), name)
     }
 
     /// Arranges a stream of `(Key, Val)` updates by `Key`. Accepts an empty instance of the trace type.
@@ -509,6 +508,17 @@ where
     R: ExchangeData,
 {
     update.0.0.hashed().into()
+}
+
+/// The default exchange parallelization contract for arrangements.
+pub fn arrange_pact<T, K, V, R>() -> Exchange<((K,V),T,R), impl Fn(&((K, V), T, R)) -> u64>
+    where
+        T: Lattice+'static,
+        K: Hashable+'static,
+        V: ExchangeData,
+        R: ExchangeData,
+{
+    Exchange::new(arrange_exchange_fn)
 }
 
 impl<G, K, V, R> Arrange<G, K, V, R> for Collection<G, (K, V), R>

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -11,7 +11,7 @@ use timely::dataflow::channels::pact::{ParallelizationContract};
 
 use ::{Collection, ExchangeData, Hashable};
 use ::difference::Semigroup;
-use operators::arrange::arrangement::Arrange;
+use operators::arrange::arrangement::{Arrange, arrange_pact};
 
 /// An extension method for consolidating weighted streams.
 pub trait Consolidate<G: Scope, D: ExchangeData+Hashable, R: ExchangeData+Semigroup> : Sized {
@@ -61,10 +61,7 @@ where
     G::Timestamp: ::lattice::Lattice+Ord,
 {
     fn consolidate_named(&self, name: &str) -> Self {
-        use trace::implementations::ord::OrdKeySpine as DefaultKeyTrace;
-        self.map(|k| (k, ()))
-            .arrange_named::<DefaultKeyTrace<_,_,_>>(name)
-            .as_collection(|d: &D, _| d.clone())
+        self.consolidate_core(arrange_pact(), name)
     }
 
     fn consolidate_core<P>(&self, pact: P, name: &str) -> Self


### PR DESCRIPTION
Extend Differential's API to take a PACT in more places to enable
clients picking their own implementation. Export the default exchange
logic as a function.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>