### PR TITLE
Avoid resetting cursor on no-op seek

### DIFF
--- a/src/trace/layers/ordered.rs
+++ b/src/trace/layers/ordered.rs
@@ -262,8 +262,11 @@ where
         }
     }
     fn seek(&mut self, storage: &OrderedLayer<K, L, O>, key: &Self::Key) {
-        self.pos += advance(&storage.keys[self.pos .. self.bounds.1], |k| k.lt(key));
-        if self.valid(storage) {
+        let step = advance(&storage.keys[self.pos .. self.bounds.1], |k| k.lt(key));
+        self.pos += step;
+        // Only reposition the child cursor if this cursor strictly advanced.
+        // If this cursor did not advance, we do not want to reset the child cursor.
+        if self.valid(storage) && step > 0 {
             self.child.reposition(&storage.vals, storage.offs[self.pos].try_into().unwrap(), storage.offs[self.pos + 1].try_into().unwrap());
         }
     }


### PR DESCRIPTION
The implementation of `seek` had the defective property that when the seek was a no-op, for example when one re-issued a seek to the same key multiple times in sequence, the child cursor (over associated values, say) would be reset each time. I judge the correct implementation of seek to not do this, so as to present a continually advancing cursor. One can always rewind a cursor's values if that is what you want. (of course, one could always test if you are at the correct key and not `seek` as well).