### PR TITLE
dogsdogsdogs/lookup_map: Add unsafe variant

### DIFF
--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -37,11 +37,11 @@ pub trait PrefixExtender<G: Scope, R: Monoid+Multiply<Output = R>> {
     /// The type to be produced as extension.
     type Extension;
     /// Annotates prefixes with the number of extensions the relation would propose.
-    fn count(&mut self, &Collection<G, (Self::Prefix, usize, usize), R>, usize) -> Collection<G, (Self::Prefix, usize, usize), R>;
+    fn count(&mut self, prefixes: &Collection<G, (Self::Prefix, usize, usize), R>, index: usize) -> Collection<G, (Self::Prefix, usize, usize), R>;
     /// Extends each prefix with corresponding extensions.
-    fn propose(&mut self, &Collection<G, Self::Prefix, R>) -> Collection<G, (Self::Prefix, Self::Extension), R>;
+    fn propose(&mut self, prefixes: &Collection<G, Self::Prefix, R>) -> Collection<G, (Self::Prefix, Self::Extension), R>;
     /// Restricts proposed extensions by those the extender would have proposed.
-    fn validate(&mut self, &Collection<G, (Self::Prefix, Self::Extension), R>) -> Collection<G, (Self::Prefix, Self::Extension), R>;
+    fn validate(&mut self, extensions: &Collection<G, (Self::Prefix, Self::Extension), R>) -> Collection<G, (Self::Prefix, Self::Extension), R>;
 }
 
 pub trait ProposeExtensionMethod<G: Scope, P: ExchangeData+Ord, R: Monoid+Multiply<Output = R>> {

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -196,9 +196,7 @@ where
                                     });
                                     consolidate(&mut output_buffer);
                                     for (time, diff2) in output_buffer.drain(..) {
-                                        for dout in output_func(key, val1, val2, initial, &time, &diff1, &diff2) {
-                                            session.give(dout);
-                                        }
+                                        session.give_iterator(output_func(key, val1, val2, initial, &time, &diff1, &diff2).into_iter())
                                     }
                                     cursor.step_val(&storage);
                                 }


### PR DESCRIPTION
Add an unsafe variant of the `lookup_map` operator in the spirit of #326.

The implementation relies on two function, where one consumes the output of `map_times` and the other one produces actual stream data. I'm not particularly happy about this design because it makes it cumbersome to share data between the two functions, but it seems to do the job.

Alternatives include passing an explicit shared piece of data to the functions, or provide direct access to the cursor and storage.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>