### PR TITLE
trace: let set_{logical,physical}_compaction take arguments equal to …

### DIFF
--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -55,6 +55,7 @@ where
     type Cursor = Tr::Cursor;
 
     fn set_logical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) {
+        debug_assert!(timely::PartialOrder::less_equal(&self.logical_compaction.borrow(), &frontier));
         self.trace.borrow_mut().adjust_logical_compaction(self.logical_compaction.borrow(), frontier);
         self.logical_compaction.clear();
         self.logical_compaction.extend(frontier.iter().cloned());

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -89,8 +89,8 @@ pub trait TraceReader {
     /// By advancing the logical compaction frontier, the caller unblocks merging of otherwise equivalent udates,
     /// but loses the ability to observe historical detail that is not beyond `frontier`.
     ///
-    /// It is an error to call this method with a frontier not beyond the most recent arguments to this method,
-    /// or the initial value of `get_logical_compaction()` if this method has not yet been called.
+    /// It is an error to call this method with a frontier not equal to or beyond the most recent arguments to
+    /// this method, or the initial value of `get_logical_compaction()` if this method has not yet been called.
     fn set_logical_compaction(&mut self, frontier: AntichainRef<Self::Time>);
 
     /// Deprecated form of `set_logical_compaction`.
@@ -125,8 +125,8 @@ pub trait TraceReader {
     /// By advancing the physical compaction frontier, the caller unblocks the merging of batches of updates,
     /// but loses the ability to create a cursor through any frontier not beyond `frontier`.
     ///
-    /// It is an error to call this method with a frontier not beyond the most recent arguments to this method,
-    /// or the initial value of `get_physical_compaction()` if this method has not yet been called.
+    /// It is an error to call this method with a frontier not equal to or beyond the most recent arguments to
+    /// this method, or the initial value of `get_physical_compaction()` if this method has not yet been called.
     fn set_physical_compaction(&mut self, frontier: AntichainRef<Self::Time>);
 
     /// Deprecated form of `set_physical_compaction`.


### PR DESCRIPTION
…or beyond current frontier.

This commit changes the requirements  set_{logical,physical}_compaction methods to match
those of Capability::downgrade. Now, these methods all accept arguments equal to or beyond
the most recent argument passed, or initial value if the function was never called before.

Also added a debug assert to make sure the logical compaction only advances.