### PR TITLE
trace: define `BatchReader` with associated types

### DIFF
--- a/dogsdogsdogs/src/operators/count.rs
+++ b/dogsdogsdogs/src/operators/count.rs
@@ -4,7 +4,7 @@ use differential_dataflow::{ExchangeData, Collection, Hashable};
 use differential_dataflow::difference::{Monoid, Multiply};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
-use differential_dataflow::trace::{Cursor, TraceReader, BatchReader};
+use differential_dataflow::trace::{Cursor, TraceReader};
 
 /// Reports a number of extensions to a stream of prefixes.
 ///
@@ -23,7 +23,6 @@ where
     G::Timestamp: Lattice,
     Tr: TraceReader<Val=(), Time=G::Timestamp, R=isize>+Clone+'static,
     Tr::Key: Ord+Hashable+Default,
-    Tr::Batch: BatchReader<Tr::Key, (), Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, (), Tr::Time, Tr::R>,
     R: Monoid+Multiply<Output = R>+ExchangeData,
     F: Fn(&P)->Tr::Key+Clone+'static,

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -42,7 +42,7 @@ use differential_dataflow::{ExchangeData, Collection, AsCollection, Hashable};
 use differential_dataflow::difference::{Monoid, Semigroup};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
-use differential_dataflow::trace::{Cursor, TraceReader, BatchReader};
+use differential_dataflow::trace::{Cursor, TraceReader};
 use differential_dataflow::consolidation::{consolidate, consolidate_updates};
 
 /// A binary equijoin that responds to updates on only its first input.
@@ -81,7 +81,6 @@ where
     Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
     Tr::Key: Ord+Hashable+ExchangeData,
     Tr::Val: Clone,
-    Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::R: Monoid+ExchangeData,
     FF: Fn(&G::Timestamp) -> G::Timestamp + 'static,
@@ -137,7 +136,6 @@ where
     Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
     Tr::Key: Ord+Hashable+ExchangeData,
     Tr::Val: Clone,
-    Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::R: Monoid+ExchangeData,
     FF: Fn(&G::Timestamp) -> G::Timestamp + 'static,

--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -10,7 +10,7 @@ use differential_dataflow::{ExchangeData, Collection, AsCollection, Hashable};
 use differential_dataflow::difference::{Semigroup, Monoid};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
-use differential_dataflow::trace::{Cursor, TraceReader, BatchReader};
+use differential_dataflow::trace::{Cursor, TraceReader};
 
 /// Proposes extensions to a stream of prefixes.
 ///
@@ -32,7 +32,6 @@ where
     Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
     Tr::Key: Ord+Hashable,
     Tr::Val: Clone,
-    Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::R: Monoid+ExchangeData,
     F: FnMut(&D, &mut Tr::Key)+Clone+'static,

--- a/dogsdogsdogs/src/operators/propose.rs
+++ b/dogsdogsdogs/src/operators/propose.rs
@@ -4,7 +4,7 @@ use differential_dataflow::{ExchangeData, Collection, Hashable};
 use differential_dataflow::difference::{Monoid, Multiply};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
-use differential_dataflow::trace::{Cursor, TraceReader, BatchReader};
+use differential_dataflow::trace::{Cursor, TraceReader};
 
 /// Proposes extensions to a prefix stream.
 ///
@@ -25,7 +25,6 @@ where
     Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
     Tr::Key: Ord+Hashable+Default,
     Tr::Val: Clone,
-    Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::R: Monoid+Multiply<Output = Tr::R>+ExchangeData,
     F: Fn(&P)->Tr::Key+Clone+'static,
@@ -58,7 +57,6 @@ where
     Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
     Tr::Key: Ord+Hashable+Default,
     Tr::Val: Clone,
-    Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::R: Monoid+Multiply<Output = Tr::R>+ExchangeData,
     F: Fn(&P)->Tr::Key+Clone+'static,

--- a/dogsdogsdogs/src/operators/validate.rs
+++ b/dogsdogsdogs/src/operators/validate.rs
@@ -6,7 +6,7 @@ use differential_dataflow::{ExchangeData, Collection};
 use differential_dataflow::difference::{Monoid, Multiply};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
-use differential_dataflow::trace::{Cursor, TraceReader, BatchReader};
+use differential_dataflow::trace::{Cursor, TraceReader};
 
 /// Proposes extensions to a stream of prefixes.
 ///
@@ -24,7 +24,6 @@ where
     Tr: TraceReader<Key=(K,V), Val=(), Time=G::Timestamp>+Clone+'static,
     K: Ord+Hash+Clone+Default,
     V: ExchangeData+Hash+Default,
-    Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::R: Monoid+Multiply<Output = Tr::R>+ExchangeData,
     F: Fn(&P)->K+Clone+'static,

--- a/src/algorithms/graphs/bfs.rs
+++ b/src/algorithms/graphs/bfs.rs
@@ -30,7 +30,6 @@ where
     G::Timestamp: Lattice+Ord,
     N: ExchangeData+Hash,
     Tr: TraceReader<Key=N, Val=N, Time=G::Timestamp, R=isize>+Clone+'static,
-    Tr::Batch: crate::trace::BatchReader<N, N, G::Timestamp, Tr::R>+'static,
     Tr::Cursor: crate::trace::Cursor<N, N, G::Timestamp, Tr::R>+'static,
 {
     // initialize roots as reaching themselves at distance 0

--- a/src/algorithms/graphs/bijkstra.rs
+++ b/src/algorithms/graphs/bijkstra.rs
@@ -46,7 +46,6 @@ where
     G::Timestamp: Lattice+Ord,
     N: ExchangeData+Hash,
     Tr: TraceReader<Key=N, Val=N, Time=G::Timestamp, R=isize>+Clone+'static,
-    Tr::Batch: crate::trace::BatchReader<N, N, G::Timestamp, Tr::R>+'static,
     Tr::Cursor: crate::trace::Cursor<N, N, G::Timestamp, Tr::R>+'static,
 {
     forward

--- a/src/algorithms/graphs/propagate.rs
+++ b/src/algorithms/graphs/propagate.rs
@@ -65,7 +65,6 @@ where
     R: From<i8>,
     L: ExchangeData,
     Tr: TraceReader<Key=N, Val=N, Time=G::Timestamp, R=R>+Clone+'static,
-    Tr::Batch: crate::trace::BatchReader<N, N, G::Timestamp, Tr::R>+'static,
     Tr::Cursor: crate::trace::Cursor<N, N, G::Timestamp, Tr::R>+'static,
     F: Fn(&L)->u64+Clone+'static,
 {

--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -92,7 +92,7 @@ where
     pub fn new(trace: Tr, operator: ::timely::dataflow::operators::generic::OperatorInfo, logging: Option<::logging::Logger>) -> (Self, TraceWriter<Tr>)
     where
         Tr: Trace,
-        Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
+        Tr::Batch: Batch,
     {
         let trace = Rc::new(RefCell::new(TraceBox::new(trace)));
         let queues = Rc::new(RefCell::new(Vec::new()));

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -65,7 +65,6 @@ impl<G: Scope, Tr> Clone for Arranged<G, Tr>
 where
     G::Timestamp: Lattice+Ord,
     Tr: TraceReader<Time=G::Timestamp> + Clone,
-    Tr::Batch: BatchReader<Tr::Key, Tr::Val, G::Timestamp, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, G::Timestamp, Tr::R>,
 {
     fn clone(&self) -> Self {
@@ -83,7 +82,6 @@ impl<G: Scope, Tr> Arranged<G, Tr>
 where
     G::Timestamp: Lattice+Ord,
     Tr: TraceReader<Time=G::Timestamp> + Clone,
-    Tr::Batch: BatchReader<Tr::Key, Tr::Val, G::Timestamp, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, G::Timestamp, Tr::R>,
 {
     /// Brings an arranged collection into a nested scope.
@@ -425,7 +423,6 @@ impl<'a, G: Scope, Tr> Arranged<Child<'a, G, G::Timestamp>, Tr>
 where
     G::Timestamp: Lattice+Ord,
     Tr: TraceReader<Time=G::Timestamp> + Clone,
-    Tr::Batch: BatchReader<Tr::Key, Tr::Val, G::Timestamp, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, G::Timestamp, Tr::R>,
 {
     /// Brings an arranged collection out of a nested region.
@@ -462,7 +459,7 @@ where
         V: ExchangeData,
         R: ExchangeData,
         Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
-        Tr::Batch: Batch<K, V, G::Timestamp, R>,
+        Tr::Batch: Batch,
         Tr::Cursor: Cursor<K, V, G::Timestamp, R>,
     {
         self.arrange_named("Arrange")
@@ -479,7 +476,7 @@ where
         V: ExchangeData,
         R: ExchangeData,
         Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
-        Tr::Batch: Batch<K, V, G::Timestamp, R>,
+        Tr::Batch: Batch,
         Tr::Cursor: Cursor<K, V, G::Timestamp, R>,
     {
         let exchange = Exchange::new(move |update: &((K,V),G::Timestamp,R)| (update.0).0.hashed().into());
@@ -495,7 +492,7 @@ where
     where
         P: ParallelizationContract<G::Timestamp, ((K,V),G::Timestamp,R)>,
         Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
-        Tr::Batch: Batch<K, V, G::Timestamp, R>,
+        Tr::Batch: Batch,
         Tr::Cursor: Cursor<K, V, G::Timestamp, R>,
     ;
 }
@@ -512,7 +509,7 @@ where
     where
         P: ParallelizationContract<G::Timestamp, ((K,V),G::Timestamp,R)>,
         Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
-        Tr::Batch: Batch<K, V, G::Timestamp, R>,
+        Tr::Batch: Batch,
         Tr::Cursor: Cursor<K, V, G::Timestamp, R>,
     {
         // The `Arrange` operator is tasked with reacting to an advancing input
@@ -547,7 +544,7 @@ where
                 };
 
                 // Where we will deposit received updates, and from which we extract batches.
-                let mut batcher = <Tr::Batch as Batch<K,V,G::Timestamp,R>>::Batcher::new();
+                let mut batcher = <Tr::Batch as Batch>::Batcher::new();
 
                 // Capabilities for the lower envelope of updates in `batcher`.
                 let mut capabilities = Antichain::<Capability<G::Timestamp>>::new();
@@ -684,7 +681,7 @@ where
     where
         P: ParallelizationContract<G::Timestamp, ((K,()),G::Timestamp,R)>,
         Tr: Trace+TraceReader<Key=K, Val=(), Time=G::Timestamp, R=R>+'static,
-        Tr::Batch: Batch<K, (), G::Timestamp, R>,
+        Tr::Batch: Batch,
         Tr::Cursor: Cursor<K, (), G::Timestamp, R>,
     {
         self.map(|k| (k, ()))

--- a/src/operators/arrange/upsert.rs
+++ b/src/operators/arrange/upsert.rs
@@ -145,7 +145,7 @@ where
     Tr::Key: ExchangeData+Hashable+std::hash::Hash,
     Tr::Val: ExchangeData,
     Tr: Trace+TraceReader<Time=G::Timestamp,R=isize>+'static,
-    Tr::Batch: Batch<Tr::Key, Tr::Val, G::Timestamp, isize>,
+    Tr::Batch: Batch,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, G::Timestamp, isize>,
 {
     let mut reader: Option<TraceAgent<Tr>> = None;
@@ -252,7 +252,7 @@ where
                                 // Prepare a cursor to the existing arrangement, and a batch builder for
                                 // new stuff that we add.
                                 let (mut trace_cursor, trace_storage) = reader_local.cursor();
-                                let mut builder = <Tr::Batch as Batch<Tr::Key,Tr::Val,G::Timestamp,Tr::R>>::Builder::new();
+                                let mut builder = <Tr::Batch as Batch>::Builder::new();
                                 for (key, mut list) in to_process.drain(..) {
 
                                     // The prior value associated with the key.

--- a/src/operators/arrange/writer.rs
+++ b/src/operators/arrange/writer.rs
@@ -23,7 +23,7 @@ pub struct TraceWriter<Tr>
 where
     Tr: Trace,
     Tr::Time: Lattice+Timestamp+Ord+Clone+std::fmt::Debug+'static,
-    Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
+    Tr::Batch: Batch,
 {
     /// Current upper limit.
     upper: Antichain<Tr::Time>,
@@ -37,7 +37,7 @@ impl<Tr> TraceWriter<Tr>
 where
     Tr: Trace,
     Tr::Time: Lattice+Timestamp+Ord+Clone+std::fmt::Debug+'static,
-    Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
+    Tr::Batch: Batch,
 {
     /// Creates a new `TraceWriter`.
     pub fn new(
@@ -96,7 +96,7 @@ where
     pub fn seal(&mut self, upper: Antichain<Tr::Time>) {
         if self.upper != upper {
             use trace::Builder;
-            let builder = <Tr::Batch as Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>>::Builder::new();
+            let builder = <Tr::Batch as Batch>::Builder::new();
             let batch = builder.done(self.upper.clone(), upper, Antichain::from_elem(Tr::Time::minimum()));
             self.insert(batch, None);
         }
@@ -107,7 +107,7 @@ impl<Tr> Drop for TraceWriter<Tr>
 where
     Tr: Trace,
     Tr::Time: Lattice+Timestamp+Ord+Clone+std::fmt::Debug+'static,
-    Tr::Batch: Batch<Tr::Key,Tr::Val,Tr::Time,Tr::R>,
+    Tr::Batch: Batch,
 {
     fn drop(&mut self) {
         self.seal(Antichain::new())

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -74,7 +74,6 @@ where
     T1: TraceReader<Val=(), Time=G::Timestamp>+Clone+'static,
     T1::Key: ExchangeData,
     T1::R: ExchangeData+Semigroup,
-    T1::Batch: BatchReader<T1::Key, (), G::Timestamp, T1::R>,
     T1::Cursor: Cursor<T1::Key, (), G::Timestamp, T1::R>,
 {
     fn count_total_core<R2: Semigroup + From<i8>>(&self) -> Collection<G, (T1::Key, T1::R), R2> {

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -190,7 +190,6 @@ where
     Tr::Key: Data+Hashable,
     Tr::Val: Data,
     Tr::R: Semigroup,
-    Tr::Batch: BatchReader<Tr::Key,Tr::Val,G::Timestamp,Tr::R>+'static,
     Tr::Cursor: Cursor<Tr::Key,Tr::Val,G::Timestamp,Tr::R>+'static,
 {
     fn join_map<V2: ExchangeData, R2: ExchangeData+Semigroup, D: Data, L>(&self, other: &Collection<G, (Tr::Key, V2), R2>, mut logic: L) -> Collection<G, D, <Tr::R as Multiply<R2>>::Output>
@@ -258,7 +257,6 @@ pub trait JoinCore<G: Scope, K: 'static, V: 'static, R: Semigroup> where G::Time
     fn join_core<Tr2,I,L> (&self, stream2: &Arranged<G,Tr2>, result: L) -> Collection<G,I::Item,<R as Multiply<Tr2::R>>::Output>
     where
         Tr2: TraceReader<Key=K, Time=G::Timestamp>+Clone+'static,
-        Tr2::Batch: BatchReader<K, Tr2::Val, G::Timestamp, Tr2::R>+'static,
         Tr2::Cursor: Cursor<K, Tr2::Val, G::Timestamp, Tr2::R>+'static,
         Tr2::Val: Ord+Clone+Debug+'static,
         Tr2::R: Semigroup,
@@ -311,7 +309,6 @@ pub trait JoinCore<G: Scope, K: 'static, V: 'static, R: Semigroup> where G::Time
     fn join_core_internal_unsafe<Tr2,I,L,D,ROut> (&self, stream2: &Arranged<G,Tr2>, result: L) -> Collection<G,D,ROut>
     where
         Tr2: TraceReader<Key=K, Time=G::Timestamp>+Clone+'static,
-        Tr2::Batch: BatchReader<K, Tr2::Val, G::Timestamp, Tr2::R>+'static,
         Tr2::Cursor: Cursor<K, Tr2::Val, G::Timestamp, Tr2::R>+'static,
         Tr2::Val: Ord+Clone+Debug+'static,
         Tr2::R: Semigroup,
@@ -334,7 +331,6 @@ where
     fn join_core<Tr2,I,L> (&self, stream2: &Arranged<G,Tr2>, result: L) -> Collection<G,I::Item,<R as Multiply<Tr2::R>>::Output>
     where
         Tr2: TraceReader<Key=K, Time=G::Timestamp>+Clone+'static,
-        Tr2::Batch: BatchReader<K, Tr2::Val, G::Timestamp, Tr2::R>+'static,
         Tr2::Cursor: Cursor<K, Tr2::Val, G::Timestamp, Tr2::R>+'static,
         Tr2::Val: Ord+Clone+Debug+'static,
         Tr2::R: Semigroup,
@@ -351,7 +347,6 @@ where
     fn join_core_internal_unsafe<Tr2,I,L,D,ROut> (&self, stream2: &Arranged<G,Tr2>, result: L) -> Collection<G,D,ROut>
     where
         Tr2: TraceReader<Key=K, Time=G::Timestamp>+Clone+'static,
-        Tr2::Batch: BatchReader<K, Tr2::Val, G::Timestamp, Tr2::R>+'static,
         Tr2::Cursor: Cursor<K, Tr2::Val, G::Timestamp, Tr2::R>+'static,
         Tr2::Val: Ord+Clone+Debug+'static,
         Tr2::R: Semigroup,
@@ -374,14 +369,12 @@ impl<G, T1> JoinCore<G, T1::Key, T1::Val, T1::R> for Arranged<G,T1>
         T1::Key: Ord+Debug+'static,
         T1::Val: Ord+Clone+Debug+'static,
         T1::R: Semigroup,
-        T1::Batch: BatchReader<T1::Key,T1::Val,G::Timestamp,T1::R>+'static,
         T1::Cursor: Cursor<T1::Key,T1::Val,G::Timestamp,T1::R>+'static,
 {
     fn join_core<Tr2,I,L>(&self, other: &Arranged<G,Tr2>, mut result: L) -> Collection<G,I::Item,<T1::R as Multiply<Tr2::R>>::Output>
     where
         Tr2::Val: Ord+Clone+Debug+'static,
         Tr2: TraceReader<Key=T1::Key,Time=G::Timestamp>+Clone+'static,
-        Tr2::Batch: BatchReader<T1::Key, Tr2::Val, G::Timestamp, Tr2::R>+'static,
         Tr2::Cursor: Cursor<T1::Key, Tr2::Val, G::Timestamp, Tr2::R>+'static,
         Tr2::R: Semigroup,
         T1::R: Multiply<Tr2::R>,
@@ -401,7 +394,6 @@ impl<G, T1> JoinCore<G, T1::Key, T1::Val, T1::R> for Arranged<G,T1>
     fn join_core_internal_unsafe<Tr2,I,L,D,ROut> (&self, other: &Arranged<G,Tr2>, mut result: L) -> Collection<G,D,ROut>
     where
         Tr2: TraceReader<Key=T1::Key, Time=G::Timestamp>+Clone+'static,
-        Tr2::Batch: BatchReader<T1::Key, Tr2::Val, G::Timestamp, Tr2::R>+'static,
         Tr2::Cursor: Cursor<T1::Key, Tr2::Val, G::Timestamp, Tr2::R>+'static,
         Tr2::Val: Ord+Clone+Debug+'static,
         Tr2::R: Semigroup,

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -108,7 +108,6 @@ where
     T1: TraceReader<Val=(), Time=G::Timestamp>+Clone+'static,
     T1::Key: ExchangeData,
     T1::R: ExchangeData+Semigroup,
-    T1::Batch: BatchReader<T1::Key, (), G::Timestamp, T1::R>,
     T1::Cursor: Cursor<T1::Key, (), G::Timestamp, T1::R>,
 {
     fn threshold_semigroup<R2, F>(&self, mut thresh: F) -> Collection<G, T1::Key, R2>

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -8,7 +8,7 @@ use lattice::Lattice;
 use trace::{Batch, Batcher, Builder};
 
 /// Creates batches from unordered tuples.
-pub struct MergeBatcher<K: Ord, V: Ord, T: Ord, R: Semigroup, B: Batch<K, V, T, R>> {
+pub struct MergeBatcher<K: Ord, V: Ord, T: Ord, R: Semigroup, B: Batch<Key=K, Val=V, Time=T, R=R>> {
     sorter: MergeSorter<(K, V), T, R>,
     lower: Antichain<T>,
     frontier: Antichain<T>,
@@ -21,7 +21,7 @@ where
     V: Ord+Clone,
     T: Lattice+timely::progress::Timestamp+Ord+Clone,
     R: Semigroup,
-    B: Batch<K, V, T, R>,
+    B: Batch<Key=K, Val=V, Time=T, R=R>,
 {
     fn new() -> Self {
         MergeBatcher {

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -62,7 +62,7 @@ where
     pub desc: Description<T>,
 }
 
-impl<K, V, T, R, O> BatchReader<K, V, T, R> for OrdValBatch<K, V, T, R, O>
+impl<K, V, T, R, O> BatchReader for OrdValBatch<K, V, T, R, O>
 where
     K: Ord+Clone+'static,
     V: Ord+Clone+'static,
@@ -70,13 +70,18 @@ where
     R: Semigroup,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
+    type Key = K;
+    type Val = V;
+    type Time = T;
+    type R = R;
+
     type Cursor = OrdValCursor<V, T, R, O>;
     fn cursor(&self) -> Self::Cursor { OrdValCursor { cursor: self.layer.cursor() } }
     fn len(&self) -> usize { <OrderedLayer<K, OrderedLayer<V, OrderedLeaf<T, R>, O>, O> as Trie>::tuples(&self.layer) }
     fn description(&self) -> &Description<T> { &self.desc }
 }
 
-impl<K, V, T, R, O> Batch<K, V, T, R> for OrdValBatch<K, V, T, R, O>
+impl<K, V, T, R, O> Batch for OrdValBatch<K, V, T, R, O>
 where
     K: Ord+Clone+'static,
     V: Ord+Clone+'static,
@@ -409,13 +414,18 @@ where
     pub desc: Description<T>,
 }
 
-impl<K, T, R, O> BatchReader<K, (), T, R> for OrdKeyBatch<K, T, R, O>
+impl<K, T, R, O> BatchReader for OrdKeyBatch<K, T, R, O>
 where
     K: Ord+Clone+'static,
     T: Lattice+Ord+Clone+'static,
     R: Semigroup,
     O: OrdOffset, <O as TryFrom<usize>>::Error: Debug, <O as TryInto<usize>>::Error: Debug
 {
+    type Key = K;
+    type Val = ();
+    type Time = T;
+    type R = R;
+
     type Cursor = OrdKeyCursor<T, R, O>;
     fn cursor(&self) -> Self::Cursor {
         OrdKeyCursor {
@@ -426,10 +436,10 @@ where
         }
     }
     fn len(&self) -> usize { <OrderedLayer<K, OrderedLeaf<T, R>, O> as Trie>::tuples(&self.layer) }
-    fn description(&self) -> &Description<T> { &self.desc }
+    fn description(&self) -> &Description<Self::Time> { &self.desc }
 }
 
-impl<K, T, R, O> Batch<K, (), T, R> for OrdKeyBatch<K, T, R, O>
+impl<K, T, R, O> Batch for OrdKeyBatch<K, T, R, O>
 where
     K: Ord+Clone+'static,
     T: Lattice+timely::progress::Timestamp+Ord+Clone+'static,

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -62,7 +62,7 @@ where
     type Time = TInner;
     type R = Tr::R;
 
-    type Batch = BatchEnter<Tr::Key, Tr::Val, Tr::Time, Tr::R, Tr::Batch, TInner,F>;
+    type Batch = BatchEnter<Tr::Batch, TInner,F>;
     type Cursor = CursorEnter<Tr::Key, Tr::Val, Tr::Time, Tr::R, Tr::Cursor, TInner,F>;
 
     fn map_batches<F2: FnMut(&Self::Batch)>(&self, mut f: F2) {
@@ -131,32 +131,26 @@ where
 
 
 /// Wrapper to provide batch to nested scope.
-pub struct BatchEnter<K, V, T, R, B, TInner, F> {
-    phantom: ::std::marker::PhantomData<(K, V, T, R)>,
+#[derive(Clone)]
+pub struct BatchEnter<B, TInner, F> {
     batch: B,
     description: Description<TInner>,
     logic: F,
 }
 
-impl<K, V, T, R, B: Clone, TInner: Clone, F: Clone> Clone for BatchEnter<K, V, T, R, B, TInner, F> {
-    fn clone(&self) -> Self {
-        BatchEnter {
-            phantom: ::std::marker::PhantomData,
-            batch: self.batch.clone(),
-            description: self.description.clone(),
-            logic: self.logic.clone(),
-        }
-    }
-}
-
-impl<K, V, T, R, B, TInner, F> BatchReader<K, V, TInner, R> for BatchEnter<K, V, T, R, B, TInner, F>
+impl<B, TInner, F> BatchReader for BatchEnter<B, TInner, F>
 where
-    B: BatchReader<K, V, T, R>,
-    T: Timestamp,
-    TInner: Refines<T>+Lattice,
-    F: FnMut(&K, &V, &T)->TInner+Clone,
+    B: BatchReader,
+    B::Time: Timestamp,
+    TInner: Refines<B::Time>+Lattice,
+    F: FnMut(&B::Key, &B::Val, &B::Time)->TInner+Clone,
 {
-    type Cursor = BatchCursorEnter<K, V, T, R, B, TInner, F>;
+    type Key = B::Key;
+    type Val = B::Val;
+    type Time = TInner;
+    type R = B::R;
+
+    type Cursor = BatchCursorEnter<B::Key, B::Val, B::Time, B::R, B, TInner, F>;
 
     fn cursor(&self) -> Self::Cursor {
         BatchCursorEnter::new(self.batch.cursor(), self.logic.clone())
@@ -165,11 +159,11 @@ where
     fn description(&self) -> &Description<TInner> { &self.description }
 }
 
-impl<K, V, T, R, B, TInner, F> BatchEnter<K, V, T, R, B, TInner, F>
+impl<B, TInner, F> BatchEnter<B, TInner, F>
 where
-    B: BatchReader<K, V, T, R>,
-    T: Timestamp,
-    TInner: Refines<T>+Lattice,
+    B: BatchReader,
+    B::Time: Timestamp,
+    TInner: Refines<B::Time>+Lattice,
 {
     /// Makes a new batch wrapper
     pub fn make_from(batch: B, logic: F) -> Self {
@@ -178,7 +172,6 @@ where
         let since: Vec<_> = batch.description().since().elements().iter().map(|x| TInner::to_inner(x.clone())).collect();
 
         BatchEnter {
-            phantom: ::std::marker::PhantomData,
             batch,
             description: Description::new(Antichain::from(lower), Antichain::from(upper), Antichain::from(since)),
             logic,
@@ -241,13 +234,13 @@ where
 
 
 /// Wrapper to provide cursor to nested scope.
-pub struct BatchCursorEnter<K, V, T, R, B: BatchReader<K, V, T, R>, TInner, F> {
+pub struct BatchCursorEnter<K, V, T, R, B: BatchReader<Key=K, Val=V, Time=T, R=R>, TInner, F> {
     phantom: ::std::marker::PhantomData<(K, V, R, TInner)>,
     cursor: B::Cursor,
     logic: F,
 }
 
-impl<K, V, T, R, B: BatchReader<K, V, T, R>, TInner, F> BatchCursorEnter<K, V, T, R, B, TInner, F> {
+impl<K, V, T, R, B: BatchReader<Key=K, Val=V, Time=T, R=R>, TInner, F> BatchCursorEnter<K, V, T, R, B, TInner, F> {
     fn new(cursor: B::Cursor, logic: F) -> Self {
         BatchCursorEnter {
             phantom: ::std::marker::PhantomData,
@@ -257,13 +250,13 @@ impl<K, V, T, R, B: BatchReader<K, V, T, R>, TInner, F> BatchCursorEnter<K, V, T
     }
 }
 
-impl<K, V, T, R, TInner, B: BatchReader<K, V, T, R>, F> Cursor<K, V, TInner, R> for BatchCursorEnter<K, V, T, R, B, TInner, F>
+impl<K, V, T, R, TInner, B: BatchReader<Key=K, Val=V, Time=T, R=R>, F> Cursor<K, V, TInner, R> for BatchCursorEnter<K, V, T, R, B, TInner, F>
 where
     T: Timestamp,
     TInner: Refines<T>+Lattice,
     F: FnMut(&K, &V, &T)->TInner,
 {
-    type Storage = BatchEnter<K, V, T, R, B, TInner, F>;
+    type Storage = BatchEnter<B, TInner, F>;
 
     #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }
     #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(&storage.batch) }

--- a/tests/trace.rs
+++ b/tests/trace.rs
@@ -19,7 +19,7 @@ fn get_trace() -> Spine<u64, u64, usize, i64, Rc<OrdValBatch<u64, u64, usize, i6
     let op_info = OperatorInfo::new(0, 0, &[]);
     let mut trace = IntegerTrace::new(op_info, None, None);
     {
-        let mut batcher = <<IntegerTrace as TraceReader>::Batch as Batch<u64, u64, usize, i64>>::Batcher::new();
+        let mut batcher = <<IntegerTrace as TraceReader>::Batch as Batch>::Batcher::new();
 
         batcher.push_batch(&mut vec![
             ((1, 2), 0, 1),


### PR DESCRIPTION
The `TraceReader` trait uses associated types to define its `Key`, `Val`, `Time`, `Diff` but the `BatchReader` trait did not, even though they are very similar in nature. Usually the choice between associated types or generic parameters on a trait is determined by whether or not a particular type is expected to implement the same trait multiple times.

My starting point was that these two trait should at the very least be consistent with respect to their structure and either both use generic parameters or both use associated types.

All the uses in this repo (and also that I can imagine being useful) don't really need `BatchReader` to be polymorphic for a particular type and so I chose to change that one to make it consistent with `TraceReader`.

The result is quite pleasing as in many cases a lot of generic parameters are erased.

In order to keep this PR short I left the `Cursor` trait untouched, but I believe a similar transformation would be beneficial there too, simplifying further many type signatures.