### PR TITLE
remove transmute and fix rust warning

### DIFF
--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -405,10 +405,10 @@ where
 
                 // Determine new frontier on queries that may be issued.
                 // TODO: This code looks very suspect; explain better or fix.
-                let frontier = std::array::IntoIter::new([
+                let frontier = IntoIterator::into_iter([
                     capability.as_ref().map(|c| c.time().clone()),
                     input1.frontier().frontier().get(0).cloned(),
-                ]).filter_map(|t| t).min();
+                ]).flatten().min();
 
                 if let Some(frontier) = frontier {
                     trace.as_mut().map(|t| t.set_logical_compaction(AntichainRef::new(&[frontier])));

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -419,7 +419,6 @@ where
     type Cursor = OrdKeyCursor<T, R, O>;
     fn cursor(&self) -> Self::Cursor {
         OrdKeyCursor {
-            empty: (),
             valid: true,
             cursor: self.layer.cursor(),
             phantom: PhantomData
@@ -634,7 +633,6 @@ where
 #[derive(Debug)]
 pub struct OrdKeyCursor<T: Lattice+Ord+Clone, R: Semigroup, O=usize> {
     valid: bool,
-    empty: (),
     cursor: OrderedCursor<OrderedLeaf<T, R>>,
     phantom: PhantomData<O>
 }
@@ -650,7 +648,7 @@ where
     type Storage = OrdKeyBatch<K, T, R, O>;
 
     fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K { &self.cursor.key(&storage.layer) }
-    fn val<'a>(&self, _storage: &'a Self::Storage) -> &'a () { unsafe { ::std::mem::transmute(&self.empty) } }
+    fn val<'a>(&self, _storage: &'a Self::Storage) -> &'a () { &() }
     fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
         self.cursor.child.rewind(&storage.layer.vals);
         while self.cursor.child.valid(&storage.layer.vals) {


### PR DESCRIPTION
while `()` is a ZST the potentially dangling reference is still undefined behaviour. Making it a static is a trivial fix.