### PR TITLE
make capture::source's token thread-safe

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -359,66 +359,65 @@ pub mod source {
         let token_mut = &mut token;
         messages_op.build(move |capabilities| {
 
-            // Vector of strong references to capabilities, which can be dropped to terminate the sources.
+            // A Weak that communicates whether the returned token has been dropped.
             let drop_activator_weak = Arc::downgrade(&drop_activator);
 
             *token_mut = Some(drop_activator);
 
             // Read messages from some source; shuffle them to UPDATES and PROGRESS; share capability with FEEDBACK.
-            // First, wrap capabilities in a rc refcell so that they can be downgraded to weak references.
-            let capability_sets = (CapabilitySet::from_elem(capabilities[0].clone()), CapabilitySet::from_elem(capabilities[1].clone()));
-            let capability_sets = ActivateOnDrop::new(capability_sets, Rc::new(address), activations);
-            let mut local_capabilities = Some(capability_sets);
+            let mut capability_sets = (CapabilitySet::from_elem(capabilities[0].clone()), CapabilitySet::from_elem(capabilities[1].clone()));
             // Capture the shared frontier to read out frontier updates to apply.
             let local_frontier = shared_frontier.clone();
             //
             move |_frontiers| {
+                // First check to ensure that we haven't been terminated by someone dropping our tokens.
                 if drop_activator_weak.upgrade().is_none() {
-                    local_capabilities = None;
+                    // Give up our capabilities
+                    capability_sets.0.downgrade(&[]);
+                    capability_sets.1.downgrade(&[]);
+                    // never continue, even if we are (erroneously) activated again.
+                    return;
                 }
 
-                // First check to ensure that we haven't been terminated by someone dropping our tokens.
-                if let Some(capabilities) = &mut local_capabilities {
-                    let (updates_caps, progress_caps) = &mut **capabilities;
-                    // Consult our shared frontier, and ensure capabilities are downgraded to it.
-                    let shared_frontier = local_frontier.borrow();
-                    updates_caps.downgrade(&shared_frontier.frontier());
-                    progress_caps.downgrade(&shared_frontier.frontier());
+                let (updates_caps, progress_caps) = &mut capability_sets;
+                // Consult our shared frontier, and ensure capabilities are downgraded to it.
+                let shared_frontier = local_frontier.borrow();
+                updates_caps.downgrade(&shared_frontier.frontier());
+                progress_caps.downgrade(&shared_frontier.frontier());
 
-                    // Next check to see if we have been terminated by the source being complete.
-                    if !updates_caps.is_empty() && !progress_caps.is_empty() {
-                        let mut updates = updates_out.activate();
-                        let mut progress = progress_out.activate();
+                // Next check to see if we have been terminated by the source being complete.
+                if !updates_caps.is_empty() && !progress_caps.is_empty() {
+                    let mut updates = updates_out.activate();
+                    let mut progress = progress_out.activate();
 
-                        // TODO(frank): this is a moment where multi-temporal capabilities need to be fixed up.
-                        // Specifically, there may not be one capability valid for all updates.
-                        let mut updates_session = updates.session(&updates_caps[0]);
-                        let mut progress_session = progress.session(&progress_caps[0]);
+                    // TODO(frank): this is a moment where multi-temporal capabilities need to be fixed up.
+                    // Specifically, there may not be one capability valid for all updates.
+                    let mut updates_session = updates.session(&updates_caps[0]);
+                    let mut progress_session = progress.session(&progress_caps[0]);
 
-                        // We presume the iterator will yield if appropriate.
-                        while let Some(message) = source.next() {
-                            match message {
-                                Message::Updates(mut updates) => {
-                                    updates_session.give_vec(&mut updates);
+                    // We presume the iterator will yield if appropriate.
+                    while let Some(message) = source.next() {
+                        match message {
+                            Message::Updates(mut updates) => {
+                                updates_session.give_vec(&mut updates);
+                            }
+                            Message::Progress(progress) => {
+                                // We must send a copy of each progress message to all workers,
+                                // but we can partition the counts across workers by timestamp.
+                                let mut to_worker = vec![Vec::new(); workers];
+                                for (time, count) in progress.counts {
+                                    to_worker[(time.hashed() as usize) % workers]
+                                        .push((time, count));
                                 }
-                                Message::Progress(progress) => {
-                                    // We must send a copy of each progress message to all workers,
-                                    // but we can partition the counts across workers by timestamp.
-                                    let mut to_worker = vec![Vec::new(); workers];
-                                    for (time, count) in progress.counts {
-                                        to_worker[(time.hashed() as usize) % workers]
-                                            .push((time, count));
-                                    }
-                                    for (worker, counts) in to_worker.into_iter().enumerate() {
-                                        progress_session.give((
-                                            worker,
-                                            Progress {
-                                                lower: progress.lower.clone(),
-                                                upper: progress.upper.clone(),
-                                                counts,
-                                            },
-                                        ));
-                                    }
+                                for (worker, counts) in to_worker.into_iter().enumerate() {
+                                    progress_session.give((
+                                        worker,
+                                        Progress {
+                                            lower: progress.lower.clone(),
+                                            upper: progress.upper.clone(),
+                                            counts,
+                                        },
+                                    ));
                                 }
                             }
                         }


### PR DESCRIPTION
As part of resolving: https://github.com/MaterializeInc/materialize/pull/11987, we 

in general, thread-safety comes at a small perf cost, but in this case, the sync activator is only called once, and the Arc is never cloned, so it will not be a measurable difference, other than the `upgrade` costing one atomic load each run. This is a strictly more general api now! The `Send + Sync` can be coerced away if need be

I can clean this up once I make a Sync version of `ActivatorOnDrop` in the timely repo!

tested locally, token drop does in fact clear the local token vector