### PR TITLE
Generalize `TraceFrontier` with `upper` frontier

### DIFF
--- a/examples/capture-test.rs
+++ b/examples/capture-test.rs
@@ -153,7 +153,7 @@ pub mod kafka {
     use differential_dataflow::lattice::Lattice;
 
     /// Creates a Kafka source from supplied configuration information.
-    pub fn create_source<G, D, T, R>(scope: G, addr: &str, topic: &str, group: &str) -> (Box<dyn std::any::Any>, Stream<G, (D, T, R)>)
+    pub fn create_source<G, D, T, R>(scope: G, addr: &str, topic: &str, group: &str) -> (Box<dyn std::any::Any + Send + Sync>, Stream<G, (D, T, R)>)
     where
         G: Scope<Timestamp = T>,
         D: ExchangeData + Hash + for<'a> serde::Deserialize<'a>,


### PR DESCRIPTION
This PR adds an `upper: Antichain<T>` frontier to `TraceFrontier`, generalizing it from the time interval `[since, ...)` to `[since, upper)`. One option for `upper` is the empty frontier, which is semantically identical. This generalization allows one to import and use an arrangement on an intentionally narrowed interval of time, for example such as when one knows that changes at times greater than or equal to `upper` are of no interest.

This PR causes the import operator to drop its capabilities at this point, so that it may shut down the dataflow. This does risk miscommunicating that the trace is now "complete", but only in the same sense that pressing the returned `ShutdownButton` does, so this is judged to be not a new risk.