### PR TITLE
Move `consolidate` methods to inherent implementations

### DIFF
--- a/examples/accumulate.rs
+++ b/examples/accumulate.rs
@@ -5,7 +5,6 @@ extern crate differential_dataflow;
 use rand::{Rng, SeedableRng, StdRng};
 
 use differential_dataflow::input::Input;
-use differential_dataflow::operators::Consolidate;
 
 fn main() {
 

--- a/examples/arrange.rs
+++ b/examples/arrange.rs
@@ -14,7 +14,6 @@ use differential_dataflow::operators::arrange::ArrangeByKey;
 use differential_dataflow::operators::reduce::Reduce;
 use differential_dataflow::operators::join::JoinCore;
 use differential_dataflow::operators::Iterate;
-use differential_dataflow::operators::Consolidate;
 
 fn main() {
 

--- a/examples/graspan.rs
+++ b/examples/graspan.rs
@@ -17,7 +17,7 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::input::{Input, InputSession};
 use differential_dataflow::operators::arrange::{ArrangeByKey, ArrangeBySelf};
 use differential_dataflow::operators::iterate::Variable;
-use differential_dataflow::operators::{Threshold, JoinCore, Consolidate};
+use differential_dataflow::operators::{Threshold, JoinCore};
 
 type Node = usize;
 type Edge = (Node, Node);

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -531,7 +531,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
           R: ::ExchangeData+Hashable,
           G::Timestamp: Lattice+Ord,
     {
-        use operators::consolidate::Consolidate;
         self.consolidate()
             .inspect(|x| panic!("Assertion failed: non-empty collection: {:?}", x));
     }
@@ -545,6 +544,7 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
 use timely::dataflow::scopes::ScopeParent;
 use timely::progress::timestamp::Refines;
 
+/// Methods requiring a nested scope.
 impl<'a, G: Scope, T: Timestamp, D: Data, R: Semigroup> Collection<Child<'a, G, T>, D, R>
 where
     T: Refines<<G as ScopeParent>::Timestamp>,
@@ -582,6 +582,7 @@ where
     }
 }
 
+/// Methods requiring a region as the scope.
 impl<'a, G: Scope, D: Data, R: Semigroup> Collection<Child<'a, G, G::Timestamp>, D, R>
 {
     /// Returns the value of a Collection from a nested region to its containing scope.
@@ -595,6 +596,7 @@ impl<'a, G: Scope, D: Data, R: Semigroup> Collection<Child<'a, G, G::Timestamp>,
     }
 }
 
+/// Methods requiring an Abelian difference, to support negation.
 impl<G: Scope, D: Data, R: Abelian> Collection<G, D, R> where G::Timestamp: Data {
     /// Creates a new collection whose counts are the negation of those in the input.
     ///

--- a/src/operators/iterate.rs
+++ b/src/operators/iterate.rs
@@ -63,7 +63,6 @@ pub trait Iterate<G: Scope, D: Data, R: Semigroup> {
     ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::Iterate;
-    /// use differential_dataflow::operators::Consolidate;
     ///
     /// fn main() {
     ///     ::timely::example(|scope| {
@@ -145,7 +144,6 @@ impl<G: Scope, D: Ord+Data+Debug, R: Semigroup> Iterate<G, D, R> for G {
 ///
 /// use differential_dataflow::input::Input;
 /// use differential_dataflow::operators::iterate::Variable;
-/// use differential_dataflow::operators::Consolidate;
 ///
 /// fn main() {
 ///     ::timely::example(|scope| {

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -5,7 +5,6 @@
 //! to several operations defined directly on the `Collection` type (e.g. `map` and `filter`).
 
 pub use self::reduce::{Reduce, Threshold, Count};
-pub use self::consolidate::Consolidate;
 pub use self::iterate::Iterate;
 pub use self::join::{Join, JoinCore};
 pub use self::count::CountTotal;

--- a/tests/join.rs
+++ b/tests/join.rs
@@ -4,7 +4,7 @@ extern crate differential_dataflow;
 use timely::dataflow::operators::{ToStream, Capture, Map};
 use timely::dataflow::operators::capture::Extract;
 use differential_dataflow::AsCollection;
-use differential_dataflow::operators::{Consolidate, Join, Count};
+use differential_dataflow::operators::{Join, Count};
 
 #[test]
 fn join() {


### PR DESCRIPTION
This PR removes the `Consolidate` trait, and moves its associated methods to inherent implementations on `Collection`. There are no other implementors of the trait. The only plausible reason I could think of for the trait is to write code generic over `Collection` and `Arrangement`, but the latter didn't implement `Consolidate` yet in any case.

The change also alters `consolidate_named` to match `arrange_named` which takes a `Tr: Trace` generic argument, which can be specified by the user. Methods are not allowed to have generic arguments with default type values, so the `consolidate` method is the only way to do this. This removes the previous ability to easily specify a name without more awkwardly specifying the trace at the same time.