### PR TITLE
Update documentation for group → reduce

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Differential dataflow is a high-throughput, low-latency data-parallel programming framework.
 //!
 //! Differential dataflow programs are written in a collection-oriented style, where you transform
-//! collections of records using traditional operations like `map`, `filter`, `join`, and `group_by`.
+//! collections of records using traditional operations like `map`, `filter`, `join`, and `reduce`.
 //! Differential dataflow also includes the less traditional operation `iterate`, which allows you
 //! to repeatedly apply differential dataflow transformations to collections.
 //!

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -4,7 +4,7 @@
 //! structure, provides access to both an indexed form of accepted updates as well as a stream of
 //! batches of newly arranged updates.
 //!
-//! Several operators (`join`, `group`, and `cogroup`, among others) are implemented against `Arranged`,
+//! Several operators (`join`, `reduce`, and `count`, among others) are implemented against `Arranged`,
 //! and can be applied directly to arranged data instead of the collection. Internally, the operators
 //! will borrow the shared state, and listen on the timely stream for shared batches of data. The
 //! resources to index the collection---communication, computation, and memory---are spent only once,

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -1,17 +1,4 @@
-//! Group records by a key, and apply a reduction function.
-//!
-//! The `group` operators act on data that can be viewed as pairs `(key, val)`. They group records
-//! with the same key, and apply user supplied functions to the key and a list of values, which are
-//! expected to populate a list of output values.
-//!
-//! Several variants of `group` exist which allow more precise control over how grouping is done.
-//! For example, the `_by` suffixed variants take arbitrary data, but require a key-value selector
-//! to be applied to each record. The `_u` suffixed variants use unsigned integers as keys, and
-//! will use a dense array rather than a `HashMap` to store their keys.
-//!
-//! The list of values are presented as an iterator which internally merges sorted lists of values.
-//! This ordering can be exploited in several cases to avoid computation when only the first few
-//! elements are required.
+//! Count the number of occurrences of each element.
 
 use timely::order::TotalOrder;
 use timely::dataflow::*;

--- a/src/operators/iterate.rs
+++ b/src/operators/iterate.rs
@@ -52,7 +52,7 @@ pub trait Iterate<G: Scope, D: Data, R: Semigroup> {
     /// Importantly, this method does not automatically consolidate results.
     /// It may be important to conclude with `consolidate()` to ensure that
     /// logically empty collections that contain cancelling records do not
-    /// result in non-termination. Operators like `group`, `distinct`, and
+    /// result in non-termination. Operators like `reduce`, `distinct`, and
     /// `count` also perform consolidation, and are safe to conclude with.
     ///
     /// # Examples

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -214,7 +214,7 @@ where
 ///
 /// This method is used by the various `join` implementations, but it can also be used
 /// directly in the event that one has a handle to an `Arranged<G,T>`, perhaps because
-/// the arrangement is available for re-use, or from the output of a `group` operator.
+/// the arrangement is available for re-use, or from the output of a `reduce` operator.
 pub trait JoinCore<G: Scope, K: 'static, V: 'static, R: Semigroup> where G::Timestamp: Lattice+Ord {
 
     /// Joins two arranged collections with the same key type.

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -239,11 +239,11 @@ where
     }
 }
 
-/// Extension trait for the `group_arranged` differential dataflow method.
+/// Extension trait for the `reduce_core` differential dataflow method.
 pub trait ReduceCore<G: Scope, K: Data, V: Data, R: Semigroup> where G::Timestamp: Lattice+Ord {
-    /// Applies `group` to arranged data, and returns an arrangement of output data.
+    /// Applies `reduce` to arranged data, and returns an arrangement of output data.
     ///
-    /// This method is used by the more ergonomic `group`, `distinct`, and `count` methods, although
+    /// This method is used by the more ergonomic `reduce`, `distinct`, and `count` methods, although
     /// it can be very useful if one needs to manually attach and re-use existing arranged collections.
     ///
     /// # Examples


### PR DESCRIPTION
Commit 2ffebb5374bb2a865f4d134998958cd525dbeb64 renamed `group`, but left some trailing references in doc comments.