### PR TITLE
Provide TraceAgent::trace_box_unstable to expose the inner trace

### DIFF
--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -160,6 +160,16 @@ where
     pub fn operator(&self) -> &OperatorInfo {
         &self.operator
     }
+
+    /// Obtain a reference to the inner [`TraceBox`]. It is the caller's obligation to maintain
+    /// the trace box and this trace agent's invariants. Specifically, it is undefined behavior
+    /// to mutate the trace box. Keeping strong references can prevent resource reclamation.
+    ///
+    /// This method is subject to changes and removal and should not be considered part of a stable
+    /// interface.
+    pub fn trace_box_unstable(&self) -> Rc<RefCell<TraceBox<Tr>>> {
+        Rc::clone(&self.trace)
+    }
 }
 
 impl<Tr> TraceAgent<Tr>


### PR DESCRIPTION
This method exposes the trace agent's trace, which requires the caller to maintain the invariants expected by Differential. Specifically, the caller should not mutate the structure, and should not hold on to strong references. The method is not part of Differential's (semi-) stable API.