### PR TITLE
Get rid of some UB

### DIFF
--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -125,9 +125,9 @@ where
 #[inline]
 unsafe fn push_unchecked<T>(vec: &mut Vec<T>, element: T) {
     debug_assert!(vec.len() < vec.capacity());
-    let idx = vec.len();
-    vec.set_len(idx + 1);
-    ::std::ptr::write(vec.get_unchecked_mut(idx), element);
+    let end = vec.as_mut_ptr().add(vec.len());
+    ::std::ptr::write(end, element);
+    vec.set_len(vec.len() + 1);
 }
 
 pub struct MergeSorter<D: Ord, T: Ord, R: Semigroup> {


### PR DESCRIPTION
Constructing a reference to an invalid value is always UB, according to [this documentation](https://doc.rust-lang.org/nomicon/what-unsafe-does.html).

In addition, even just the `set_len` call can cause UB if we panic immediately after it (and thus try to drop the invalid value).

The new implementation is taken from `Vec::push`. Hat tip to @guswynn , @doy-materialize, and @petrosagg for talking me through why it was indeed UB, and the latter for also suggesting the `Vec::push` implementation.