### PR TITLE
remove deref bound from containers

### DIFF
--- a/src/trace/layers/mod.rs
+++ b/src/trace/layers/mod.rs
@@ -119,12 +119,63 @@ pub trait BatchContainer: Default {
     fn copy(&mut self, item: &Self::Item);
     /// Extends from a slice of items.
     fn copy_slice(&mut self, slice: &[Self::Item]);
+    /// Extends from a slice of items.
+    fn copy_range(&mut self, other: &Self, start: usize, end: usize);
     /// Creates a new container with sufficient capacity.
     fn with_capacity(size: usize) -> Self;
     /// Reserves additional capacity.
     fn reserve(&mut self, additional: usize);
     /// Creates a new container with sufficient capacity.
     fn merge_capacity(cont1: &Self, cont2: &Self) -> Self;
+
+    /// Reference to element at this position.
+    fn index(&self, index: usize) -> &Self::Item;
+    /// Number of contained elements
+    fn len(&self) -> usize;
+    
+    /// Reports the number of elements satisfing the predicate.
+    ///
+    /// This methods *relies strongly* on the assumption that the predicate
+    /// stays false once it becomes false, a joint property of the predicate
+    /// and the slice. This allows `advance` to use exponential search to
+    /// count the number of elements in time logarithmic in the result.
+    fn advance<F: Fn(&Self::Item)->bool>(&self, start: usize, end: usize, function: F) -> usize {
+
+        let small_limit = 8;
+
+        // Exponential seach if the answer isn't within `small_limit`.
+        if end > start + small_limit && function(self.index(start + small_limit)) {
+
+            // start with no advance
+            let mut index = small_limit + 1;
+            if start + index < end && function(self.index(start + index)) {
+
+                // advance in exponentially growing steps.
+                let mut step = 1;
+                while start + index + step < end && function(self.index(start + index + step)) {
+                    index += step;
+                    step = step << 1;
+                }
+
+                // advance in exponentially shrinking steps.
+                step = step >> 1;
+                while step > 0 {
+                    if start + index + step < end && function(self.index(start + index + step)) {
+                        index += step;
+                    }
+                    step = step >> 1;
+                }
+
+                index += 1;
+            }
+
+            index
+        }
+        else {
+            let limit = std::cmp::min(end, start + small_limit);
+            (start .. limit).filter(|x| function(self.index(*x))).count()
+        }
+    }
 }
 
 impl<T: Clone> BatchContainer for Vec<T> {
@@ -138,6 +189,9 @@ impl<T: Clone> BatchContainer for Vec<T> {
     fn copy_slice(&mut self, slice: &[T]) {
         self.extend_from_slice(slice);
     }
+    fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
+        self.extend_from_slice(&other[start .. end]);
+    }
     fn with_capacity(size: usize) -> Self {
         Vec::with_capacity(size)
     }
@@ -147,6 +201,8 @@ impl<T: Clone> BatchContainer for Vec<T> {
     fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
         Vec::with_capacity(cont1.len() + cont2.len())
     }
+    fn index(&self, index: usize) -> &Self::Item { &self[index] }
+    fn len(&self) -> usize { self[..].len() }
 }
 
 impl<T: Columnation> BatchContainer for TimelyStack<T> {
@@ -163,6 +219,13 @@ impl<T: Columnation> BatchContainer for TimelyStack<T> {
             self.copy(item);
         }
     }
+    fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
+        let slice = &other[start .. end];
+        self.reserve_items(slice.iter());
+        for item in slice.iter() {
+            self.copy(item);
+        }
+    }
     fn with_capacity(size: usize) -> Self {
         Self::with_capacity(size)
     }
@@ -173,49 +236,7 @@ impl<T: Columnation> BatchContainer for TimelyStack<T> {
         new.reserve_regions(std::iter::once(cont1).chain(std::iter::once(cont2)));
         new
     }
-}
 
-
-/// Reports the number of elements satisfing the predicate.
-///
-/// This methods *relies strongly* on the assumption that the predicate
-/// stays false once it becomes false, a joint property of the predicate
-/// and the slice. This allows `advance` to use exponential search to
-/// count the number of elements in time logarithmic in the result.
-pub fn advance<T, F: Fn(&T)->bool>(slice: &[T], function: F) -> usize {
-
-    let small_limit = 8;
-
-    // Exponential seach if the answer isn't within `small_limit`.
-    if slice.len() > small_limit && function(&slice[small_limit]) {
-
-        // start with no advance
-        let mut index = small_limit + 1;
-        if index < slice.len() && function(&slice[index]) {
-
-            // advance in exponentially growing steps.
-            let mut step = 1;
-            while index + step < slice.len() && function(&slice[index + step]) {
-                index += step;
-                step = step << 1;
-            }
-
-            // advance in exponentially shrinking steps.
-            step = step >> 1;
-            while step > 0 {
-                if index + step < slice.len() && function(&slice[index + step]) {
-                    index += step;
-                }
-                step = step >> 1;
-            }
-
-            index += 1;
-        }
-
-        index
-    }
-    else {
-        let limit = std::cmp::min(slice.len(), small_limit);
-        slice[..limit].iter().filter(|x| function(*x)).count()
-    }
+    fn index(&self, index: usize) -> &Self::Item { &self[index] }
+    fn len(&self) -> usize { self[..].len() }
 }

--- a/src/trace/layers/mod.rs
+++ b/src/trace/layers/mod.rs
@@ -119,7 +119,7 @@ pub trait BatchContainer: Default {
     fn copy(&mut self, item: &Self::Item);
     /// Extends from a slice of items.
     fn copy_slice(&mut self, slice: &[Self::Item]);
-    /// Extends from a slice of items.
+    /// Extends from a range of items in another`Self`.
     fn copy_range(&mut self, other: &Self, start: usize, end: usize);
     /// Creates a new container with sufficient capacity.
     fn with_capacity(size: usize) -> Self;
@@ -128,7 +128,7 @@ pub trait BatchContainer: Default {
     /// Creates a new container with sufficient capacity.
     fn merge_capacity(cont1: &Self, cont2: &Self) -> Self;
 
-    /// Reference to element at this position.
+    /// Reference to the element at this position.
     fn index(&self, index: usize) -> &Self::Item;
     /// Number of contained elements
     fn len(&self) -> usize;
@@ -137,7 +137,7 @@ pub trait BatchContainer: Default {
     ///
     /// This methods *relies strongly* on the assumption that the predicate
     /// stays false once it becomes false, a joint property of the predicate
-    /// and the slice. This allows `advance` to use exponential search to
+    /// and the layout of `Self. This allows `advance` to use exponential search to
     /// count the number of elements in time logarithmic in the result.
     fn advance<F: Fn(&Self::Item)->bool>(&self, start: usize, end: usize, function: F) -> usize {
 
@@ -201,8 +201,12 @@ impl<T: Clone> BatchContainer for Vec<T> {
     fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
         Vec::with_capacity(cont1.len() + cont2.len())
     }
-    fn index(&self, index: usize) -> &Self::Item { &self[index] }
-    fn len(&self) -> usize { self[..].len() }
+    fn index(&self, index: usize) -> &Self::Item {
+        &self[index]
+    }
+    fn len(&self) -> usize {
+        self[..].len()
+    }
 }
 
 impl<T: Columnation> BatchContainer for TimelyStack<T> {
@@ -236,7 +240,10 @@ impl<T: Columnation> BatchContainer for TimelyStack<T> {
         new.reserve_regions(std::iter::once(cont1).chain(std::iter::once(cont2)));
         new
     }
-
-    fn index(&self, index: usize) -> &Self::Item { &self[index] }
-    fn len(&self) -> usize { self[..].len() }
+    fn index(&self, index: usize) -> &Self::Item {
+        &self[index]
+    }
+    fn len(&self) -> usize {
+        self[..].len()
+    }
 }

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -2,7 +2,7 @@
 
 use ::difference::Semigroup;
 
-use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, BatchContainer, advance};
+use super::{Trie, Cursor, Builder, MergeBuilder, TupleBuilder, BatchContainer};
 use std::ops::Deref;
 
 /// A layer of unordered values.
@@ -62,7 +62,7 @@ where
     }
     #[inline]
     fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize) {
-        self.vals.copy_slice(&other.vals[lower .. upper]);
+        self.vals.copy_range(&other.vals, lower, upper);
     }
     fn push_merge(&mut self, other1: (&Self::Trie, usize, usize), other2: (&Self::Trie, usize, usize)) -> usize {
 
@@ -77,7 +77,7 @@ where
             match trie1.vals[lower1].0.cmp(&trie2.vals[lower2].0) {
                 ::std::cmp::Ordering::Less => {
                     // determine how far we can advance lower1 until we reach/pass lower2
-                    let step = 1 + advance(&trie1.vals[(1+lower1)..upper1], |x| x.0 < trie2.vals[lower2].0);
+                    let step = 1 + trie1.vals.advance(1+lower1, upper1, |x| x.0 < trie2.vals[lower2].0);
                     let step = std::cmp::min(step, 1000);
                     <OrderedLeafBuilder<K, R, C> as MergeBuilder>::copy_range(self, trie1, lower1, lower1 + step);
                     lower1 += step;
@@ -95,7 +95,7 @@ where
                 }
                 ::std::cmp::Ordering::Greater => {
                     // determine how far we can advance lower2 until we reach/pass lower1
-                    let step = 1 + advance(&trie2.vals[(1+lower2)..upper2], |x| x.0 < trie1.vals[lower1].0);
+                    let step = 1 + trie2.vals.advance(1+lower2, upper2, |x| x.0 < trie1.vals[lower1].0);
                     let step = std::cmp::min(step, 1000);
                     <OrderedLeafBuilder<K, R, C> as MergeBuilder>::copy_range(self, trie2, lower2, lower2 + step);
                     lower2 += step;


### PR DESCRIPTION
Same as #416 but for some reason this one works. Next step: figure out what is the diff between the two and why that makes #416 fail.