### PR TITLE
Quality of life updates: non-optional compaction, and `Builder::copy`.

### DIFF
--- a/src/trace/implementations/merge_batcher_col.rs
+++ b/src/trace/implementations/merge_batcher_col.rs
@@ -84,7 +84,7 @@ impl<B: Batch> Batcher<B> for ColumnatedMergeBatcher<B>
                     keep.copy(datum);
                 }
                 else {
-                    builder.push((key.clone(), val.clone(), time.clone(), diff.clone()));
+                    builder.copy((key, val, time, diff));
                 }
             }
             // Recycling buffer.

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -363,6 +363,10 @@ where
         self.builder.push_tuple((key, (val, (time, diff))));
     }
 
+    fn copy(&mut self, (key, val, time, diff): (&<OrdValBatch<L, C> as BatchReader>::Key, &<OrdValBatch<L, C> as BatchReader>::Val, &<OrdValBatch<L, C> as BatchReader>::Time, &<OrdValBatch<L, C> as BatchReader>::R)) {
+        self.builder.push_tuple((key.clone(), (val.clone(), (time.clone(), diff.clone()))));
+    }
+
     #[inline(never)]
     fn done(self, lower: Antichain<<OrdValBatch<L, C> as BatchReader>::Time>, upper: Antichain<<OrdValBatch<L, C> as BatchReader>::Time>, since: Antichain<<OrdValBatch<L, C> as BatchReader>::Time>) -> OrdValBatch<L, C> {
         OrdValBatch {
@@ -656,6 +660,11 @@ where
     #[inline]
     fn push(&mut self, (key, _, time, diff): (<L::Target as Update>::Key, (), <L::Target as Update>::Time, <L::Target as Update>::Diff)) {
         self.builder.push_tuple((key, (time, diff)));
+    }
+
+    #[inline]
+    fn copy(&mut self, (key, _, time, diff): (&<L::Target as Update>::Key, &(), &<L::Target as Update>::Time, &<L::Target as Update>::Diff)) {
+        self.builder.push_tuple((key.clone(), (time.clone(), diff.clone())));
     }
 
     #[inline(never)]

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -109,7 +109,7 @@ mod val_batch {
         type Builder = OrdValBuilder<L>;
         type Merger = OrdValMerger<L>;
 
-        fn begin_merge(&self, other: &Self, compaction_frontier: Option<AntichainRef<<L::Target as Update>::Time>>) -> Self::Merger {
+        fn begin_merge(&self, other: &Self, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self::Merger {
             OrdValMerger::new(self, other, compaction_frontier)
         }
     }
@@ -133,14 +133,13 @@ mod val_batch {
     }
 
     impl<L: Layout> Merger<OrdValBatch<L>> for OrdValMerger<L> {
-        fn new(batch1: &OrdValBatch<L>, batch2: &OrdValBatch<L>, compaction_frontier: Option<AntichainRef<<L::Target as Update>::Time>>) -> Self {
+        fn new(batch1: &OrdValBatch<L>, batch2: &OrdValBatch<L>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
 
             assert!(batch1.upper() == batch2.lower());
             use lattice::Lattice;
             let mut since = batch1.description().since().join(batch2.description().since());
-            if let Some(compaction_frontier) = compaction_frontier {
-                since = since.join(&compaction_frontier.to_owned());
-            }
+            since = since.join(&compaction_frontier.to_owned());
+
             let description = Description::new(batch1.lower().clone(), batch2.upper().clone(), since);
 
             let batch1 = &batch1.storage;

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -473,9 +473,9 @@ mod val_batch {
         fn copy(&mut self, (key, val, time, diff): (&<L::Target as Update>::Key, &<L::Target as Update>::Val, &<L::Target as Update>::Time, &<L::Target as Update>::Diff)) {
 
             // Perhaps this is a continuation of an already received key.
-            if self.result.keys.last() == Some(&key) {
+            if self.result.keys.last() == Some(key) {
                 // Perhaps this is a continuation of an already received value.
-                if self.result.vals.last() == Some(&val) {
+                if self.result.vals.last() == Some(val) {
                     // TODO: here we could look for repetition, and not push the update in that case.
                     // More logic (and state) would be required to correctly wrangle this.
                     self.result.updates.push((time.clone(), diff.clone()));

--- a/src/trace/implementations/spine_fueled.rs
+++ b/src/trace/implementations/spine_fueled.rs
@@ -675,7 +675,7 @@ where
                         complete: None,
                     }
                 ));
-                let compaction_frontier = Some(self.logical_frontier.borrow());
+                let compaction_frontier = self.logical_frontier.borrow();
                 self.merging[index] = MergeState::begin_merge(old, batch, compaction_frontier);
             }
             MergeState::Double(_) => {
@@ -869,7 +869,7 @@ impl<B: Batch> MergeState<B> where B::Time: Eq {
     /// empty batch whose upper and lower froniers are equal. This
     /// option exists purely for bookkeeping purposes, and no computation
     /// is performed to merge the two batches.
-    fn begin_merge(batch1: Option<B>, batch2: Option<B>, compaction_frontier: Option<AntichainRef<B::Time>>) -> MergeState<B> {
+    fn begin_merge(batch1: Option<B>, batch2: Option<B>, compaction_frontier: AntichainRef<B::Time>) -> MergeState<B> {
         let variant =
         match (batch1, batch2) {
             (Some(batch1), Some(batch2)) => {


### PR DESCRIPTION
Two changes; I thought there would be more but stopping here for now:
1. Compaction used to be an optional argument for merging. However, we never use that and it's something of an antipattern (in ye olde days, we only compacted the largest batch in merges).
2. Added a `copy` method to `Builder` allowing for non-owned presentation of tuples. This is especially useful when the destination container does not need to take ownership. Unfortunately we do not retrofit the `TupleBulider` trait used by trie layers, as they conceal their `Item` type structure well enough to not support e.g. `(&Key, &Val)` in place of `&(Key, Val)`.