### PR TITLE
Trait reorganization

### DIFF
--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -11,7 +11,7 @@ use timely::progress::{Antichain, frontier::AntichainRef};
 use timely::dataflow::operators::CapabilitySet;
 
 use lattice::Lattice;
-use trace::{Trace, TraceReader, Batch, BatchReader, Cursor};
+use trace::{Trace, TraceReader, Batch, BatchReader};
 
 use trace::wrappers::rc::TraceBox;
 
@@ -53,6 +53,7 @@ where
     type R = Tr::R;
 
     type Batch = Tr::Batch;
+    type Storage = Tr::Storage;
     type Cursor = Tr::Cursor;
 
     fn set_logical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) {
@@ -77,7 +78,7 @@ where
     fn get_physical_compaction(&mut self) -> AntichainRef<Tr::Time> {
         self.physical_compaction.borrow()
     }
-    fn cursor_through(&mut self, frontier: AntichainRef<Tr::Time>) -> Option<(Tr::Cursor, <Tr::Cursor as Cursor>::Storage)> {
+    fn cursor_through(&mut self, frontier: AntichainRef<Tr::Time>) -> Option<(Self::Cursor, Self::Storage)> {
         self.trace.borrow_mut().trace.cursor_through(frontier)
     }
     fn map_batches<F: FnMut(&Self::Batch)>(&self, f: F) { self.trace.borrow().trace.map_batches(f) }

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -454,7 +454,7 @@ where
         K: ExchangeData+Hashable,
         V: ExchangeData,
         R: ExchangeData,
-        Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
+        Tr: Trace+TraceReader<Time=G::Timestamp>+'static,
         Tr::Batch: Batch,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,V),G::Timestamp,R)>,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
@@ -472,7 +472,7 @@ where
         K: ExchangeData+Hashable,
         V: ExchangeData,
         R: ExchangeData,
-        Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
+        Tr: Trace+TraceReader<Time=G::Timestamp>+'static,
         Tr::Batch: Batch,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,V),G::Timestamp,R)>,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
@@ -489,7 +489,7 @@ where
     fn arrange_core<P, Tr>(&self, pact: P, name: &str) -> Arranged<G, TraceAgent<Tr>>
     where
         P: ParallelizationContract<G::Timestamp, ((K,V),G::Timestamp,R)>,
-        Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
+        Tr: Trace+TraceReader<Time=G::Timestamp>+'static,
         Tr::Batch: Batch,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,V),G::Timestamp,R)>,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
@@ -509,7 +509,7 @@ where
         K: ExchangeData + Hashable,
         V: ExchangeData,
         R: ExchangeData,
-        Tr: Trace + TraceReader<Key=K, Val=V, Time=G::Timestamp, R=R> + 'static, Tr::Batch: Batch,
+        Tr: Trace + TraceReader<Time=G::Timestamp> + 'static, Tr::Batch: Batch,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,V),G::Timestamp,R)>,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
     {
@@ -521,7 +521,7 @@ where
         K: ExchangeData + Hashable,
         V: ExchangeData,
         R: ExchangeData,
-        Tr: Trace + TraceReader<Key=K, Val=V, Time=G::Timestamp, R=R> + 'static, Tr::Batch: Batch,
+        Tr: Trace + TraceReader<Time=G::Timestamp> + 'static, Tr::Batch: Batch,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,V),G::Timestamp,R)>,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
     {
@@ -532,7 +532,7 @@ where
     fn arrange_core<P, Tr>(&self, pact: P, name: &str) -> Arranged<G, TraceAgent<Tr>>
     where
         P: ParallelizationContract<G::Timestamp, ((K,V),G::Timestamp,R)>,
-        Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
+        Tr: Trace+TraceReader<Time=G::Timestamp>+'static,
         Tr::Batch: Batch,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,V),G::Timestamp,R)>,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
@@ -697,7 +697,7 @@ where
     fn arrange_core<P, Tr>(&self, pact: P, name: &str) -> Arranged<G, TraceAgent<Tr>>
     where
         P: ParallelizationContract<G::Timestamp, ((K,()),G::Timestamp,R)>,
-        Tr: Trace+TraceReader<Key=K, Val=(), Time=G::Timestamp, R=R>+'static,
+        Tr: Trace+TraceReader<Time=G::Timestamp>+'static,
         Tr::Batch: Batch,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,()),G::Timestamp,R)>,
         <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -456,6 +456,8 @@ where
         R: ExchangeData,
         Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
         Tr::Batch: Batch,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,V),G::Timestamp,R)>,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
     {
         self.arrange_named("Arrange")
     }
@@ -472,6 +474,8 @@ where
         R: ExchangeData,
         Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
         Tr::Batch: Batch,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,V),G::Timestamp,R)>,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
     {
         let exchange = Exchange::new(move |update: &((K,V),G::Timestamp,R)| (update.0).0.hashed().into());
         self.arrange_core(exchange, name)
@@ -487,6 +491,8 @@ where
         P: ParallelizationContract<G::Timestamp, ((K,V),G::Timestamp,R)>,
         Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
         Tr::Batch: Batch,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,V),G::Timestamp,R)>,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
     ;
 }
 
@@ -503,7 +509,9 @@ where
         K: ExchangeData + Hashable,
         V: ExchangeData,
         R: ExchangeData,
-        Tr: Trace + TraceReader<Key=K, Val=V, Time=G::Timestamp, R=R> + 'static, Tr::Batch: Batch
+        Tr: Trace + TraceReader<Key=K, Val=V, Time=G::Timestamp, R=R> + 'static, Tr::Batch: Batch,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,V),G::Timestamp,R)>,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
     {
         self.arrange_named("Arrange")
     }
@@ -513,7 +521,9 @@ where
         K: ExchangeData + Hashable,
         V: ExchangeData,
         R: ExchangeData,
-        Tr: Trace + TraceReader<Key=K, Val=V, Time=G::Timestamp, R=R> + 'static, Tr::Batch: Batch
+        Tr: Trace + TraceReader<Key=K, Val=V, Time=G::Timestamp, R=R> + 'static, Tr::Batch: Batch,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,V),G::Timestamp,R)>,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
     {
         let exchange = Exchange::new(move |update: &((K,V),G::Timestamp,R)| (update.0).0.hashed().into());
         self.arrange_core(exchange, name)
@@ -524,6 +534,8 @@ where
         P: ParallelizationContract<G::Timestamp, ((K,V),G::Timestamp,R)>,
         Tr: Trace+TraceReader<Key=K,Val=V,Time=G::Timestamp,R=R>+'static,
         Tr::Batch: Batch,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,V),G::Timestamp,R)>,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
     {
         // The `Arrange` operator is tasked with reacting to an advancing input
         // frontier by producing the sequence of batches whose lower and upper
@@ -687,6 +699,8 @@ where
         P: ParallelizationContract<G::Timestamp, ((K,()),G::Timestamp,R)>,
         Tr: Trace+TraceReader<Key=K, Val=(), Time=G::Timestamp, R=R>+'static,
         Tr::Batch: Batch,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((K,()),G::Timestamp,R)>,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
     {
         self.map(|k| (k, ()))
             .arrange_core(pact, name)

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -456,8 +456,8 @@ where
         R: ExchangeData,
         Tr: Trace+TraceReader<Time=G::Timestamp>+'static,
         Tr::Batch: Batch,
-        <Tr::Batch as Batch>::Batcher: Batcher<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp>,
-        <Tr::Batch as Batch>::Builder: Builder<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
+        Tr::Batcher: Batcher<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp>,
+        Tr::Builder: Builder<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
     {
         self.arrange_named("Arrange")
     }
@@ -474,8 +474,8 @@ where
         R: ExchangeData,
         Tr: Trace+TraceReader<Time=G::Timestamp>+'static,
         Tr::Batch: Batch,
-        <Tr::Batch as Batch>::Batcher: Batcher<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp>,
-        <Tr::Batch as Batch>::Builder: Builder<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
+        Tr::Batcher: Batcher<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp>,
+        Tr::Builder: Builder<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
     {
         let exchange = Exchange::new(move |update: &((K,V),G::Timestamp,R)| (update.0).0.hashed().into());
         self.arrange_core(exchange, name)
@@ -491,8 +491,8 @@ where
         P: ParallelizationContract<G::Timestamp, ((K,V),G::Timestamp,R)>,
         Tr: Trace+TraceReader<Time=G::Timestamp>+'static,
         Tr::Batch: Batch,
-        <Tr::Batch as Batch>::Batcher: Batcher<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp>,
-        <Tr::Batch as Batch>::Builder: Builder<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
+        Tr::Batcher: Batcher<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp>,
+        Tr::Builder: Builder<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
     ;
 }
 
@@ -510,8 +510,8 @@ where
         V: ExchangeData,
         R: ExchangeData,
         Tr: Trace + TraceReader<Time=G::Timestamp> + 'static, Tr::Batch: Batch,
-        <Tr::Batch as Batch>::Batcher: Batcher<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp>,
-        <Tr::Batch as Batch>::Builder: Builder<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
+        Tr::Batcher: Batcher<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp>,
+        Tr::Builder: Builder<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
     {
         self.arrange_named("Arrange")
     }
@@ -522,8 +522,8 @@ where
         V: ExchangeData,
         R: ExchangeData,
         Tr: Trace + TraceReader<Time=G::Timestamp> + 'static, Tr::Batch: Batch,
-        <Tr::Batch as Batch>::Batcher: Batcher<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp>,
-        <Tr::Batch as Batch>::Builder: Builder<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
+        Tr::Batcher: Batcher<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp>,
+        Tr::Builder: Builder<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
     {
         let exchange = Exchange::new(move |update: &((K,V),G::Timestamp,R)| (update.0).0.hashed().into());
         self.arrange_core(exchange, name)
@@ -534,8 +534,8 @@ where
         P: ParallelizationContract<G::Timestamp, ((K,V),G::Timestamp,R)>,
         Tr: Trace+TraceReader<Time=G::Timestamp>+'static,
         Tr::Batch: Batch,
-        <Tr::Batch as Batch>::Batcher: Batcher<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp>,
-        <Tr::Batch as Batch>::Builder: Builder<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
+        Tr::Batcher: Batcher<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp>,
+        Tr::Builder: Builder<Item = ((K,V),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
     {
         // The `Arrange` operator is tasked with reacting to an advancing input
         // frontier by producing the sequence of batches whose lower and upper
@@ -569,7 +569,7 @@ where
                 };
 
                 // Where we will deposit received updates, and from which we extract batches.
-                let mut batcher = <Tr::Batch as Batch>::Batcher::new();
+                let mut batcher = Tr::Batcher::new();
 
                 // Capabilities for the lower envelope of updates in `batcher`.
                 let mut capabilities = Antichain::<Capability<G::Timestamp>>::new();
@@ -645,7 +645,7 @@ where
                                     }
 
                                     // Extract updates not in advance of `upper`.
-                                    let batch = batcher.seal::<<Tr::Batch as Batch>::Builder>(upper.clone());
+                                    let batch = batcher.seal::<Tr::Builder>(upper.clone());
 
                                     writer.insert(batch.clone(), Some(capability.time().clone()));
 
@@ -673,7 +673,7 @@ where
                         }
                         else {
                             // Announce progress updates, even without data.
-                            let _batch = batcher.seal::<<Tr::Batch as Batch>::Builder>(input.frontier().frontier().to_owned());
+                            let _batch = batcher.seal::<Tr::Builder>(input.frontier().frontier().to_owned());
                             writer.seal(input.frontier().frontier().to_owned());
                         }
 
@@ -699,8 +699,8 @@ where
         P: ParallelizationContract<G::Timestamp, ((K,()),G::Timestamp,R)>,
         Tr: Trace+TraceReader<Time=G::Timestamp>+'static,
         Tr::Batch: Batch,
-        <Tr::Batch as Batch>::Batcher: Batcher<Item = ((K,()),G::Timestamp,R), Time = G::Timestamp>,
-        <Tr::Batch as Batch>::Builder: Builder<Item = ((K,()),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
+        Tr::Batcher: Batcher<Item = ((K,()),G::Timestamp,R), Time = G::Timestamp>,
+        Tr::Builder: Builder<Item = ((K,()),G::Timestamp,R), Time = G::Timestamp, Output = Tr::Batch>,
     {
         self.map(|k| (k, ()))
             .arrange_core(pact, name)

--- a/src/operators/arrange/upsert.rs
+++ b/src/operators/arrange/upsert.rs
@@ -146,6 +146,7 @@ where
     Tr::Val: ExchangeData,
     Tr: Trace+TraceReader<Time=G::Timestamp,R=isize>+'static,
     Tr::Batch: Batch,
+    <Tr::Batch as Batch>::Builder: Builder<Tr::Batch, Item = ((Tr::Key, Tr::Val), Tr::Time, Tr::R)>,
 {
     let mut reader: Option<TraceAgent<Tr>> = None;
 
@@ -277,10 +278,10 @@ where
                                     for (time, std::cmp::Reverse(next)) in list {
                                         if prev_value != next {
                                             if let Some(prev) = prev_value {
-                                                updates.push((key.clone(), prev, time.clone(), -1));
+                                                updates.push(((key.clone(), prev), time.clone(), -1));
                                             }
                                             if let Some(next) = next.as_ref() {
-                                                updates.push((key.clone(), next.clone(), time.clone(), 1));
+                                                updates.push(((key.clone(), next.clone()), time.clone(), 1));
                                             }
                                             prev_value = next;
                                         }

--- a/src/operators/arrange/upsert.rs
+++ b/src/operators/arrange/upsert.rs
@@ -146,7 +146,7 @@ where
     Tr::Val: ExchangeData,
     Tr: Trace+TraceReader<Time=G::Timestamp,R=isize>+'static,
     Tr::Batch: Batch,
-    <Tr::Batch as Batch>::Builder: Builder<Tr::Batch, Item = ((Tr::Key, Tr::Val), Tr::Time, Tr::R)>,
+    <Tr::Batch as Batch>::Builder: Builder<Item = ((Tr::Key, Tr::Val), Tr::Time, Tr::R)>,
 {
     let mut reader: Option<TraceAgent<Tr>> = None;
 

--- a/src/operators/arrange/upsert.rs
+++ b/src/operators/arrange/upsert.rs
@@ -146,7 +146,7 @@ where
     Tr::Val: ExchangeData,
     Tr: Trace+TraceReader<Time=G::Timestamp,R=isize>+'static,
     Tr::Batch: Batch,
-    <Tr::Batch as Batch>::Builder: Builder<Item = ((Tr::Key, Tr::Val), Tr::Time, Tr::R)>,
+    Tr::Builder: Builder<Item = ((Tr::Key, Tr::Val), Tr::Time, Tr::R)>,
 {
     let mut reader: Option<TraceAgent<Tr>> = None;
 
@@ -249,7 +249,7 @@ where
                                 // Prepare a cursor to the existing arrangement, and a batch builder for
                                 // new stuff that we add.
                                 let (mut trace_cursor, trace_storage) = reader_local.cursor();
-                                let mut builder = <Tr::Batch as Batch>::Builder::new();
+                                let mut builder = Tr::Builder::new();
                                 for (key, mut list) in to_process.drain(..) {
 
                                     // The prior value associated with the key.

--- a/src/operators/arrange/writer.rs
+++ b/src/operators/arrange/writer.rs
@@ -96,7 +96,7 @@ where
     pub fn seal(&mut self, upper: Antichain<Tr::Time>) {
         if self.upper != upper {
             use trace::Builder;
-            let builder = <Tr::Batch as Batch>::Builder::new();
+            let builder = Tr::Builder::new();
             let batch = builder.done(self.upper.clone(), upper, Antichain::from_elem(Tr::Time::minimum()));
             self.insert(batch, None);
         }

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -13,7 +13,7 @@ use ::difference::Semigroup;
 
 use Data;
 use lattice::Lattice;
-use trace::{Batch, Batcher, Builder};
+use trace::{Batcher, Builder};
 
 /// Methods which require data be arrangeable.
 impl<G, D, R> Collection<G, D, R>
@@ -58,8 +58,8 @@ where
     where
         Tr: crate::trace::Trace+crate::trace::TraceReader<Key=D,Val=(),Time=G::Timestamp,R=R>+'static,
         Tr::Batch: crate::trace::Batch,
-        <Tr::Batch as Batch>::Batcher: Batcher<Item = ((D,()),G::Timestamp,R), Time = G::Timestamp>,
-        <Tr::Batch as Batch>::Builder: Builder<Item = ((D,()),G::Timestamp,R), Time = G::Timestamp>,
+        Tr::Batcher: Batcher<Item = ((D,()),G::Timestamp,R), Time = G::Timestamp>,
+        Tr::Builder: Builder<Item = ((D,()),G::Timestamp,R), Time = G::Timestamp>,
     {
         use operators::arrange::arrangement::Arrange;
         self.map(|k| (k, ()))

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -13,7 +13,7 @@ use ::difference::Semigroup;
 
 use Data;
 use lattice::Lattice;
-use trace::{Batch, Batcher};
+use trace::{Batch, Batcher, Builder};
 
 /// Methods which require data be arrangeable.
 impl<G, D, R> Collection<G, D, R>
@@ -58,8 +58,8 @@ where
     where
         Tr: crate::trace::Trace+crate::trace::TraceReader<Key=D,Val=(),Time=G::Timestamp,R=R>+'static,
         Tr::Batch: crate::trace::Batch,
-        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((D,()),G::Timestamp,R)>,
-        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
+        <Tr::Batch as Batch>::Batcher: Batcher<Item = ((D,()),G::Timestamp,R), Time = G::Timestamp>,
+        <Tr::Batch as Batch>::Builder: Builder<Item = ((D,()),G::Timestamp,R), Time = G::Timestamp>,
     {
         use operators::arrange::arrangement::Arrange;
         self.map(|k| (k, ()))

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -13,6 +13,7 @@ use ::difference::Semigroup;
 
 use Data;
 use lattice::Lattice;
+use trace::{Batch, Batcher};
 
 /// Methods which require data be arrangeable.
 impl<G, D, R> Collection<G, D, R>
@@ -57,6 +58,8 @@ where
     where
         Tr: crate::trace::Trace+crate::trace::TraceReader<Key=D,Val=(),Time=G::Timestamp,R=R>+'static,
         Tr::Batch: crate::trace::Batch,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Item = ((D,()),G::Timestamp,R)>,
+        <Tr::Batch as Batch>::Batcher: Batcher<Tr::Batch, Time = G::Timestamp>,
     {
         use operators::arrange::arrangement::Arrange;
         self.map(|k| (k, ()))

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -633,12 +633,12 @@ impl<G, T1> JoinCore<G, T1::Key, T1::Val, T1::R> for Arranged<G,T1>
 /// The structure wraps cursors which allow us to play out join computation at whatever rate we like.
 /// This allows us to avoid producing and buffering massive amounts of data, without giving the timely
 /// dataflow system a chance to run operators that can consume and aggregate the data.
-struct Deferred<K, T, R, C1, C2, D>
+struct Deferred<K, T, R, S1, S2, C1, C2, D>
 where
     T: Timestamp+Lattice+Ord+Debug,
     R: Semigroup,
-    C1: Cursor<Key=K, Time=T>,
-    C2: Cursor<Key=K, Time=T>,
+    C1: Cursor<S1, Key=K, Time=T>,
+    C2: Cursor<S2, Key=K, Time=T>,
     C1::Val: Ord+Clone,
     C2::Val: Ord+Clone,
     C1::R: Semigroup,
@@ -647,19 +647,19 @@ where
 {
     phant: ::std::marker::PhantomData<K>,
     trace: C1,
-    trace_storage: C1::Storage,
+    trace_storage: S1,
     batch: C2,
-    batch_storage: C2::Storage,
+    batch_storage: S2,
     capability: Capability<T>,
     done: bool,
     temp: Vec<((D, T), R)>,
 }
 
-impl<K, T, R, C1, C2, D> Deferred<K, T, R, C1, C2, D>
+impl<K, T, R, S1, S2, C1, C2, D> Deferred<K, T, R, S1, S2, C1, C2, D>
 where
     K: Ord+Debug+Eq,
-    C1: Cursor<Key=K, Time=T>,
-    C2: Cursor<Key=K, Time=T>,
+    C1: Cursor<S1, Key=K, Time=T>,
+    C2: Cursor<S2, Key=K, Time=T>,
     C1::Val: Ord+Clone+Debug,
     C2::Val: Ord+Clone+Debug,
     C1::R: Semigroup,
@@ -668,7 +668,7 @@ where
     R: Semigroup,
     D: Clone+Data,
 {
-    fn new(trace: C1, trace_storage: C1::Storage, batch: C2, batch_storage: C2::Storage, capability: Capability<T>) -> Self {
+    fn new(trace: C1, trace_storage: S1, batch: C2, batch_storage: S2, capability: Capability<T>) -> Self {
         Deferred {
             phant: ::std::marker::PhantomData,
             trace,

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -38,8 +38,8 @@ impl<'a, V:'a, T, R> EditList<'a, V, T, R> where T: Ord+Clone, R: Semigroup {
         }
     }
     /// Loads the contents of a cursor.
-    fn load<C, L>(&mut self, cursor: &mut C, storage: &'a C::Storage, logic: L)
-    where V: Clone, C: Cursor<Val=V, Time=T, R=R>, C::Key: Eq, L: Fn(&T)->T {
+    fn load<S, C, L>(&mut self, cursor: &mut C, storage: &'a S, logic: L)
+    where V: Clone, C: Cursor<S, Val=V, Time=T, R=R>, C::Key: Eq, L: Fn(&T)->T {
         self.clear();
         while cursor.val_valid(storage) {
             cursor.map_times(storage, |time1, diff1| self.push(logic(time1), diff1.clone()));
@@ -101,22 +101,22 @@ impl<'storage, V: Ord+Clone+'storage, T: Lattice+Ord+Clone, R: Semigroup> ValueH
         self.history.clear();
         self.buffer.clear();
     }
-    fn load<C, L>(&mut self, cursor: &mut C, storage: &'storage C::Storage, logic: L)
-    where C: Cursor<Val=V, Time=T, R=R>, C::Key: Eq, L: Fn(&T)->T {
+    fn load<S, C, L>(&mut self, cursor: &mut C, storage: &'storage S, logic: L)
+    where C: Cursor<S, Val=V, Time=T, R=R>, C::Key: Eq, L: Fn(&T)->T {
         self.edits.load(cursor, storage, logic);
     }
 
     /// Loads and replays a specified key.
     ///
     /// If the key is absent, the replayed history will be empty.
-    fn replay_key<'history, C, L>(
+    fn replay_key<'history, S, C, L>(
         &'history mut self,
         cursor: &mut C,
-        storage: &'storage C::Storage,
+        storage: &'storage S,
         key: &C::Key,
         logic: L
     ) -> HistoryReplay<'storage, 'history, V, T, R>
-    where C: Cursor<Val=V, Time=T, R=R>, C::Key: Eq, L: Fn(&T)->T
+    where C: Cursor<S, Val=V, Time=T, R=R>, C::Key: Eq, L: Fn(&T)->T
     {
         self.clear();
         cursor.seek_key(storage, key);

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -276,6 +276,7 @@ pub trait ReduceCore<G: Scope, K: Data, V: Data, R: Semigroup> where G::Timestam
             T2::Val: Data,
             T2::R: Abelian,
             T2::Batch: Batch,
+            <T2::Batch as Batch>::Builder: Builder<T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val, T2::R)>)+'static,
         {
             self.reduce_core::<_,T2>(name, move |key, input, output, change| {
@@ -298,6 +299,7 @@ pub trait ReduceCore<G: Scope, K: Data, V: Data, R: Semigroup> where G::Timestam
             T2::Val: Data,
             T2::R: Semigroup,
             T2::Batch: Batch,
+            <T2::Batch as Batch>::Builder: Builder<T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val,T2::R)>, &mut Vec<(T2::Val,T2::R)>)+'static
             ;
 }
@@ -316,6 +318,7 @@ where
             T2::R: Semigroup,
             T2: Trace+TraceReader<Key=K, Time=G::Timestamp>+'static,
             T2::Batch: Batch,
+            <T2::Batch as Batch>::Builder: Builder<T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val,T2::R)>, &mut Vec<(T2::Val, T2::R)>)+'static
     {
         self.arrange_by_key_named(&format!("Arrange: {}", name))
@@ -334,6 +337,7 @@ where
             T2::Val: Data,
             T2::R: Semigroup,
             T2::Batch: Batch,
+            <T2::Batch as Batch>::Builder: Builder<T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val,T2::R)>, &mut Vec<(T2::Val, T2::R)>)+'static {
 
         let mut result_trace = None;
@@ -548,7 +552,7 @@ where
                                 for index in 0 .. buffers.len() {
                                     buffers[index].1.sort_by(|x,y| x.0.cmp(&y.0));
                                     for (val, time, diff) in buffers[index].1.drain(..) {
-                                        builders[index].push((key.clone(), val, time, diff));
+                                        builders[index].push(((key.clone(), val), time, diff));
                                     }
                                 }
                             }

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -276,7 +276,7 @@ pub trait ReduceCore<G: Scope, K: Data, V: Data, R: Semigroup> where G::Timestam
             T2::Val: Data,
             T2::R: Abelian,
             T2::Batch: Batch,
-            <T2::Batch as Batch>::Builder: Builder<Output=T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
+            T2::Builder: Builder<Output=T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val, T2::R)>)+'static,
         {
             self.reduce_core::<_,T2>(name, move |key, input, output, change| {
@@ -299,7 +299,7 @@ pub trait ReduceCore<G: Scope, K: Data, V: Data, R: Semigroup> where G::Timestam
             T2::Val: Data,
             T2::R: Semigroup,
             T2::Batch: Batch,
-            <T2::Batch as Batch>::Builder: Builder<Output=T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
+            T2::Builder: Builder<Output=T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val,T2::R)>, &mut Vec<(T2::Val,T2::R)>)+'static
             ;
 }
@@ -318,7 +318,7 @@ where
             T2::R: Semigroup,
             T2: Trace+TraceReader<Key=K, Time=G::Timestamp>+'static,
             T2::Batch: Batch,
-            <T2::Batch as Batch>::Builder: Builder<Output=T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
+            T2::Builder: Builder<Output=T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val,T2::R)>, &mut Vec<(T2::Val, T2::R)>)+'static
     {
         self.arrange_by_key_named(&format!("Arrange: {}", name))
@@ -337,7 +337,7 @@ where
             T2::Val: Data,
             T2::R: Semigroup,
             T2::Batch: Batch,
-            <T2::Batch as Batch>::Builder: Builder<Output=T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
+            T2::Builder: Builder<Output=T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val,T2::R)>, &mut Vec<(T2::Val, T2::R)>)+'static {
 
         let mut result_trace = None;
@@ -476,7 +476,7 @@ where
                             let mut builders = Vec::new();
                             for i in 0 .. capabilities.len() {
                                 buffers.push((capabilities[i].time().clone(), Vec::new()));
-                                builders.push(<T2::Batch as Batch>::Builder::new());
+                                builders.push(T2::Builder::new());
                             }
 
                             // cursors for navigating input and output traces.

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -276,7 +276,7 @@ pub trait ReduceCore<G: Scope, K: Data, V: Data, R: Semigroup> where G::Timestam
             T2::Val: Data,
             T2::R: Abelian,
             T2::Batch: Batch,
-            <T2::Batch as Batch>::Builder: Builder<T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
+            <T2::Batch as Batch>::Builder: Builder<Output=T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val, T2::R)>)+'static,
         {
             self.reduce_core::<_,T2>(name, move |key, input, output, change| {
@@ -299,7 +299,7 @@ pub trait ReduceCore<G: Scope, K: Data, V: Data, R: Semigroup> where G::Timestam
             T2::Val: Data,
             T2::R: Semigroup,
             T2::Batch: Batch,
-            <T2::Batch as Batch>::Builder: Builder<T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
+            <T2::Batch as Batch>::Builder: Builder<Output=T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val,T2::R)>, &mut Vec<(T2::Val,T2::R)>)+'static
             ;
 }
@@ -318,7 +318,7 @@ where
             T2::R: Semigroup,
             T2: Trace+TraceReader<Key=K, Time=G::Timestamp>+'static,
             T2::Batch: Batch,
-            <T2::Batch as Batch>::Builder: Builder<T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
+            <T2::Batch as Batch>::Builder: Builder<Output=T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val,T2::R)>, &mut Vec<(T2::Val, T2::R)>)+'static
     {
         self.arrange_by_key_named(&format!("Arrange: {}", name))
@@ -337,7 +337,7 @@ where
             T2::Val: Data,
             T2::R: Semigroup,
             T2::Batch: Batch,
-            <T2::Batch as Batch>::Builder: Builder<T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
+            <T2::Batch as Batch>::Builder: Builder<Output=T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::R)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val,T2::R)>, &mut Vec<(T2::Val, T2::R)>)+'static {
 
         let mut result_trace = None;

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -651,12 +651,12 @@ where
     R2: Semigroup,
 {
     fn new() -> Self;
-    fn compute<K, C1, C2, C3, L>(
+    fn compute<K, S1, S2, S3, C1, C2, C3, L>(
         &mut self,
         key: &K,
-        source_cursor: (&mut C1, &'a C1::Storage),
-        output_cursor: (&mut C2, &'a C2::Storage),
-        batch_cursor: (&mut C3, &'a C3::Storage),
+        source_cursor: (&mut C1, &'a S1),
+        output_cursor: (&mut C2, &'a S2),
+        batch_cursor: (&mut C3, &'a S3),
         times: &mut Vec<T>,
         logic: &mut L,
         upper_limit: &Antichain<T>,
@@ -664,9 +664,9 @@ where
         new_interesting: &mut Vec<T>) -> (usize, usize)
     where
         K: Eq+Clone,
-        C1: Cursor<Key = K, Val = V1, Time = T, R = R1>,
-        C2: Cursor<Key = K, Val = V2, Time = T, R = R2>,
-        C3: Cursor<Key = K, Val = V1, Time = T, R = R1>,
+        C1: Cursor<S1, Key = K, Val = V1, Time = T, R = R1>,
+        C2: Cursor<S2, Key = K, Val = V2, Time = T, R = R2>,
+        C3: Cursor<S3, Key = K, Val = V1, Time = T, R = R1>,
         L: FnMut(&K, &[(&V1, R1)], &mut Vec<(V2, R2)>, &mut Vec<(V2, R2)>);
 }
 
@@ -729,12 +729,12 @@ mod history_replay {
             }
         }
         #[inline(never)]
-        fn compute<K, C1, C2, C3, L>(
+        fn compute<K, S1, S2, S3, C1, C2, C3, L>(
             &mut self,
             key: &K,
-            (source_cursor, source_storage): (&mut C1, &'a C1::Storage),
-            (output_cursor, output_storage): (&mut C2, &'a C2::Storage),
-            (batch_cursor, batch_storage): (&mut C3, &'a C3::Storage),
+            (source_cursor, source_storage): (&mut C1, &'a S1),
+            (output_cursor, output_storage): (&mut C2, &'a S2),
+            (batch_cursor, batch_storage): (&mut C3, &'a S3),
             times: &mut Vec<T>,
             logic: &mut L,
             upper_limit: &Antichain<T>,
@@ -742,9 +742,9 @@ mod history_replay {
             new_interesting: &mut Vec<T>) -> (usize, usize)
         where
             K: Eq+Clone,
-            C1: Cursor<Key = K, Val = V1, Time = T, R = R1>,
-            C2: Cursor<Key = K, Val = V2, Time = T, R = R2>,
-            C3: Cursor<Key = K, Val = V1, Time = T, R = R1>,
+            C1: Cursor<S1, Key = K, Val = V1, Time = T, R = R1>,
+            C2: Cursor<S2, Key = K, Val = V2, Time = T, R = R2>,
+            C3: Cursor<S3, Key = K, Val = V1, Time = T, R = R1>,
             L: FnMut(&K, &[(&V1, R1)], &mut Vec<(V2, R2)>, &mut Vec<(V2, R2)>)
         {
 

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -15,13 +15,13 @@ pub use self::cursor_list::CursorList;
 pub trait Cursor<Storage: ?Sized> {
 
     /// Key by which updates are indexed.
-    type Key;
+    type Key: ?Sized;
     /// Values associated with keys.
-    type Val;
+    type Val: ?Sized;
     /// Timestamps associated with updates
-    type Time;
+    type Time: ?Sized;
     /// Associated update.
-    type R;
+    type R: ?Sized;
 
     /// Indicates if the current key is valid.
     ///

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -12,7 +12,7 @@ pub mod cursor_list;
 pub use self::cursor_list::CursorList;
 
 /// A cursor for navigating ordered `(key, val, time, diff)` updates.
-pub trait Cursor {
+pub trait Cursor<Storage: ?Sized> {
 
     /// Key by which updates are indexed.
     type Key;
@@ -23,53 +23,50 @@ pub trait Cursor {
     /// Associated update.
     type R;
 
-    /// Type the cursor addresses data in.
-    type Storage;
-
     /// Indicates if the current key is valid.
     ///
     /// A value of `false` indicates that the cursor has exhausted all keys.
-    fn key_valid(&self, storage: &Self::Storage) -> bool;
+    fn key_valid(&self, storage: &Storage) -> bool;
     /// Indicates if the current value is valid.
     ///
     /// A value of `false` indicates that the cursor has exhausted all values for this key.
-    fn val_valid(&self, storage: &Self::Storage) -> bool;
+    fn val_valid(&self, storage: &Storage) -> bool;
 
     /// A reference to the current key. Asserts if invalid.
-    fn key<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Key;
+    fn key<'a>(&self, storage: &'a Storage) -> &'a Self::Key;
     /// A reference to the current value. Asserts if invalid.
-    fn val<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Val;
+    fn val<'a>(&self, storage: &'a Storage) -> &'a Self::Val;
 
     /// Returns a reference to the current key, if valid.
-    fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<&'a Self::Key> {
+    fn get_key<'a>(&self, storage: &'a Storage) -> Option<&'a Self::Key> {
         if self.key_valid(storage) { Some(self.key(storage)) } else { None }
     }
     /// Returns a reference to the current value, if valid.
-    fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<&'a Self::Val> {
+    fn get_val<'a>(&self, storage: &'a Storage) -> Option<&'a Self::Val> {
         if self.val_valid(storage) { Some(self.val(storage)) } else { None }
     }
 
     /// Applies `logic` to each pair of time and difference. Intended for mutation of the
     /// closure's scope.
-    fn map_times<L: FnMut(&Self::Time, &Self::R)>(&mut self, storage: &Self::Storage, logic: L);
+    fn map_times<L: FnMut(&Self::Time, &Self::R)>(&mut self, storage: &Storage, logic: L);
 
     /// Advances the cursor to the next key.
-    fn step_key(&mut self, storage: &Self::Storage);
+    fn step_key(&mut self, storage: &Storage);
     /// Advances the cursor to the specified key.
-    fn seek_key(&mut self, storage: &Self::Storage, key: &Self::Key);
+    fn seek_key(&mut self, storage: &Storage, key: &Self::Key);
 
     /// Advances the cursor to the next value.
-    fn step_val(&mut self, storage: &Self::Storage);
+    fn step_val(&mut self, storage: &Storage);
     /// Advances the cursor to the specified value.
-    fn seek_val(&mut self, storage: &Self::Storage, val: &Self::Val);
+    fn seek_val(&mut self, storage: &Storage, val: &Self::Val);
 
     /// Rewinds the cursor to the first key.
-    fn rewind_keys(&mut self, storage: &Self::Storage);
+    fn rewind_keys(&mut self, storage: &Storage);
     /// Rewinds the cursor to the first value for current key.
-    fn rewind_vals(&mut self, storage: &Self::Storage);
+    fn rewind_vals(&mut self, storage: &Storage);
 
     /// Rewinds the cursor and outputs its contents to a Vec
-    fn to_vec(&mut self, storage: &Self::Storage) -> Vec<((Self::Key, Self::Val), Vec<(Self::Time, Self::R)>)>
+    fn to_vec(&mut self, storage: &Storage) -> Vec<((Self::Key, Self::Val), Vec<(Self::Time, Self::R)>)>
     where
         Self::Key: Clone,
         Self::Val: Clone,

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -26,6 +26,9 @@ where
     B::Time: Lattice+timely::progress::Timestamp+Ord+Clone,
     B::R: Semigroup,
 {
+    type Item = ((B::Key,B::Val),B::Time,B::R);
+    type Time = B::Time;
+
     fn new() -> Self {
         MergeBatcher {
             sorter: MergeSorter::new(),
@@ -36,7 +39,7 @@ where
     }
 
     #[inline(never)]
-    fn push_batch(&mut self, batch: RefOrMut<Vec<((B::Key,B::Val),B::Time,B::R)>>) {
+    fn push_batch(&mut self, batch: RefOrMut<Vec<Self::Item>>) {
         // `batch` is either a shared reference or an owned allocations.
         match batch {
             RefOrMut::Ref(reference) => {

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -25,6 +25,7 @@ where
     B::Val: Ord+Clone,
     B::Time: Lattice+timely::progress::Timestamp+Ord+Clone,
     B::R: Semigroup,
+    B::Builder: Builder<B, Item = ((B::Key, B::Val), B::Time, B::R)>,
 {
     type Item = ((B::Key,B::Val),B::Time,B::R);
     type Time = B::Time;
@@ -86,7 +87,7 @@ where
                     keep.push(((key, val), time, diff));
                 }
                 else {
-                    builder.push((key, val, time, diff));
+                    builder.push(((key, val), time, diff));
                 }
             }
             // Recycling buffer.

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -7,34 +7,26 @@ use timely::progress::frontier::Antichain;
 
 use ::difference::Semigroup;
 
-use lattice::Lattice;
-use trace::{Batch, Batcher, Builder};
+use trace::{Batcher, Builder};
+use trace::implementations::Update;
 
 /// Creates batches from unordered tuples.
-pub struct MergeBatcher<B: Batch> where B::Key: Ord, B::Val: Ord, B::Time: Ord, B::R: Semigroup {
-    sorter: MergeSorter<(B::Key, B::Val), B::Time, B::R>,
-    lower: Antichain<B::Time>,
-    frontier: Antichain<B::Time>,
-    phantom: ::std::marker::PhantomData<B>,
+pub struct MergeBatcher<U: Update> {
+    sorter: MergeSorter<(U::Key, U::Val), U::Time, U::Diff>,
+    lower: Antichain<U::Time>,
+    frontier: Antichain<U::Time>,
+    phantom: ::std::marker::PhantomData<U>,
 }
 
-impl<B> Batcher<B> for MergeBatcher<B>
-where
-    B: Batch,
-    B::Key: Ord+Clone,
-    B::Val: Ord+Clone,
-    B::Time: Lattice+timely::progress::Timestamp+Ord+Clone,
-    B::R: Semigroup,
-    B::Builder: Builder<B, Item = ((B::Key, B::Val), B::Time, B::R)>,
-{
-    type Item = ((B::Key,B::Val),B::Time,B::R);
-    type Time = B::Time;
+impl<U: Update> Batcher for MergeBatcher<U> {
+    type Item = ((U::Key,U::Val),U::Time,U::Diff);
+    type Time = U::Time;
 
     fn new() -> Self {
         MergeBatcher {
             sorter: MergeSorter::new(),
             frontier: Antichain::new(),
-            lower: Antichain::from_elem(<B::Time as timely::progress::Timestamp>::minimum()),
+            lower: Antichain::from_elem(<U::Time as timely::progress::Timestamp>::minimum()),
             phantom: ::std::marker::PhantomData,
         }
     }
@@ -61,9 +53,9 @@ where
     // which we call `lower`, by assumption that after sealing a batcher we receive no more
     // updates with times not greater or equal to `upper`.
     #[inline(never)]
-    fn seal(&mut self, upper: Antichain<B::Time>) -> B {
+    fn seal<B: Builder<Item=Self::Item, Time=Self::Time>>(&mut self, upper: Antichain<U::Time>) -> B::Output {
 
-        let mut builder = B::Builder::new();
+        let mut builder = B::new();
 
         let mut merged = Vec::new();
         self.sorter.finish_into(&mut merged);
@@ -109,18 +101,18 @@ where
         let mut buffer = Vec::new();
         self.sorter.push(&mut buffer);
         // We recycle buffers with allocations (capacity, and not zero-sized).
-        while buffer.capacity() > 0 && std::mem::size_of::<((B::Key,B::Val),B::Time,B::R)>() > 0 {
+        while buffer.capacity() > 0 && std::mem::size_of::<((U::Key,U::Val),U::Time,U::Diff)>() > 0 {
             buffer = Vec::new();
             self.sorter.push(&mut buffer);
         }
 
-        let seal = builder.done(self.lower.clone(), upper.clone(), Antichain::from_elem(<B::Time as timely::progress::Timestamp>::minimum()));
+        let seal = builder.done(self.lower.clone(), upper.clone(), Antichain::from_elem(<U::Time as timely::progress::Timestamp>::minimum()));
         self.lower = upper;
         seal
     }
 
     // the frontier of elements remaining after the most recent call to `self.seal`.
-    fn frontier(&mut self) -> timely::progress::frontier::AntichainRef<B::Time> {
+    fn frontier(&mut self) -> timely::progress::frontier::AntichainRef<U::Time> {
         self.frontier.borrow()
     }
 }

--- a/src/trace/implementations/merge_batcher_col.rs
+++ b/src/trace/implementations/merge_batcher_col.rs
@@ -32,6 +32,9 @@ impl<B: Batch> Batcher<B> for ColumnatedMergeBatcher<B>
         B::Time: Lattice+timely::progress::Timestamp+Ord+Clone+Columnation+'static,
         B::R: Semigroup+Columnation+'static,
 {
+    type Item = ((B::Key,B::Val),B::Time,B::R);
+    type Time = B::Time;
+
     fn new() -> Self {
         ColumnatedMergeBatcher {
             sorter: MergeSorterColumnation::new(),
@@ -42,7 +45,7 @@ impl<B: Batch> Batcher<B> for ColumnatedMergeBatcher<B>
     }
 
     #[inline]
-    fn push_batch(&mut self, batch: RefOrMut<Vec<((B::Key, B::Val), B::Time, B::R)>>) {
+    fn push_batch(&mut self, batch: RefOrMut<Vec<Self::Item>>) {
         // `batch` is either a shared reference or an owned allocations.
         match batch {
             RefOrMut::Ref(reference) => {

--- a/src/trace/implementations/merge_batcher_col.rs
+++ b/src/trace/implementations/merge_batcher_col.rs
@@ -8,39 +8,38 @@ use timely::progress::frontier::Antichain;
 
 use ::difference::Semigroup;
 
-use lattice::Lattice;
-use trace::{Batch, Batcher, Builder};
+use trace::{Batcher, Builder};
+use trace::implementations::Update;
 
 /// Creates batches from unordered tuples.
-pub struct ColumnatedMergeBatcher<B: Batch>
-    where
-        B::Key: Ord+Clone+Columnation,
-        B::Val: Ord+Clone+Columnation,
-        B::Time: Lattice+timely::progress::Timestamp+Ord+Clone+Columnation,
-        B::R: Semigroup+Columnation,
+pub struct ColumnatedMergeBatcher<U: Update>
+where
+    U::Key: Columnation,
+    U::Val: Columnation,
+    U::Time: Columnation,
+    U::Diff: Columnation,
 {
-    sorter: MergeSorterColumnation<(B::Key, B::Val), B::Time, B::R>,
-    lower: Antichain<B::Time>,
-    frontier: Antichain<B::Time>,
-    phantom: PhantomData<B>,
+    sorter: MergeSorterColumnation<(U::Key, U::Val), U::Time, U::Diff>,
+    lower: Antichain<U::Time>,
+    frontier: Antichain<U::Time>,
+    phantom: PhantomData<U>,
 }
 
-impl<B: Batch> Batcher<B> for ColumnatedMergeBatcher<B>
-    where
-        B::Key: Ord+Clone+Columnation+'static,
-        B::Val: Ord+Clone+Columnation+'static,
-        B::Time: Lattice+timely::progress::Timestamp+Ord+Clone+Columnation+'static,
-        B::R: Semigroup+Columnation+'static,
-        B::Builder: Builder<B, Item = ((B::Key, B::Val), B::Time, B::R)>,
+impl<U: Update> Batcher for ColumnatedMergeBatcher<U>
+where
+    U::Key: Columnation + 'static,
+    U::Val: Columnation + 'static,
+    U::Time: Columnation + 'static,
+    U::Diff: Columnation + 'static,
 {
-    type Item = ((B::Key,B::Val),B::Time,B::R);
-    type Time = B::Time;
+    type Item = ((U::Key,U::Val),U::Time,U::Diff);
+    type Time = U::Time;
 
     fn new() -> Self {
         ColumnatedMergeBatcher {
             sorter: MergeSorterColumnation::new(),
             frontier: Antichain::new(),
-            lower: Antichain::from_elem(<B::Time as timely::progress::Timestamp>::minimum()),
+            lower: Antichain::from_elem(<U::Time as timely::progress::Timestamp>::minimum()),
             phantom: PhantomData,
         }
     }
@@ -65,9 +64,9 @@ impl<B: Batch> Batcher<B> for ColumnatedMergeBatcher<B>
     // which we call `lower`, by assumption that after sealing a batcher we receive no more
     // updates with times not greater or equal to `upper`.
     #[inline]
-    fn seal(&mut self, upper: Antichain<B::Time>) -> B {
+    fn seal<B: Builder<Item=Self::Item, Time=Self::Time>>(&mut self, upper: Antichain<U::Time>) -> B::Output {
 
-        let mut builder = B::Builder::new();
+        let mut builder = B::new();
 
         let mut merged = Default::default();
         self.sorter.finish_into(&mut merged);
@@ -106,13 +105,13 @@ impl<B: Batch> Batcher<B> for ColumnatedMergeBatcher<B>
         // Drain buffers (fast reclamation).
         self.sorter.clear_stash();
 
-        let seal = builder.done(self.lower.clone(), upper.clone(), Antichain::from_elem(<B::Time as timely::progress::Timestamp>::minimum()));
+        let seal = builder.done(self.lower.clone(), upper.clone(), Antichain::from_elem(<U::Time as timely::progress::Timestamp>::minimum()));
         self.lower = upper;
         seal
     }
 
     // the frontier of elements remaining after the most recent call to `self.seal`.
-    fn frontier(&mut self) -> timely::progress::frontier::AntichainRef<B::Time> {
+    fn frontier(&mut self) -> timely::progress::frontier::AntichainRef<U::Time> {
         self.frontier.borrow()
     }
 }

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -10,11 +10,8 @@
 
 use std::rc::Rc;
 use std::convert::{TryFrom, TryInto};
-use std::marker::PhantomData;
 use std::fmt::Debug;
 
-use timely::container::columnation::TimelyStack;
-use timely::container::columnation::Columnation;
 use timely::progress::{Antichain, frontier::AntichainRef};
 
 use lattice::Lattice;
@@ -39,35 +36,60 @@ use trace::implementations::RetainFrom;
 
 use super::{Update, Layout, Vector, TStack};
 
+use trace::rc_blanket_impls::RcBuilder;
+use trace::abomonated_blanket_impls::AbomonatedBuilder;
+
 /// A trace implementation using a spine of ordered lists.
-pub type OrdValSpine<K, V, T, R, O=usize> = Spine<Rc<OrdValBatch<Vector<((K,V),T,R), O>, Vec<((K,V),T,R)>>>>;
+pub type OrdValSpine<K, V, T, R, O=usize> = Spine<
+    Rc<OrdValBatch<Vector<((K,V),T,R), O>>>,
+    MergeBatcher<((K,V),T,R)>,
+    RcBuilder<OrdValBuilder<Vector<((K,V),T,R), O>>>,
+>;
 
 /// A trace implementation using a spine of abomonated ordered lists.
-pub type OrdValSpineAbom<K, V, T, R, O=usize> = Spine<Rc<Abomonated<OrdValBatch<Vector<((K,V),T,R), O>, Vec<((K,V),T,R)>>, Vec<u8>>>>;
+pub type OrdValSpineAbom<K, V, T, R, O=usize> = Spine<
+    Rc<Abomonated<OrdValBatch<Vector<((K,V),T,R), O>>, Vec<u8>>>,
+    MergeBatcher<((K,V),T,R)>,
+    AbomonatedBuilder<OrdValBuilder<Vector<((K,V),T,R), O>>>,
+>;
 
 /// A trace implementation for empty values using a spine of ordered lists.
-pub type OrdKeySpine<K, T, R, O=usize> = Spine<Rc<OrdKeyBatch<Vector<((K,()),T,R), O>, Vec<((K,()),T,R)>>>>;
+pub type OrdKeySpine<K, T, R, O=usize> = Spine<
+    Rc<OrdKeyBatch<Vector<((K,()),T,R), O>>>,
+    MergeBatcher<((K,()),T,R)>,
+    RcBuilder<OrdKeyBuilder<Vector<((K,()),T,R), O>>>,
+>;
 
 /// A trace implementation for empty values using a spine of abomonated ordered lists.
-pub type OrdKeySpineAbom<K, T, R, O=usize> = Spine<Rc<Abomonated<OrdKeyBatch<Vector<((K,()),T,R), O>, Vec<((K,()),T,R)>>, Vec<u8>>>>;
+pub type OrdKeySpineAbom<K, T, R, O=usize> = Spine<
+    Rc<Abomonated<OrdKeyBatch<Vector<((K,()),T,R), O>>, Vec<u8>>>,
+    MergeBatcher<((K,()),T,R)>,
+    AbomonatedBuilder<OrdKeyBuilder<Vector<((K,()),T,R), O>>>,
+>;
 
 /// A trace implementation backed by columnar storage.
-pub type ColValSpine<K, V, T, R, O=usize> = Spine<Rc<OrdValBatch<TStack<((K,V),T,R), O>, TimelyStack<((K,V),T,R)>>>>;
+pub type ColValSpine<K, V, T, R, O=usize> = Spine<
+    Rc<OrdValBatch<TStack<((K,V),T,R), O>>>,
+    ColumnatedMergeBatcher<((K,V),T,R)>,
+    RcBuilder<OrdValBuilder<TStack<((K,V),T,R), O>>>,
+>;
 /// A trace implementation backed by columnar storage.
-pub type ColKeySpine<K, T, R, O=usize> = Spine<Rc<OrdKeyBatch<TStack<((K,()),T,R), O>, TimelyStack<((K,()),T,R)>>>>;
+pub type ColKeySpine<K, T, R, O=usize> = Spine<
+    Rc<OrdKeyBatch<TStack<((K,()),T,R), O>>>,
+    ColumnatedMergeBatcher<((K,()),T,R)>,
+    RcBuilder<OrdKeyBuilder<TStack<((K,()),T,R), O>>>,
+>;
 
 /// An immutable collection of update tuples, from a contiguous interval of logical times.
 ///
 /// The `L` parameter captures the updates should be laid out, and `C` determines which
 /// merge batcher to select.
 #[derive(Abomonation)]
-pub struct OrdValBatch<L: Layout, C> {
+pub struct OrdValBatch<L: Layout> {
     /// Where all the dataz is.
     pub layer: KVTDLayer<L>,
     /// Description of the update times this layer represents.
     pub desc: Description<<L::Target as Update>::Time>,
-    /// Phantom data
-    pub phantom: PhantomData<C>,
 }
 
 // Type aliases to make certain types readable.
@@ -80,22 +102,20 @@ type VTDBuilder<L> = OrderedBuilder<<<L as Layout>::Target as Update>::Val, TDBu
 type KTDBuilder<L> = OrderedBuilder<<<L as Layout>::Target as Update>::Key, TDBuilder<L>, <L as Layout>::KeyOffset, <L as Layout>::KeyContainer>;
 type KVTDBuilder<L> = OrderedBuilder<<<L as Layout>::Target as Update>::Key, VTDBuilder<L>, <L as Layout>::KeyOffset, <L as Layout>::KeyContainer>;
 
-impl<L: Layout, C> BatchReader for OrdValBatch<L, C> {
+impl<L: Layout> BatchReader for OrdValBatch<L> {
     type Key = <L::Target as Update>::Key;
     type Val = <L::Target as Update>::Val;
     type Time = <L::Target as Update>::Time;
     type R = <L::Target as Update>::Diff;
 
-    type Cursor = OrdValCursor<L, C>;
+    type Cursor = OrdValCursor<L>;
     fn cursor(&self) -> Self::Cursor { OrdValCursor { cursor: self.layer.cursor(), phantom: std::marker::PhantomData } }
     fn len(&self) -> usize { <KVTDLayer<L> as Trie>::tuples(&self.layer) }
     fn description(&self) -> &Description<<L::Target as Update>::Time> { &self.desc }
 }
 
-impl<L: Layout> Batch for OrdValBatch<L, Vec<L::Target>>
+impl<L: Layout> Batch for OrdValBatch<L>
 {
-    type Batcher = MergeBatcher<L::Target>;
-    type Builder = OrdValBuilder<L, Vec<L::Target>>;
     type Merger = OrdValMerger<L>;
 
     fn begin_merge(&self, other: &Self, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self::Merger {
@@ -103,24 +123,8 @@ impl<L: Layout> Batch for OrdValBatch<L, Vec<L::Target>>
     }
 }
 
-impl<L: Layout> Batch for OrdValBatch<L, TimelyStack<L::Target>>
-where
-    <L as Layout>::Target: Columnation,
-    Self::Key: Columnation + 'static,
-    Self::Val: Columnation + 'static,
-    Self::Time: Columnation + 'static,
-    Self::R: Columnation + 'static,
-{
-    type Batcher = ColumnatedMergeBatcher<L::Target>;
-    type Builder = OrdValBuilder<L, TimelyStack<L::Target>>;
-    type Merger = OrdValMerger<L>;
 
-    fn begin_merge(&self, other: &Self, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self::Merger {
-        OrdValMerger::new(self, other, compaction_frontier)
-    }
-}
-
-impl<L: Layout, C> OrdValBatch<L, C> {
+impl<L: Layout> OrdValBatch<L> {
     fn advance_builder_from(layer: &mut KVTDBuilder<L>, frontier: AntichainRef<<L::Target as Update>::Time>, key_pos: usize) {
 
         let key_start = key_pos;
@@ -222,11 +226,11 @@ pub struct OrdValMerger<L: Layout> {
     description: Description<<L::Target as Update>::Time>,
 }
 
-impl<L: Layout, C> Merger<OrdValBatch<L, C>> for OrdValMerger<L>
+impl<L: Layout> Merger<OrdValBatch<L>> for OrdValMerger<L>
 where
-    OrdValBatch<L, C>: Batch<Time=<L::Target as Update>::Time>
+    OrdValBatch<L>: Batch<Time=<L::Target as Update>::Time>
 {
-    fn new(batch1: &OrdValBatch<L, C>, batch2: &OrdValBatch<L, C>, compaction_frontier: AntichainRef<<OrdValBatch<L, C> as BatchReader>::Time>) -> Self {
+    fn new(batch1: &OrdValBatch<L>, batch2: &OrdValBatch<L>, compaction_frontier: AntichainRef<<OrdValBatch<L> as BatchReader>::Time>) -> Self {
 
         assert!(batch1.upper() == batch2.lower());
 
@@ -244,7 +248,7 @@ where
             description: description,
         }
     }
-    fn done(self) -> OrdValBatch<L, C> {
+    fn done(self) -> OrdValBatch<L> {
 
         assert!(self.lower1 == self.upper1);
         assert!(self.lower2 == self.upper2);
@@ -252,10 +256,9 @@ where
         OrdValBatch {
             layer: self.result.done(),
             desc: self.description,
-            phantom: PhantomData,
         }
     }
-    fn work(&mut self, source1: &OrdValBatch<L, C>, source2: &OrdValBatch<L, C>, fuel: &mut isize) {
+    fn work(&mut self, source1: &OrdValBatch<L>, source2: &OrdValBatch<L>, fuel: &mut isize) {
 
         let starting_updates = self.result.vals.vals.vals.len();
         let mut effort = 0isize;
@@ -293,7 +296,7 @@ where
         effort = (self.result.vals.vals.vals.len() - starting_updates) as isize;
 
         // if we are supplied a frontier, we should compact.
-        OrdValBatch::<L, C>::advance_builder_from(&mut self.result, self.description.since().borrow(), initial_key_pos);
+        OrdValBatch::<L>::advance_builder_from(&mut self.result, self.description.since().borrow(), initial_key_pos);
 
         *fuel -= effort;
 
@@ -304,63 +307,60 @@ where
 }
 
 /// A cursor for navigating a single layer.
-pub struct OrdValCursor<L: Layout, C> {
-    phantom: std::marker::PhantomData<(L, C)>,
+pub struct OrdValCursor<L: Layout> {
+    phantom: std::marker::PhantomData<L>,
     cursor: OrderedCursor<VTDLayer<L>>,
 }
 
-impl<L: Layout, C> Cursor<OrdValBatch<L, C>> for OrdValCursor<L, C> {
+impl<L: Layout> Cursor<OrdValBatch<L>> for OrdValCursor<L> {
     type Key = <L::Target as Update>::Key;
     type Val = <L::Target as Update>::Val;
     type Time = <L::Target as Update>::Time;
     type R = <L::Target as Update>::Diff;
 
-    // type Storage = OrdValBatch<L, C>;
+    // type Storage = OrdValBatch<L>;
 
-    fn key<'a>(&self, storage: &'a OrdValBatch<L, C>) -> &'a Self::Key { &self.cursor.key(&storage.layer) }
-    fn val<'a>(&self, storage: &'a OrdValBatch<L, C>) -> &'a Self::Val { &self.cursor.child.key(&storage.layer.vals) }
-    fn map_times<L2: FnMut(&Self::Time, &Self::R)>(&mut self, storage: &OrdValBatch<L, C>, mut logic: L2) {
+    fn key<'a>(&self, storage: &'a OrdValBatch<L>) -> &'a Self::Key { &self.cursor.key(&storage.layer) }
+    fn val<'a>(&self, storage: &'a OrdValBatch<L>) -> &'a Self::Val { &self.cursor.child.key(&storage.layer.vals) }
+    fn map_times<L2: FnMut(&Self::Time, &Self::R)>(&mut self, storage: &OrdValBatch<L>, mut logic: L2) {
         self.cursor.child.child.rewind(&storage.layer.vals.vals);
         while self.cursor.child.child.valid(&storage.layer.vals.vals) {
             logic(&self.cursor.child.child.key(&storage.layer.vals.vals).0, &self.cursor.child.child.key(&storage.layer.vals.vals).1);
             self.cursor.child.child.step(&storage.layer.vals.vals);
         }
     }
-    fn key_valid(&self, storage: &OrdValBatch<L, C>) -> bool { self.cursor.valid(&storage.layer) }
-    fn val_valid(&self, storage: &OrdValBatch<L, C>) -> bool { self.cursor.child.valid(&storage.layer.vals) }
-    fn step_key(&mut self, storage: &OrdValBatch<L, C>){ self.cursor.step(&storage.layer); }
-    fn seek_key(&mut self, storage: &OrdValBatch<L, C>, key: &Self::Key) { self.cursor.seek(&storage.layer, key); }
-    fn step_val(&mut self, storage: &OrdValBatch<L, C>) { self.cursor.child.step(&storage.layer.vals); }
-    fn seek_val(&mut self, storage: &OrdValBatch<L, C>, val: &Self::Val) { self.cursor.child.seek(&storage.layer.vals, val); }
-    fn rewind_keys(&mut self, storage: &OrdValBatch<L, C>) { self.cursor.rewind(&storage.layer); }
-    fn rewind_vals(&mut self, storage: &OrdValBatch<L, C>) { self.cursor.child.rewind(&storage.layer.vals); }
+    fn key_valid(&self, storage: &OrdValBatch<L>) -> bool { self.cursor.valid(&storage.layer) }
+    fn val_valid(&self, storage: &OrdValBatch<L>) -> bool { self.cursor.child.valid(&storage.layer.vals) }
+    fn step_key(&mut self, storage: &OrdValBatch<L>){ self.cursor.step(&storage.layer); }
+    fn seek_key(&mut self, storage: &OrdValBatch<L>, key: &Self::Key) { self.cursor.seek(&storage.layer, key); }
+    fn step_val(&mut self, storage: &OrdValBatch<L>) { self.cursor.child.step(&storage.layer.vals); }
+    fn seek_val(&mut self, storage: &OrdValBatch<L>, val: &Self::Val) { self.cursor.child.seek(&storage.layer.vals, val); }
+    fn rewind_keys(&mut self, storage: &OrdValBatch<L>) { self.cursor.rewind(&storage.layer); }
+    fn rewind_vals(&mut self, storage: &OrdValBatch<L>) { self.cursor.child.rewind(&storage.layer.vals); }
 }
 
 /// A builder for creating layers from unsorted update tuples.
-pub struct OrdValBuilder<L: Layout, C> {
+pub struct OrdValBuilder<L: Layout> {
     builder: KVTDBuilder<L>,
-    phantom: PhantomData<C>,
 }
 
 
-impl<L: Layout, C> Builder for OrdValBuilder<L, C>
+impl<L: Layout> Builder for OrdValBuilder<L>
 where
-    OrdValBatch<L, C>: Batch<Key=<L::Target as Update>::Key, Val=<L::Target as Update>::Val, Time=<L::Target as Update>::Time, R=<L::Target as Update>::Diff>
+    OrdValBatch<L>: Batch<Key=<L::Target as Update>::Key, Val=<L::Target as Update>::Val, Time=<L::Target as Update>::Time, R=<L::Target as Update>::Diff>
 {
     type Item = ((<L::Target as Update>::Key, <L::Target as Update>::Val), <L::Target as Update>::Time, <L::Target as Update>::Diff);
     type Time = <L::Target as Update>::Time;
-    type Output = OrdValBatch<L, C>;
+    type Output = OrdValBatch<L>;
 
     fn new() -> Self {
         OrdValBuilder {
             builder: <KVTDBuilder<L>>::new(),
-            phantom: std::marker::PhantomData,
         }
     }
     fn with_capacity(cap: usize) -> Self {
         OrdValBuilder {
             builder: <KVTDBuilder<L> as TupleBuilder>::with_capacity(cap),
-            phantom: std::marker::PhantomData,
         }
     }
 
@@ -374,11 +374,10 @@ where
     }
 
     #[inline(never)]
-    fn done(self, lower: Antichain<Self::Time>, upper: Antichain<Self::Time>, since: Antichain<Self::Time>) -> OrdValBatch<L, C> {
+    fn done(self, lower: Antichain<Self::Time>, upper: Antichain<Self::Time>, since: Antichain<Self::Time>) -> OrdValBatch<L> {
         OrdValBatch {
             layer: self.builder.done(),
             desc: Description::new(lower, upper, since),
-            phantom: PhantomData,
         }
     }
 }
@@ -388,36 +387,31 @@ where
 
 /// An immutable collection of update tuples, from a contiguous interval of logical times.
 #[derive(Abomonation)]
-pub struct OrdKeyBatch<L: Layout, C> {
+pub struct OrdKeyBatch<L: Layout> {
     /// Where all the dataz is.
     pub layer: KTDLayer<L>,
     /// Description of the update times this layer represents.
     pub desc: Description<<L::Target as Update>::Time>,
-    /// Phantom data
-    pub phantom: PhantomData<C>,
 }
 
-impl<L: Layout, C> BatchReader for OrdKeyBatch<L, C> {
+impl<L: Layout> BatchReader for OrdKeyBatch<L> {
     type Key = <L::Target as Update>::Key;
     type Val = ();
     type Time = <L::Target as Update>::Time;
     type R = <L::Target as Update>::Diff;
 
-    type Cursor = OrdKeyCursor<L, C>;
+    type Cursor = OrdKeyCursor<L>;
     fn cursor(&self) -> Self::Cursor {
         OrdKeyCursor {
             valid: true,
             cursor: self.layer.cursor(),
-            phantom: PhantomData
         }
     }
     fn len(&self) -> usize { <KTDLayer<L> as Trie>::tuples(&self.layer) }
     fn description(&self) -> &Description<<L::Target as Update>::Time> { &self.desc }
 }
 
-impl<L: Layout> Batch for OrdKeyBatch<L, Vec<L::Target>> where L::Target: Update<Val = ()> {
-    type Batcher = MergeBatcher<L::Target>;
-    type Builder = OrdKeyBuilder<L, Vec<L::Target>>;
+impl<L: Layout> Batch for OrdKeyBatch<L> where L::Target: Update<Val = ()> {
     type Merger = OrdKeyMerger<L>;
 
     fn begin_merge(&self, other: &Self, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self::Merger {
@@ -425,23 +419,7 @@ impl<L: Layout> Batch for OrdKeyBatch<L, Vec<L::Target>> where L::Target: Update
     }
 }
 
-impl<L: Layout> Batch for OrdKeyBatch<L, TimelyStack<L::Target>>
-where
-    <L as Layout>::Target: Update<Val = ()> + Columnation + 'static,
-    Self::Key: Columnation + 'static,
-    Self::Time: Columnation + 'static,
-    Self::R: Columnation + 'static,
-{
-    type Batcher = ColumnatedMergeBatcher<L::Target>;
-    type Builder = OrdKeyBuilder<L, TimelyStack<L::Target>>;
-    type Merger = OrdKeyMerger<L>;
-
-    fn begin_merge(&self, other: &Self, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self::Merger {
-        OrdKeyMerger::new(self, other, compaction_frontier)
-    }
-}
-
-impl<L: Layout, C> OrdKeyBatch<L, C> {
+impl<L: Layout> OrdKeyBatch<L> {
     fn advance_builder_from(layer: &mut KTDBuilder<L>, frontier: AntichainRef<<L::Target as Update>::Time>, key_pos: usize) {
 
         let key_start = key_pos;
@@ -517,11 +495,11 @@ pub struct OrdKeyMerger<L: Layout> {
     description: Description<<L::Target as Update>::Time>,
 }
 
-impl<L: Layout, C> Merger<OrdKeyBatch<L, C>> for OrdKeyMerger<L>
+impl<L: Layout> Merger<OrdKeyBatch<L>> for OrdKeyMerger<L>
 where
-    OrdKeyBatch<L, C>: Batch<Time=<L::Target as Update>::Time>
+    OrdKeyBatch<L>: Batch<Time=<L::Target as Update>::Time>
 {
-    fn new(batch1: &OrdKeyBatch<L, C>, batch2: &OrdKeyBatch<L, C>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
+    fn new(batch1: &OrdKeyBatch<L>, batch2: &OrdKeyBatch<L>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
 
         assert!(batch1.upper() == batch2.lower());
 
@@ -539,7 +517,7 @@ where
             description: description,
         }
     }
-    fn done(self) -> OrdKeyBatch<L, C> {
+    fn done(self) -> OrdKeyBatch<L> {
 
         assert!(self.lower1 == self.upper1);
         assert!(self.lower2 == self.upper2);
@@ -547,10 +525,9 @@ where
         OrdKeyBatch {
             layer: self.result.done(),
             desc: self.description,
-            phantom: PhantomData,
         }
     }
-    fn work(&mut self, source1: &OrdKeyBatch<L, C>, source2: &OrdKeyBatch<L, C>, fuel: &mut isize) {
+    fn work(&mut self, source1: &OrdKeyBatch<L>, source2: &OrdKeyBatch<L>, fuel: &mut isize) {
 
         let starting_updates = self.result.vals.vals.len();
         let mut effort = 0isize;
@@ -594,7 +571,7 @@ where
         effort = (self.result.vals.vals.len() - starting_updates) as isize;
 
         // if we are supplied a frontier, we should compact.
-        OrdKeyBatch::<L, C>::advance_builder_from(&mut self.result, self.description.since().borrow(), initial_key_pos);
+        OrdKeyBatch::<L>::advance_builder_from(&mut self.result, self.description.since().borrow(), initial_key_pos);
 
         *fuel -= effort;
 
@@ -607,63 +584,59 @@ where
 
 /// A cursor for navigating a single layer.
 #[derive(Debug)]
-pub struct OrdKeyCursor<L: Layout, C> {
+pub struct OrdKeyCursor<L: Layout> {
     valid: bool,
     cursor: OrderedCursor<OrderedLeaf<<L::Target as Update>::Time, <L::Target as Update>::Diff>>,
-    phantom: PhantomData<(L, C)>,
 }
 
-impl<L: Layout, C> Cursor<OrdKeyBatch<L, C>> for OrdKeyCursor<L, C> {
+impl<L: Layout> Cursor<OrdKeyBatch<L>> for OrdKeyCursor<L> {
     type Key = <L::Target as Update>::Key;
     type Val = ();
     type Time = <L::Target as Update>::Time;
     type R = <L::Target as Update>::Diff;
 
-    fn key<'a>(&self, storage: &'a OrdKeyBatch<L, C>) -> &'a Self::Key { &self.cursor.key(&storage.layer) }
-    fn val<'a>(&self, _storage: &'a OrdKeyBatch<L, C>) -> &'a () { &() }
-    fn map_times<L2: FnMut(&Self::Time, &Self::R)>(&mut self, storage: &OrdKeyBatch<L, C>, mut logic: L2) {
+    fn key<'a>(&self, storage: &'a OrdKeyBatch<L>) -> &'a Self::Key { &self.cursor.key(&storage.layer) }
+    fn val<'a>(&self, _storage: &'a OrdKeyBatch<L>) -> &'a () { &() }
+    fn map_times<L2: FnMut(&Self::Time, &Self::R)>(&mut self, storage: &OrdKeyBatch<L>, mut logic: L2) {
         self.cursor.child.rewind(&storage.layer.vals);
         while self.cursor.child.valid(&storage.layer.vals) {
             logic(&self.cursor.child.key(&storage.layer.vals).0, &self.cursor.child.key(&storage.layer.vals).1);
             self.cursor.child.step(&storage.layer.vals);
         }
     }
-    fn key_valid(&self, storage: &OrdKeyBatch<L, C>) -> bool { self.cursor.valid(&storage.layer) }
-    fn val_valid(&self, _storage: &OrdKeyBatch<L, C>) -> bool { self.valid }
-    fn step_key(&mut self, storage: &OrdKeyBatch<L, C>){ self.cursor.step(&storage.layer); self.valid = true; }
-    fn seek_key(&mut self, storage: &OrdKeyBatch<L, C>, key: &Self::Key) { self.cursor.seek(&storage.layer, key); self.valid = true; }
-    fn step_val(&mut self, _storage: &OrdKeyBatch<L, C>) { self.valid = false; }
-    fn seek_val(&mut self, _storage: &OrdKeyBatch<L, C>, _val: &()) { }
-    fn rewind_keys(&mut self, storage: &OrdKeyBatch<L, C>) { self.cursor.rewind(&storage.layer); self.valid = true; }
-    fn rewind_vals(&mut self, _storage: &OrdKeyBatch<L, C>) { self.valid = true; }
+    fn key_valid(&self, storage: &OrdKeyBatch<L>) -> bool { self.cursor.valid(&storage.layer) }
+    fn val_valid(&self, _storage: &OrdKeyBatch<L>) -> bool { self.valid }
+    fn step_key(&mut self, storage: &OrdKeyBatch<L>){ self.cursor.step(&storage.layer); self.valid = true; }
+    fn seek_key(&mut self, storage: &OrdKeyBatch<L>, key: &Self::Key) { self.cursor.seek(&storage.layer, key); self.valid = true; }
+    fn step_val(&mut self, _storage: &OrdKeyBatch<L>) { self.valid = false; }
+    fn seek_val(&mut self, _storage: &OrdKeyBatch<L>, _val: &()) { }
+    fn rewind_keys(&mut self, storage: &OrdKeyBatch<L>) { self.cursor.rewind(&storage.layer); self.valid = true; }
+    fn rewind_vals(&mut self, _storage: &OrdKeyBatch<L>) { self.valid = true; }
 }
 
 
 /// A builder for creating layers from unsorted update tuples.
-pub struct OrdKeyBuilder<L: Layout, C> {
+pub struct OrdKeyBuilder<L: Layout> {
     builder: KTDBuilder<L>,
-    phantom: std::marker::PhantomData<C>
 }
 
-impl<L: Layout, C> Builder for OrdKeyBuilder<L, C>
+impl<L: Layout> Builder for OrdKeyBuilder<L>
 where
-    OrdKeyBatch<L, C>: Batch<Key=<L::Target as Update>::Key, Val=(), Time=<L::Target as Update>::Time, R=<L::Target as Update>::Diff>
+    OrdKeyBatch<L>: Batch<Key=<L::Target as Update>::Key, Val=(), Time=<L::Target as Update>::Time, R=<L::Target as Update>::Diff>
 {
     type Item = ((<L::Target as Update>::Key, ()), <L::Target as Update>::Time, <L::Target as Update>::Diff);
     type Time = <L::Target as Update>::Time;
-    type Output = OrdKeyBatch<L, C>;
+    type Output = OrdKeyBatch<L>;
 
     fn new() -> Self {
         OrdKeyBuilder {
             builder: <KTDBuilder<L>>::new(),
-            phantom: std::marker::PhantomData,
         }
     }
 
     fn with_capacity(cap: usize) -> Self {
         OrdKeyBuilder {
             builder: <KTDBuilder<L> as TupleBuilder>::with_capacity(cap),
-            phantom: std::marker::PhantomData,
         }
     }
 
@@ -678,11 +651,10 @@ where
     }
 
     #[inline(never)]
-    fn done(self, lower: Antichain<Self::Time>, upper: Antichain<Self::Time>, since: Antichain<Self::Time>) -> OrdKeyBatch<L, C> {
+    fn done(self, lower: Antichain<Self::Time>, upper: Antichain<Self::Time>, since: Antichain<Self::Time>) -> OrdKeyBatch<L> {
         OrdKeyBatch {
             layer: self.builder.done(),
             desc: Description::new(lower, upper, since),
-            phantom: PhantomData,
         }
     }
 }

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -9,22 +9,31 @@
 //! and should consume fewer resources (computation and memory) when it applies.
 
 use std::rc::Rc;
-use timely::container::columnation::TimelyStack;
 
 use trace::implementations::spine_fueled::Spine;
+use trace::implementations::merge_batcher::MergeBatcher;
+use trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
+use trace::rc_blanket_impls::RcBuilder;
 
 use super::{Update, Layout, Vector, TStack};
 
-use self::val_batch::{OrdValBatch};
-
+use self::val_batch::{OrdValBatch, OrdValBuilder};
 
 /// A trace implementation using a spine of ordered lists.
-pub type OrdValSpine<K, V, T, R, O=usize> = Spine<Rc<OrdValBatch<Vector<((K,V),T,R), O>, Vec<((K,V),T,R)>>>>;
+pub type OrdValSpine<K, V, T, R, O=usize> = Spine<
+    Rc<OrdValBatch<Vector<((K,V),T,R), O>>>,
+    MergeBatcher<((K,V),T,R)>,
+    RcBuilder<OrdValBuilder<Vector<((K,V),T,R), O>>>,
+>;
 // /// A trace implementation for empty values using a spine of ordered lists.
 // pub type OrdKeySpine<K, T, R, O=usize> = Spine<Rc<OrdKeyBatch<Vector<((K,()),T,R), O>>>>;
 
 /// A trace implementation backed by columnar storage.
-pub type ColValSpine<K, V, T, R, O=usize> = Spine<Rc<OrdValBatch<TStack<((K,V),T,R), O>, TimelyStack<((K,V),T,R)>>>>;
+pub type ColValSpine<K, V, T, R, O=usize> = Spine<
+    Rc<OrdValBatch<TStack<((K,V),T,R), O>>>,
+    ColumnatedMergeBatcher<((K,V),T,R)>,
+    RcBuilder<OrdValBuilder<TStack<((K,V),T,R), O>>>,
+>;
 // /// A trace implementation backed by columnar storage.
 // pub type ColKeySpine<K, T, R, O=usize> = Spine<Rc<OrdKeyBatch<TStack<((K,()),T,R), O>>>>;
 
@@ -32,15 +41,12 @@ mod val_batch {
 
     use std::convert::TryInto;
     use std::marker::PhantomData;
-    use timely::container::columnation::{Columnation, TimelyStack};
     use timely::progress::{Antichain, frontier::AntichainRef};
 
     use trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
-    use trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
     use trace::layers::BatchContainer;
     
     use super::{Layout, Update};
-    use super::super::merge_batcher::MergeBatcher;
 
     /// An immutable collection of update tuples, from a contiguous interval of logical times.
     #[derive(Abomonation, Debug)]
@@ -90,7 +96,7 @@ mod val_batch {
     /// The `L` parameter captures how the updates should be laid out, and `C` determines which
     /// merge batcher to select.
     #[derive(Abomonation)]
-    pub struct OrdValBatch<L: Layout, C> {
+    pub struct OrdValBatch<L: Layout> {
         /// The updates themselves.
         pub storage: OrdValStorage<L>,
         /// Description of the update times this layer represents.
@@ -101,22 +107,20 @@ mod val_batch {
         /// we may have many more updates than `storage.updates.len()`. It should equal that 
         /// length, plus the number of singleton optimizations employed.
         pub updates: usize,
-        /// Phantom marker for Rust happiness.
-        pub phantom: PhantomData<C>,
     }
 
-    impl<L: Layout, C> BatchReader for OrdValBatch<L, C> {
+    impl<L: Layout> BatchReader for OrdValBatch<L> {
         type Key = <L::Target as Update>::Key;
         type Val = <L::Target as Update>::Val;
         type Time = <L::Target as Update>::Time;
         type R = <L::Target as Update>::Diff;
 
-        type Cursor = OrdValCursor<L, C>;
+        type Cursor = OrdValCursor<L>;
         fn cursor(&self) -> Self::Cursor { 
             OrdValCursor {
                 key_cursor: 0,
                 val_cursor: 0,
-                phantom: PhantomData,
+                phantom: std::marker::PhantomData,
             }
         }
         fn len(&self) -> usize { 
@@ -127,26 +131,7 @@ mod val_batch {
         fn description(&self) -> &Description<<L::Target as Update>::Time> { &self.description }
     }
 
-    impl<L: Layout> Batch for OrdValBatch<L, Vec<L::Target>> {
-        type Batcher = MergeBatcher<L::Target>;
-        type Builder = OrdValBuilder<L, Vec<L::Target>>;
-        type Merger = OrdValMerger<L>;
-
-        fn begin_merge(&self, other: &Self, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self::Merger {
-            OrdValMerger::new(self, other, compaction_frontier)
-        }
-    }
-
-    impl<L: Layout> Batch for OrdValBatch<L, TimelyStack<L::Target>>
-    where
-        <L as Layout>::Target: Columnation,
-        Self::Key: Columnation + 'static,
-        Self::Val: Columnation + 'static,
-        Self::Time: Columnation + 'static,
-        Self::R: Columnation + 'static,
-    {
-        type Batcher = ColumnatedMergeBatcher<L::Target>;
-        type Builder = OrdValBuilder<L, TimelyStack<L::Target>>;
+    impl<L: Layout> Batch for OrdValBatch<L> {
         type Merger = OrdValMerger<L>;
 
         fn begin_merge(&self, other: &Self, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self::Merger {
@@ -174,11 +159,11 @@ mod val_batch {
         singletons: usize,
     }
 
-    impl<L: Layout, C> Merger<OrdValBatch<L, C>> for OrdValMerger<L>
+    impl<L: Layout> Merger<OrdValBatch<L>> for OrdValMerger<L>
     where
-        OrdValBatch<L, C>: Batch<Time=<L::Target as Update>::Time>
+        OrdValBatch<L>: Batch<Time=<L::Target as Update>::Time>
     {
-        fn new(batch1: &OrdValBatch<L, C>, batch2: &OrdValBatch<L, C>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
+        fn new(batch1: &OrdValBatch<L>, batch2: &OrdValBatch<L>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
 
             assert!(batch1.upper() == batch2.lower());
             use lattice::Lattice;
@@ -210,15 +195,14 @@ mod val_batch {
                 singletons: 0,
             }
         }
-        fn done(self) -> OrdValBatch<L, C> {
+        fn done(self) -> OrdValBatch<L> {
             OrdValBatch {
                 updates: self.result.updates.len() + self.singletons,
                 storage: self.result,
                 description: self.description,
-                phantom: PhantomData
             }
         }
-        fn work(&mut self, source1: &OrdValBatch<L, C>, source2: &OrdValBatch<L, C>, fuel: &mut isize) {
+        fn work(&mut self, source1: &OrdValBatch<L>, source2: &OrdValBatch<L>, fuel: &mut isize) {
 
             // An (incomplete) indication of the amount of work we've done so far.
             let starting_updates = self.result.updates.len();
@@ -417,33 +401,33 @@ mod val_batch {
     }
 
     /// A cursor for navigating a single layer.
-    pub struct OrdValCursor<L: Layout, C> {
+    pub struct OrdValCursor<L: Layout> {
         /// Absolute position of the current key.
         key_cursor: usize,
         /// Absolute position of the current value.
         val_cursor: usize,
         /// Phantom marker for Rust happiness.
-        phantom: PhantomData<(L, C)>,
+        phantom: PhantomData<L>,
     }
 
-    impl<L: Layout, C> Cursor<OrdValBatch<L, C>> for OrdValCursor<L, C> {
+    impl<L: Layout> Cursor<OrdValBatch<L>> for OrdValCursor<L> {
         type Key = <L::Target as Update>::Key;
         type Val = <L::Target as Update>::Val;
         type Time = <L::Target as Update>::Time;
         type R = <L::Target as Update>::Diff;
 
-        fn key<'a>(&self, storage: &'a OrdValBatch<L, C>) -> &'a Self::Key { storage.storage.keys.index(self.key_cursor) }
-        fn val<'a>(&self, storage: &'a OrdValBatch<L, C>) -> &'a Self::Val { storage.storage.vals.index(self.val_cursor) }
-        fn map_times<L2: FnMut(&Self::Time, &Self::R)>(&mut self, storage: &OrdValBatch<L, C>, mut logic: L2) {
+        fn key<'a>(&self, storage: &'a OrdValBatch<L>) -> &'a Self::Key { storage.storage.keys.index(self.key_cursor) }
+        fn val<'a>(&self, storage: &'a OrdValBatch<L>) -> &'a Self::Val { storage.storage.vals.index(self.val_cursor) }
+        fn map_times<L2: FnMut(&Self::Time, &Self::R)>(&mut self, storage: &OrdValBatch<L>, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_value(self.val_cursor);
             for index in lower .. upper {
                 let (time, diff) = &storage.storage.updates.index(index);
                 logic(time, diff);
             }
         }
-        fn key_valid(&self, storage: &OrdValBatch<L, C>) -> bool { self.key_cursor < storage.storage.keys.len() }
-        fn val_valid(&self, storage: &OrdValBatch<L, C>) -> bool { self.val_cursor < storage.storage.values_for_key(self.key_cursor).1 }
-        fn step_key(&mut self, storage: &OrdValBatch<L, C>){ 
+        fn key_valid(&self, storage: &OrdValBatch<L>) -> bool { self.key_cursor < storage.storage.keys.len() }
+        fn val_valid(&self, storage: &OrdValBatch<L>) -> bool { self.val_cursor < storage.storage.values_for_key(self.key_cursor).1 }
+        fn step_key(&mut self, storage: &OrdValBatch<L>){
             self.key_cursor += 1;
             if self.key_valid(storage) {
                 self.rewind_vals(storage);
@@ -452,34 +436,34 @@ mod val_batch {
                 self.key_cursor = storage.storage.keys.len();
             }
         }
-        fn seek_key(&mut self, storage: &OrdValBatch<L, C>, key: &Self::Key) { 
+        fn seek_key(&mut self, storage: &OrdValBatch<L>, key: &Self::Key) {
             self.key_cursor += storage.storage.keys.advance(self.key_cursor, storage.storage.keys.len(), |x| x.lt(key));
             if self.key_valid(storage) {
                 self.rewind_vals(storage);
             }
         }
-        fn step_val(&mut self, storage: &OrdValBatch<L, C>) {
+        fn step_val(&mut self, storage: &OrdValBatch<L>) {
             self.val_cursor += 1; 
             if !self.val_valid(storage) {
                 self.val_cursor = storage.storage.values_for_key(self.key_cursor).1;
             }
         }
-        fn seek_val(&mut self, storage: &OrdValBatch<L, C>, val: &Self::Val) { 
+        fn seek_val(&mut self, storage: &OrdValBatch<L>, val: &Self::Val) {
             self.val_cursor += storage.storage.vals.advance(self.val_cursor, storage.storage.values_for_key(self.key_cursor).1, |x| x.lt(val));
         }
-        fn rewind_keys(&mut self, storage: &OrdValBatch<L, C>) { 
+        fn rewind_keys(&mut self, storage: &OrdValBatch<L>) {
             self.key_cursor = 0;
             if self.key_valid(storage) {
                 self.rewind_vals(storage)
             }
         }
-        fn rewind_vals(&mut self, storage: &OrdValBatch<L, C>) { 
+        fn rewind_vals(&mut self, storage: &OrdValBatch<L>) {
             self.val_cursor = storage.storage.values_for_key(self.key_cursor).0;
         }
     }
 
     /// A builder for creating layers from unsorted update tuples.
-    pub struct OrdValBuilder<L: Layout, C> {
+    pub struct OrdValBuilder<L: Layout> {
         result: OrdValStorage<L>,
         singleton: Option<(<L::Target as Update>::Time, <L::Target as Update>::Diff)>,
         /// Counts the number of singleton optimizations we performed.
@@ -487,11 +471,9 @@ mod val_batch {
         /// This number allows us to correctly gauge the total number of updates reflected in a batch,
         /// even though `updates.len()` may be much shorter than this amount.
         singletons: usize,
-        /// Phantom marker for Rust happiness.
-        pub phantom: PhantomData<C>,
     }
 
-    impl<L: Layout, C> OrdValBuilder<L, C> {
+    impl<L: Layout> OrdValBuilder<L> {
         /// Pushes a single update, which may set `self.singleton` rather than push.
         ///
         /// This operation is meant to be equivalent to `self.results.updates.push((time, diff))`.
@@ -519,13 +501,13 @@ mod val_batch {
         }
     }
 
-    impl<L: Layout, C> Builder for OrdValBuilder<L, C>
+    impl<L: Layout> Builder for OrdValBuilder<L>
     where
-        OrdValBatch<L, C>: Batch<Key=<L::Target as Update>::Key, Val=<L::Target as Update>::Val, Time=<L::Target as Update>::Time, R=<L::Target as Update>::Diff>
+        OrdValBatch<L>: Batch<Key=<L::Target as Update>::Key, Val=<L::Target as Update>::Val, Time=<L::Target as Update>::Time, R=<L::Target as Update>::Diff>
     {
         type Item = ((<L::Target as Update>::Key, <L::Target as Update>::Val), <L::Target as Update>::Time, <L::Target as Update>::Diff);
         type Time = <L::Target as Update>::Time;
-        type Output = OrdValBatch<L, C>;
+        type Output = OrdValBatch<L>;
 
         fn new() -> Self { Self::with_capacity(0) }
         fn with_capacity(cap: usize) -> Self {
@@ -540,7 +522,6 @@ mod val_batch {
                 },
                 singleton: None,
                 singletons: 0,
-                phantom: std::marker::PhantomData,
             }
         }
 
@@ -601,7 +582,7 @@ mod val_batch {
         }
 
         #[inline(never)]
-        fn done(mut self, lower: Antichain<Self::Time>, upper: Antichain<Self::Time>, since: Antichain<Self::Time>) -> OrdValBatch<L, C> {
+        fn done(mut self, lower: Antichain<Self::Time>, upper: Antichain<Self::Time>, since: Antichain<Self::Time>) -> OrdValBatch<L> {
             // Record the final offsets
             self.result.vals_offs.push(self.result.updates.len().try_into().ok().unwrap());
             // Remove any pending singleton, and if it was set increment our count.
@@ -611,7 +592,6 @@ mod val_batch {
                 updates: self.result.updates.len() + self.singletons,
                 storage: self.result,
                 description: Description::new(lower, upper, since),
-                phantom: PhantomData,
             }
         }
     }

--- a/src/trace/implementations/spine_fueled.rs
+++ b/src/trace/implementations/spine_fueled.rs
@@ -75,7 +75,7 @@ use ::logging::Logger;
 use ::difference::Semigroup;
 use lattice::Lattice;
 use trace::{Batch, BatchReader, Trace, TraceReader, ExertionLogic};
-use trace::cursor::{Cursor, CursorList};
+use trace::cursor::CursorList;
 use trace::Merger;
 
 use ::timely::dataflow::operators::generic::OperatorInfo;
@@ -115,9 +115,10 @@ where
     type R = B::R;
 
     type Batch = B;
+    type Storage = Vec<B>;
     type Cursor = CursorList<<B as BatchReader>::Cursor>;
 
-    fn cursor_through(&mut self, upper: AntichainRef<Self::Time>) -> Option<(Self::Cursor, <Self::Cursor as Cursor>::Storage)> {
+    fn cursor_through(&mut self, upper: AntichainRef<Self::Time>) -> Option<(Self::Cursor, Self::Storage)> {
 
         // If `upper` is the minimum frontier, we can return an empty cursor.
         // This can happen with operators that are written to expect the ability to acquire cursors

--- a/src/trace/implementations/spine_fueled.rs
+++ b/src/trace/implementations/spine_fueled.rs
@@ -74,7 +74,7 @@ use std::fmt::Debug;
 use ::logging::Logger;
 use ::difference::Semigroup;
 use lattice::Lattice;
-use trace::{Batch, BatchReader, Trace, TraceReader, ExertionLogic};
+use trace::{Batch, Batcher, Builder, BatchReader, Trace, TraceReader, ExertionLogic};
 use trace::cursor::CursorList;
 use trace::Merger;
 
@@ -87,7 +87,14 @@ use ::timely::order::PartialOrder;
 /// A spine maintains a small number of immutable collections of update tuples, merging the collections when
 /// two have similar sizes. In this way, it allows the addition of more tuples, which may then be merged with
 /// other immutable collections.
-pub struct Spine<B: Batch> where B::Time: Lattice+Ord, B::R: Semigroup {
+pub struct Spine<B: Batch, BA, BU>
+where
+    B::Time: Lattice+Ord,
+    B::R: Semigroup,
+    // Intended constraints:
+    // BA: Batcher<Time = B::Time>,
+    // BU: Builder<Item=BA::Item, Time=BA::Time, Output = B>,
+{
     operator: OperatorInfo,
     logger: Option<Logger>,
     logical_frontier: Antichain<B::Time>,   // Times after which the trace must accumulate correctly.
@@ -99,9 +106,10 @@ pub struct Spine<B: Batch> where B::Time: Lattice+Ord, B::R: Semigroup {
     activator: Option<timely::scheduling::activate::Activator>,
     /// Logic to indicate whether and how many records we should introduce in the absence of actual updates.
     exert_logic: ExertionLogic,
+    phantom: std::marker::PhantomData<(BA, BU)>,
 }
 
-impl<B> TraceReader for Spine<B>
+impl<B, BA, BU> TraceReader for Spine<B, BA, BU>
 where
     B: Batch+Clone+'static,
     B::Key: Ord+Clone,           // Clone is required by `batch::advance_*` (in-place could remove).
@@ -249,14 +257,21 @@ where
 
 // A trace implementation for any key type that can be borrowed from or converted into `Key`.
 // TODO: Almost all this implementation seems to be generic with respect to the trace and batch types.
-impl<B> Trace for Spine<B>
+impl<B, BA, BU> Trace for Spine<B, BA, BU>
 where
     B: Batch+Clone+'static,
     B::Key: Ord+Clone,
     B::Val: Ord+Clone,
     B::Time: Lattice+timely::progress::Timestamp+Ord+Clone+Debug,
     B::R: Semigroup,
+    BA: Batcher<Time = B::Time>,
+    BU: Builder<Item=BA::Item, Time=BA::Time, Output = B>,
 {
+    /// A type used to assemble batches from disordered updates.
+    type Batcher = BA;
+    /// A type used to assemble batches from ordered update sequences.
+    type Builder = BU;
+
     fn new(
         info: ::timely::dataflow::operators::generic::OperatorInfo,
         logging: Option<::logging::Logger>,
@@ -319,8 +334,7 @@ where
     /// Completes the trace with a final empty batch.
     fn close(&mut self) {
         if !self.upper.borrow().is_empty() {
-            use trace::Builder;
-            let builder = B::Builder::new();
+            let builder = Self::Builder::new();
             let batch = builder.done(self.upper.clone(), Antichain::new(), Antichain::from_elem(<Self::Time as timely::progress::Timestamp>::minimum()));
             self.insert(batch);
         }
@@ -328,7 +342,7 @@ where
 }
 
 // Drop implementation allows us to log batch drops, to zero out maintained totals.
-impl<B> Drop for Spine<B>
+impl<B, BA, BU> Drop for Spine<B, BA, BU>
 where
     B: Batch,
     B::Time: Lattice+Ord,
@@ -340,7 +354,7 @@ where
 }
 
 
-impl<B> Spine<B>
+impl<B, BA, BU> Spine<B, BA, BU>
 where
     B: Batch,
     B::Time: Lattice+Ord,
@@ -386,7 +400,7 @@ where
     }
 }
 
-impl<B> Spine<B>
+impl<B, BA, BU> Spine<B, BA, BU>
 where
     B: Batch,
     B::Key: Ord+Clone,
@@ -451,6 +465,7 @@ where
             effort,
             activator,
             exert_logic: std::sync::Arc::new(|_batches| None),
+            phantom: std::marker::PhantomData,
         }
     }
 

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -63,6 +63,7 @@ where
     type R = Tr::R;
 
     type Batch = BatchEnter<Tr::Batch, TInner,F>;
+    type Storage = Tr::Storage;
     type Cursor = CursorEnter<Tr::Cursor, TInner,F>;
 
     fn map_batches<F2: FnMut(&Self::Batch)>(&self, mut f: F2) {
@@ -102,7 +103,7 @@ where
         self.stash2.borrow()
     }
 
-    fn cursor_through(&mut self, upper: AntichainRef<TInner>) -> Option<(Self::Cursor, <Self::Cursor as Cursor>::Storage)> {
+    fn cursor_through(&mut self, upper: AntichainRef<TInner>) -> Option<(Self::Cursor, Self::Storage)> {
         self.stash1.clear();
         for time in upper.iter() {
             self.stash1.insert(time.clone().to_outer());
@@ -180,13 +181,13 @@ where
 }
 
 /// Wrapper to provide cursor to nested scope.
-pub struct CursorEnter<C: Cursor, TInner, F> {
+pub struct CursorEnter<C, TInner, F> {
     phantom: ::std::marker::PhantomData<TInner>,
     cursor: C,
     logic: F,
 }
 
-impl<C: Cursor, TInner, F> CursorEnter<C, TInner, F> {
+impl<C, TInner, F> CursorEnter<C, TInner, F> {
     fn new(cursor: C, logic: F) -> Self {
         CursorEnter {
             phantom: ::std::marker::PhantomData,
@@ -196,9 +197,9 @@ impl<C: Cursor, TInner, F> CursorEnter<C, TInner, F> {
     }
 }
 
-impl<C, TInner, F> Cursor for CursorEnter<C, TInner, F>
+impl<S, C, TInner, F> Cursor<S> for CursorEnter<C, TInner, F>
 where
-    C: Cursor,
+    C: Cursor<S>,
     C::Time: Timestamp,
     TInner: Refines<C::Time>+Lattice,
     F: FnMut(&C::Key, &C::Val, &C::Time)->TInner,
@@ -208,16 +209,14 @@ where
     type Time = TInner;
     type R = C::R;
 
-    type Storage = C::Storage;
+    #[inline] fn key_valid(&self, storage: &S) -> bool { self.cursor.key_valid(storage) }
+    #[inline] fn val_valid(&self, storage: &S) -> bool { self.cursor.val_valid(storage) }
 
-    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
-    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
-
-    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Key { self.cursor.key(storage) }
-    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Val { self.cursor.val(storage) }
+    #[inline] fn key<'a>(&self, storage: &'a S) -> &'a Self::Key { self.cursor.key(storage) }
+    #[inline] fn val<'a>(&self, storage: &'a S) -> &'a Self::Val { self.cursor.val(storage) }
 
     #[inline]
-    fn map_times<L: FnMut(&TInner, &Self::R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<L: FnMut(&TInner, &Self::R)>(&mut self, storage: &S, mut logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         let logic2 = &mut self.logic;
@@ -226,14 +225,14 @@ where
         })
     }
 
-    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &Self::Key) { self.cursor.seek_key(storage, key) }
+    #[inline] fn step_key(&mut self, storage: &S) { self.cursor.step_key(storage) }
+    #[inline] fn seek_key(&mut self, storage: &S, key: &Self::Key) { self.cursor.seek_key(storage, key) }
 
-    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
-    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &Self::Val) { self.cursor.seek_val(storage, val) }
+    #[inline] fn step_val(&mut self, storage: &S) { self.cursor.step_val(storage) }
+    #[inline] fn seek_val(&mut self, storage: &S, val: &Self::Val) { self.cursor.seek_val(storage, val) }
 
-    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
-    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
+    #[inline] fn rewind_keys(&mut self, storage: &S) { self.cursor.rewind_keys(storage) }
+    #[inline] fn rewind_vals(&mut self, storage: &S) { self.cursor.rewind_vals(storage) }
 }
 
 
@@ -255,7 +254,7 @@ impl<B: BatchReader, TInner, F> BatchCursorEnter<B, TInner, F> {
     }
 }
 
-impl<TInner, B: BatchReader, F> Cursor for BatchCursorEnter<B, TInner, F>
+impl<TInner, B: BatchReader, F> Cursor<BatchEnter<B, TInner, F>> for BatchCursorEnter<B, TInner, F>
 where
     B::Time: Timestamp,
     TInner: Refines<B::Time>+Lattice,
@@ -266,16 +265,14 @@ where
     type Time = TInner;
     type R = B::R;
 
-    type Storage = BatchEnter<B, TInner, F>;
+    #[inline] fn key_valid(&self, storage: &BatchEnter<B, TInner, F>) -> bool { self.cursor.key_valid(&storage.batch) }
+    #[inline] fn val_valid(&self, storage: &BatchEnter<B, TInner, F>) -> bool { self.cursor.val_valid(&storage.batch) }
 
-    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }
-    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(&storage.batch) }
-
-    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Key { self.cursor.key(&storage.batch) }
-    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Val { self.cursor.val(&storage.batch) }
+    #[inline] fn key<'a>(&self, storage: &'a BatchEnter<B, TInner, F>) -> &'a Self::Key { self.cursor.key(&storage.batch) }
+    #[inline] fn val<'a>(&self, storage: &'a BatchEnter<B, TInner, F>) -> &'a Self::Val { self.cursor.val(&storage.batch) }
 
     #[inline]
-    fn map_times<L: FnMut(&TInner, &Self::R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<L: FnMut(&TInner, &Self::R)>(&mut self, storage: &BatchEnter<B, TInner, F>, mut logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         let logic2 = &mut self.logic;
@@ -284,12 +281,12 @@ where
         })
     }
 
-    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
-    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &Self::Key) { self.cursor.seek_key(&storage.batch, key) }
+    #[inline] fn step_key(&mut self, storage: &BatchEnter<B, TInner, F>) { self.cursor.step_key(&storage.batch) }
+    #[inline] fn seek_key(&mut self, storage: &BatchEnter<B, TInner, F>, key: &Self::Key) { self.cursor.seek_key(&storage.batch, key) }
 
-    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
-    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &Self::Val) { self.cursor.seek_val(&storage.batch, val) }
+    #[inline] fn step_val(&mut self, storage: &BatchEnter<B, TInner, F>) { self.cursor.step_val(&storage.batch) }
+    #[inline] fn seek_val(&mut self, storage: &BatchEnter<B, TInner, F>, val: &Self::Val) { self.cursor.seek_val(&storage.batch, val) }
 
-    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
-    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }
+    #[inline] fn rewind_keys(&mut self, storage: &BatchEnter<B, TInner, F>) { self.cursor.rewind_keys(&storage.batch) }
+    #[inline] fn rewind_vals(&mut self, storage: &BatchEnter<B, TInner, F>) { self.cursor.rewind_vals(&storage.batch) }
 }

--- a/src/trace/wrappers/freeze.rs
+++ b/src/trace/wrappers/freeze.rs
@@ -92,6 +92,7 @@ where
     type R = Tr::R;
 
     type Batch = BatchFreeze<Tr::Batch, F>;
+    type Storage = Tr::Storage;
     type Cursor = CursorFreeze<Tr::Cursor, F>;
 
     fn map_batches<F2: FnMut(&Self::Batch)>(&self, mut f: F2) {
@@ -107,7 +108,7 @@ where
     fn set_physical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.set_physical_compaction(frontier) }
     fn get_physical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.trace.get_physical_compaction() }
 
-    fn cursor_through(&mut self, upper: AntichainRef<Tr::Time>) -> Option<(Self::Cursor, <Self::Cursor as Cursor>::Storage)> {
+    fn cursor_through(&mut self, upper: AntichainRef<Tr::Time>) -> Option<(Self::Cursor, Self::Storage)> {
         let func = &self.func;
         self.trace.cursor_through(upper)
             .map(|(cursor, storage)| (CursorFreeze::new(cursor, func.clone()), storage))
@@ -185,12 +186,12 @@ where
 }
 
 /// Wrapper to provide cursor to nested scope.
-pub struct CursorFreeze<C: Cursor, F> {
+pub struct CursorFreeze<C, F> {
     cursor: C,
     func: Rc<F>,
 }
 
-impl<C: Cursor, F> CursorFreeze<C, F> {
+impl<C, F> CursorFreeze<C, F> {
     fn new(cursor: C, func: Rc<F>) -> Self {
         CursorFreeze {
             cursor: cursor,
@@ -199,9 +200,9 @@ impl<C: Cursor, F> CursorFreeze<C, F> {
     }
 }
 
-impl<C, F> Cursor for CursorFreeze<C, F>
+impl<S, C, F> Cursor<S> for CursorFreeze<C, F>
 where
-    C: Cursor,
+    C: Cursor<S>,
     F: Fn(&C::Time)->Option<C::Time>,
 {
     type Key = C::Key;
@@ -209,15 +210,13 @@ where
     type Time = C::Time;
     type R = C::R;
 
-    type Storage = C::Storage;
+    #[inline] fn key_valid(&self, storage: &S) -> bool { self.cursor.key_valid(storage) }
+    #[inline] fn val_valid(&self, storage: &S) -> bool { self.cursor.val_valid(storage) }
 
-    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
-    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
+    #[inline] fn key<'a>(&self, storage: &'a S) -> &'a Self::Key { self.cursor.key(storage) }
+    #[inline] fn val<'a>(&self, storage: &'a S) -> &'a Self::Val { self.cursor.val(storage) }
 
-    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Key { self.cursor.key(storage) }
-    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Val { self.cursor.val(storage) }
-
-    #[inline] fn map_times<L: FnMut(&Self::Time, &Self::R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    #[inline] fn map_times<L: FnMut(&Self::Time, &Self::R)>(&mut self, storage: &S, mut logic: L) {
         let func = &self.func;
         self.cursor.map_times(storage, |time, diff| {
             if let Some(time) = func(time) {
@@ -226,14 +225,14 @@ where
         })
     }
 
-    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &Self::Key) { self.cursor.seek_key(storage, key) }
+    #[inline] fn step_key(&mut self, storage: &S) { self.cursor.step_key(storage) }
+    #[inline] fn seek_key(&mut self, storage: &S, key: &Self::Key) { self.cursor.seek_key(storage, key) }
 
-    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
-    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &Self::Val) { self.cursor.seek_val(storage, val) }
+    #[inline] fn step_val(&mut self, storage: &S) { self.cursor.step_val(storage) }
+    #[inline] fn seek_val(&mut self, storage: &S, val: &Self::Val) { self.cursor.seek_val(storage, val) }
 
-    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
-    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
+    #[inline] fn rewind_keys(&mut self, storage: &S) { self.cursor.rewind_keys(storage) }
+    #[inline] fn rewind_vals(&mut self, storage: &S) { self.cursor.rewind_vals(storage) }
 }
 
 
@@ -252,7 +251,7 @@ impl<B: BatchReader, F> BatchCursorFreeze<B, F> {
     }
 }
 
-impl<B: BatchReader, F> Cursor for BatchCursorFreeze<B, F>
+impl<B: BatchReader, F> Cursor<BatchFreeze<B, F>> for BatchCursorFreeze<B, F>
 where
     F: Fn(&B::Time)->Option<B::Time>,
 {
@@ -261,15 +260,13 @@ where
     type Time = B::Time;
     type R = B::R;
 
-    type Storage = BatchFreeze<B, F>;
+    #[inline] fn key_valid(&self, storage: &BatchFreeze<B, F>) -> bool { self.cursor.key_valid(&storage.batch) }
+    #[inline] fn val_valid(&self, storage: &BatchFreeze<B, F>) -> bool { self.cursor.val_valid(&storage.batch) }
 
-    #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }
-    #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(&storage.batch) }
+    #[inline] fn key<'a>(&self, storage: &'a BatchFreeze<B, F>) -> &'a Self::Key { self.cursor.key(&storage.batch) }
+    #[inline] fn val<'a>(&self, storage: &'a BatchFreeze<B, F>) -> &'a Self::Val { self.cursor.val(&storage.batch) }
 
-    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Key { self.cursor.key(&storage.batch) }
-    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Val { self.cursor.val(&storage.batch) }
-
-    #[inline] fn map_times<L: FnMut(&Self::Time, &Self::R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    #[inline] fn map_times<L: FnMut(&Self::Time, &Self::R)>(&mut self, storage: &BatchFreeze<B, F>, mut logic: L) {
         let func = &self.func;
         self.cursor.map_times(&storage.batch, |time, diff| {
             if let Some(time) = func(time) {
@@ -278,12 +275,12 @@ where
         })
     }
 
-    #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
-    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &Self::Key) { self.cursor.seek_key(&storage.batch, key) }
+    #[inline] fn step_key(&mut self, storage: &BatchFreeze<B, F>) { self.cursor.step_key(&storage.batch) }
+    #[inline] fn seek_key(&mut self, storage: &BatchFreeze<B, F>, key: &Self::Key) { self.cursor.seek_key(&storage.batch, key) }
 
-    #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
-    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &Self::Val) { self.cursor.seek_val(&storage.batch, val) }
+    #[inline] fn step_val(&mut self, storage: &BatchFreeze<B, F>) { self.cursor.step_val(&storage.batch) }
+    #[inline] fn seek_val(&mut self, storage: &BatchFreeze<B, F>, val: &Self::Val) { self.cursor.seek_val(&storage.batch, val) }
 
-    #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
-    #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }
+    #[inline] fn rewind_keys(&mut self, storage: &BatchFreeze<B, F>) { self.cursor.rewind_keys(&storage.batch) }
+    #[inline] fn rewind_vals(&mut self, storage: &BatchFreeze<B, F>) { self.cursor.rewind_vals(&storage.batch) }
 }

--- a/src/trace/wrappers/freeze.rs
+++ b/src/trace/wrappers/freeze.rs
@@ -203,6 +203,7 @@ impl<C, F> CursorFreeze<C, F> {
 impl<S, C, F> Cursor<S> for CursorFreeze<C, F>
 where
     C: Cursor<S>,
+    C::Time: Sized,
     F: Fn(&C::Time)->Option<C::Time>,
 {
     type Key = C::Key;

--- a/src/trace/wrappers/rc.rs
+++ b/src/trace/wrappers/rc.rs
@@ -18,7 +18,6 @@ use timely::progress::{Antichain, frontier::{AntichainRef, MutableAntichain}};
 
 use lattice::Lattice;
 use trace::TraceReader;
-use trace::cursor::Cursor;
 
 /// A wrapper around a trace which tracks the frontiers of all referees.
 ///
@@ -103,6 +102,7 @@ where
     type R = Tr::R;
 
     type Batch = Tr::Batch;
+    type Storage = Tr::Storage;
     type Cursor = Tr::Cursor;
 
     /// Sets frontier to now be elements in `frontier`.
@@ -122,7 +122,7 @@ where
     }
     fn get_physical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.physical_compaction.borrow() }
     /// Creates a new cursor over the wrapped trace.
-    fn cursor_through(&mut self, frontier: AntichainRef<Tr::Time>) -> Option<(Tr::Cursor, <Tr::Cursor as Cursor>::Storage)> {
+    fn cursor_through(&mut self, frontier: AntichainRef<Tr::Time>) -> Option<(Tr::Cursor, Tr::Storage)> {
         ::std::cell::RefCell::borrow_mut(&self.wrapper).trace.cursor_through(frontier)
     }
 

--- a/tests/trace.rs
+++ b/tests/trace.rs
@@ -5,18 +5,17 @@ use timely::dataflow::operators::generic::OperatorInfo;
 use timely::progress::{Antichain, frontier::AntichainRef};
 
 use differential_dataflow::trace::implementations::ValSpine;
-use differential_dataflow::trace::{Trace, TraceReader, Batch, Batcher};
+use differential_dataflow::trace::{Trace, TraceReader, Batcher};
 use differential_dataflow::trace::cursor::Cursor;
 
 type IntegerTrace = ValSpine<u64, u64, usize, i64>;
-type IntegerBatch = <IntegerTrace as TraceReader>::Batch;
-type IntegerBuilder = <IntegerBatch as Batch>::Builder;
+type IntegerBuilder = <IntegerTrace as Trace>::Builder;
 
 fn get_trace() -> ValSpine<u64, u64, usize, i64> {
     let op_info = OperatorInfo::new(0, 0, &[]);
     let mut trace = IntegerTrace::new(op_info, None, None);
     {
-        let mut batcher = <IntegerBatch as Batch>::Batcher::new();
+        let mut batcher = <IntegerTrace as Trace>::Batcher::new();
 
         use timely::communication::message::RefOrMut;
         batcher.push_batch(RefOrMut::Mut(&mut vec![


### PR DESCRIPTION
Reorganize a bunch of traits, like `Cursor`, `Batcher`, and `Builder`, to reveal more independence of their types. This was meant as an exercise to understand what is needed to break these apart, and e.g. accept owned inputs but potentially reveal borrow types as outputs (e.g. `String` in, and `&[u8]` out).