### PR TITLE
Only retain two allocations

### DIFF
--- a/src/trace/implementations/merge_batcher_col.rs
+++ b/src/trace/implementations/merge_batcher_col.rs
@@ -203,7 +203,7 @@ impl<D: Ord+Clone+Columnation+'static, T: Ord+Clone+Columnation+'static, R: Semi
 
     /// Insert an empty buffer into the stash. Panics if the buffer is not empty.
     fn recycle(&mut self, mut buffer: TimelyStack<(D, T, R)>) {
-        if buffer.capacity() == Self::buffer_size() {
+        if buffer.capacity() == Self::buffer_size() && self.stash.len() <= 2 {
             buffer.clear();
             self.stash.push(buffer);
         }


### PR DESCRIPTION
This fixes retaining memory as large as the output when sealing the merge batcher for columnation.