### PR TITLE
Remove batcher dependence on updates

### DIFF
--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -42,41 +42,41 @@ use trace::abomonated_blanket_impls::AbomonatedBuilder;
 /// A trace implementation using a spine of ordered lists.
 pub type OrdValSpine<K, V, T, R, O=usize> = Spine<
     Rc<OrdValBatch<Vector<((K,V),T,R), O>>>,
-    MergeBatcher<((K,V),T,R)>,
+    MergeBatcher<K,V,T,R>,
     RcBuilder<OrdValBuilder<Vector<((K,V),T,R), O>>>,
 >;
 
 /// A trace implementation using a spine of abomonated ordered lists.
 pub type OrdValSpineAbom<K, V, T, R, O=usize> = Spine<
     Rc<Abomonated<OrdValBatch<Vector<((K,V),T,R), O>>, Vec<u8>>>,
-    MergeBatcher<((K,V),T,R)>,
+    MergeBatcher<K,V,T,R>,
     AbomonatedBuilder<OrdValBuilder<Vector<((K,V),T,R), O>>>,
 >;
 
 /// A trace implementation for empty values using a spine of ordered lists.
 pub type OrdKeySpine<K, T, R, O=usize> = Spine<
     Rc<OrdKeyBatch<Vector<((K,()),T,R), O>>>,
-    MergeBatcher<((K,()),T,R)>,
+    MergeBatcher<K,(),T,R>,
     RcBuilder<OrdKeyBuilder<Vector<((K,()),T,R), O>>>,
 >;
 
 /// A trace implementation for empty values using a spine of abomonated ordered lists.
 pub type OrdKeySpineAbom<K, T, R, O=usize> = Spine<
     Rc<Abomonated<OrdKeyBatch<Vector<((K,()),T,R), O>>, Vec<u8>>>,
-    MergeBatcher<((K,()),T,R)>,
+    MergeBatcher<K,(),T,R>,
     AbomonatedBuilder<OrdKeyBuilder<Vector<((K,()),T,R), O>>>,
 >;
 
 /// A trace implementation backed by columnar storage.
 pub type ColValSpine<K, V, T, R, O=usize> = Spine<
     Rc<OrdValBatch<TStack<((K,V),T,R), O>>>,
-    ColumnatedMergeBatcher<((K,V),T,R)>,
+    ColumnatedMergeBatcher<K,V,T,R>,
     RcBuilder<OrdValBuilder<TStack<((K,V),T,R), O>>>,
 >;
 /// A trace implementation backed by columnar storage.
 pub type ColKeySpine<K, T, R, O=usize> = Spine<
     Rc<OrdKeyBatch<TStack<((K,()),T,R), O>>>,
-    ColumnatedMergeBatcher<((K,()),T,R)>,
+    ColumnatedMergeBatcher<K,(),T,R>,
     RcBuilder<OrdKeyBuilder<TStack<((K,()),T,R), O>>>,
 >;
 

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -22,7 +22,7 @@ use self::val_batch::{OrdValBatch, OrdValBuilder};
 /// A trace implementation using a spine of ordered lists.
 pub type OrdValSpine<K, V, T, R, O=usize> = Spine<
     Rc<OrdValBatch<Vector<((K,V),T,R), O>>>,
-    MergeBatcher<((K,V),T,R)>,
+    MergeBatcher<K,V,T,R>,
     RcBuilder<OrdValBuilder<Vector<((K,V),T,R), O>>>,
 >;
 // /// A trace implementation for empty values using a spine of ordered lists.
@@ -31,14 +31,14 @@ pub type OrdValSpine<K, V, T, R, O=usize> = Spine<
 /// A trace implementation backed by columnar storage.
 pub type ColValSpine<K, V, T, R, O=usize> = Spine<
     Rc<OrdValBatch<TStack<((K,V),T,R), O>>>,
-    ColumnatedMergeBatcher<((K,V),T,R)>,
+    ColumnatedMergeBatcher<K,V,T,R>,
     RcBuilder<OrdValBuilder<TStack<((K,V),T,R), O>>>,
 >;
 
 /// A trace implementation backed by columnar storage.
 pub type PreferredSpine<K, V, T, R, O=usize> = Spine<
     Rc<OrdValBatch<Preferred<K,V,T,R,O>>>,
-    ColumnatedMergeBatcher<Preferred<K,V,T,R,O>>,
+    ColumnatedMergeBatcher<<K as ToOwned>::Owned,<V as ToOwned>::Owned,T,R>,
     RcBuilder<OrdValBuilder<Preferred<K,V,T,R,O>>>,
 >;
 

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -20,7 +20,7 @@ use self::val_batch::{RhhValBatch, RhhValBuilder};
 /// A trace implementation using a spine of ordered lists.
 pub type VecSpine<K, V, T, R, O=usize> = Spine<
     Rc<RhhValBatch<Vector<((K,V),T,R), O>>>,
-    MergeBatcher<((K,V),T,R)>,
+    MergeBatcher<K,V,T,R>,
     RcBuilder<RhhValBuilder<Vector<((K,V),T,R), O>>>,
 >;
 // /// A trace implementation for empty values using a spine of ordered lists.
@@ -29,7 +29,7 @@ pub type VecSpine<K, V, T, R, O=usize> = Spine<
 /// A trace implementation backed by columnar storage.
 pub type ColSpine<K, V, T, R, O=usize> = Spine<
     Rc<RhhValBatch<TStack<((K,V),T,R), O>>>,
-    ColumnatedMergeBatcher<((K,V),T,R)>,
+    ColumnatedMergeBatcher<K,V,T,R>,
     RcBuilder<RhhValBuilder<TStack<((K,V),T,R), O>>>,
 >;
 // /// A trace implementation backed by columnar storage.


### PR DESCRIPTION
This PR removes both batchers' dependence on `U: Update`, replacing the dependence with the vanilla types it would extract from the update. This generally simplifies things when we know explicit types, and is a bit more confusing when we baked a more complicated rule into the update. We may need to re-jigger in the future, but I don't think we need to make these types update-aware.