### PR TITLE
Fix lookup_map compile error

### DIFF
--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -30,7 +30,7 @@ where
     G: Scope,
     G::Timestamp: Lattice,
     Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
-    Tr::Key: Ord+Hashable,
+    Tr::Key: Ord+Hashable+Sized,
     Tr::Val: Clone,
     Tr::R: Monoid+ExchangeData,
     F: FnMut(&D, &mut Tr::Key)+Clone+'static,


### PR DESCRIPTION
It doesn't make any effort to relax the trait bounds in dogs^3, if possible at all.