### PR TITLE
Arrangement GATs

### DIFF
--- a/dogsdogsdogs/src/operators/count.rs
+++ b/dogsdogsdogs/src/operators/count.rs
@@ -21,17 +21,17 @@ pub fn count<G, Tr, R, F, P>(
 where
     G: Scope,
     G::Timestamp: Lattice,
-    Tr: TraceReader<Val=(), Time=G::Timestamp, Diff=isize>+Clone+'static,
-    Tr::Key: Ord+Hashable+Default,
+    Tr: TraceReader<ValOwned=(), Time=G::Timestamp, Diff=isize>+Clone+'static,
+    Tr::KeyOwned: Hashable + Default,
     R: Monoid+Multiply<Output = R>+ExchangeData,
-    F: Fn(&P)->Tr::Key+Clone+'static,
+    F: Fn(&P)->Tr::KeyOwned+Clone+'static,
     P: ExchangeData,
 {
     crate::operators::lookup_map(
         prefixes,
         arrangement,
-        move |p: &(P,usize,usize), k: &mut Tr::Key| { *k = key_selector(&p.0); },
-        move |(p,c,i), r, &(), s| {
+        move |p: &(P,usize,usize), k: &mut Tr::KeyOwned| { *k = key_selector(&p.0); },
+        move |(p,c,i), r, _, s| {
             let s = *s as usize;
             if *c < s { ((p.clone(), *c, *i), r.clone()) }
             else      { ((p.clone(), s, index), r.clone()) }

--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -31,8 +31,6 @@ where
     G::Timestamp: Lattice,
     Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
     Tr::KeyOwned: Hashable,
-    // Tr::Key: Ord+Hashable+Sized,
-    // Tr::Val: Clone,
     Tr::Diff: Monoid+ExchangeData,
     F: FnMut(&D, &mut Tr::KeyOwned)+Clone+'static,
     D: ExchangeData,

--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -22,23 +22,24 @@ pub fn lookup_map<G, D, R, Tr, F, DOut, ROut, S>(
     mut arrangement: Arranged<G, Tr>,
     key_selector: F,
     mut output_func: S,
-    supplied_key0: Tr::Key,
-    supplied_key1: Tr::Key,
-    supplied_key2: Tr::Key,
+    supplied_key0: Tr::KeyOwned,
+    supplied_key1: Tr::KeyOwned,
+    supplied_key2: Tr::KeyOwned,
 ) -> Collection<G, DOut, ROut>
 where
     G: Scope,
     G::Timestamp: Lattice,
     Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
-    Tr::Key: Ord+Hashable+Sized,
-    Tr::Val: Clone,
+    Tr::KeyOwned: Hashable,
+    // Tr::Key: Ord+Hashable+Sized,
+    // Tr::Val: Clone,
     Tr::Diff: Monoid+ExchangeData,
-    F: FnMut(&D, &mut Tr::Key)+Clone+'static,
+    F: FnMut(&D, &mut Tr::KeyOwned)+Clone+'static,
     D: ExchangeData,
     R: ExchangeData+Monoid,
     DOut: Clone+'static,
     ROut: Monoid,
-    S: FnMut(&D, &R, &Tr::Val, &Tr::Diff)->(DOut, ROut)+'static,
+    S: FnMut(&D, &R, Tr::Val<'_>, &Tr::Diff)->(DOut, ROut)+'static,
 {
     // No need to block physical merging for this operator.
     arrangement.trace.set_physical_compaction(Antichain::new().borrow());
@@ -51,14 +52,14 @@ where
 
     let mut buffer = Vec::new();
 
-    let mut key: Tr::Key = supplied_key0;
+    let mut key: Tr::KeyOwned = supplied_key0;
     let exchange = Exchange::new(move |update: &(D,G::Timestamp,R)| {
         logic1(&update.0, &mut key);
         key.hashed().into()
     });
 
-    let mut key1: Tr::Key = supplied_key1;
-    let mut key2: Tr::Key = supplied_key2;
+    let mut key1: Tr::KeyOwned = supplied_key1;
+    let mut key2: Tr::KeyOwned = supplied_key2;
 
     prefixes.inner.binary_frontier(&propose_stream, exchange, Pipeline, "LookupMap", move |_,_| move |input1, input2, output| {
 
@@ -96,8 +97,9 @@ where
                     for &mut (ref prefix, ref time, ref mut diff) in prefixes.iter_mut() {
                         if !input2.frontier.less_equal(time) {
                             logic2(prefix, &mut key1);
-                            cursor.seek_key(&storage, &key1);
-                            if cursor.get_key(&storage) == Some(&key1) {
+                            use differential_dataflow::trace::cursor::MyTrait;
+                            cursor.seek_key(&storage, MyTrait::borrow_as(&key1));
+                            if cursor.get_key(&storage) == Some(MyTrait::borrow_as(&key1)) {
                                 while let Some(value) = cursor.get_val(&storage) {
                                     let mut count = Tr::Diff::zero();
                                     cursor.map_times(&storage, |t, d| {

--- a/dogsdogsdogs/src/operators/propose.rs
+++ b/dogsdogsdogs/src/operators/propose.rs
@@ -5,6 +5,7 @@ use differential_dataflow::difference::{Monoid, Multiply};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::TraceReader;
+use differential_dataflow::trace::cursor::MyTrait;
 
 /// Proposes extensions to a prefix stream.
 ///
@@ -18,22 +19,21 @@ pub fn propose<G, Tr, F, P>(
     prefixes: &Collection<G, P, Tr::Diff>,
     arrangement: Arranged<G, Tr>,
     key_selector: F,
-) -> Collection<G, (P, Tr::Val), Tr::Diff>
+) -> Collection<G, (P, Tr::ValOwned), Tr::Diff>
 where
     G: Scope,
     G::Timestamp: Lattice,
     Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
-    Tr::Key: Ord+Hashable+Default,
-    Tr::Val: Clone,
+    Tr::KeyOwned: Hashable + Default,
     Tr::Diff: Monoid+Multiply<Output = Tr::Diff>+ExchangeData,
-    F: Fn(&P)->Tr::Key+Clone+'static,
+    F: Fn(&P)->Tr::KeyOwned+Clone+'static,
     P: ExchangeData,
 {
     crate::operators::lookup_map(
         prefixes,
         arrangement,
-        move |p: &P, k: &mut Tr::Key| { *k = key_selector(p); },
-        |prefix, diff, value, sum| ((prefix.clone(), value.clone()), diff.clone().multiply(sum)),
+        move |p: &P, k: &mut Tr::KeyOwned | { *k = key_selector(p); },
+        |prefix, diff, value, sum| ((prefix.clone(), value.into_owned()), diff.clone().multiply(sum)),
         Default::default(),
         Default::default(),
         Default::default(),
@@ -49,22 +49,21 @@ pub fn propose_distinct<G, Tr, F, P>(
     prefixes: &Collection<G, P, Tr::Diff>,
     arrangement: Arranged<G, Tr>,
     key_selector: F,
-) -> Collection<G, (P, Tr::Val), Tr::Diff>
+) -> Collection<G, (P, Tr::ValOwned), Tr::Diff>
 where
     G: Scope,
     G::Timestamp: Lattice,
     Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
-    Tr::Key: Ord+Hashable+Default,
-    Tr::Val: Clone,
+    Tr::KeyOwned: Hashable + Default,
     Tr::Diff: Monoid+Multiply<Output = Tr::Diff>+ExchangeData,
-    F: Fn(&P)->Tr::Key+Clone+'static,
+    F: Fn(&P)->Tr::KeyOwned+Clone+'static,
     P: ExchangeData,
 {
     crate::operators::lookup_map(
         prefixes,
         arrangement,
-        move |p: &P, k: &mut Tr::Key| { *k = key_selector(p); },
-        |prefix, diff, value, _sum| ((prefix.clone(), value.clone()), diff.clone()),
+        move |p: &P, k: &mut Tr::KeyOwned| { *k = key_selector(p); },
+        |prefix, diff, value, _sum| ((prefix.clone(), value.into_owned()), diff.clone()),
         Default::default(),
         Default::default(),
         Default::default(),

--- a/dogsdogsdogs/src/operators/validate.rs
+++ b/dogsdogsdogs/src/operators/validate.rs
@@ -21,7 +21,7 @@ pub fn validate<G, K, V, Tr, F, P>(
 where
     G: Scope,
     G::Timestamp: Lattice,
-    Tr: TraceReader<Key=(K,V), Val=(), Time=G::Timestamp>+Clone+'static,
+    Tr: TraceReader<KeyOwned=(K,V), ValOwned=(), Time=G::Timestamp>+Clone+'static,
     K: Ord+Hash+Clone+Default,
     V: ExchangeData+Hash+Default,
     Tr::Diff: Monoid+Multiply<Output = Tr::Diff>+ExchangeData,
@@ -32,7 +32,7 @@ where
         extensions,
         arrangement,
         move |(pre,val),key| { *key = (key_selector(pre), val.clone()); },
-        |(pre,val),r,&(),_| ((pre.clone(), val.clone()), r.clone()),
+        |(pre,val),r,_,_| ((pre.clone(), val.clone()), r.clone()),
         Default::default(),
         Default::default(),
         Default::default(),

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -139,6 +139,7 @@ where
     Tr::Val: Debug + Clone,
     Tr::Time: Debug + Clone,
     Tr::Diff: Debug + Clone,
+    <Tr::Cursor as Cursor>::ValOwned: Debug,
 {
     let (mut cursor, storage) = trace.cursor();
     for ((k, v), diffs) in cursor.to_vec(&storage).iter() {

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -139,7 +139,6 @@ where
     Tr::ValOwned: Debug + Clone,
     Tr::Time: Debug + Clone,
     Tr::Diff: Debug + Clone,
-    <Tr::Cursor as Cursor>::ValOwned: Debug,
 {
     let (mut cursor, storage) = trace.cursor();
     for ((k, v), diffs) in cursor.to_vec(&storage).iter() {

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -135,8 +135,8 @@ fn main() {
 fn dump_cursor<Tr>(round: u32, index: usize, trace: &mut Tr)
 where
     Tr: TraceReader,
-    Tr::Key: Debug + Clone,
-    Tr::Val: Debug + Clone,
+    Tr::KeyOwned: Debug + Clone,
+    Tr::ValOwned: Debug + Clone,
     Tr::Time: Debug + Clone,
     Tr::Diff: Debug + Clone,
     <Tr::Cursor as Cursor>::ValOwned: Debug,

--- a/examples/spines.rs
+++ b/examples/spines.rs
@@ -24,33 +24,33 @@ fn main() {
         let mut probe = Handle::new();
         let (mut data_input, mut keys_input) = worker.dataflow(|scope| {
 
-            use differential_dataflow::operators::{arrange::Arrange, JoinCore};
+            use differential_dataflow::operators::{arrange::Arrange, JoinCore, join::join_traces};
 
             let (data_input, data) = scope.new_collection::<String, isize>();
             let (keys_input, keys) = scope.new_collection::<String, isize>();
 
             match mode.as_str() {
-                "new" => {
-                    use differential_dataflow::trace::implementations::ord_neu::ColKeySpine;
-                    let data = data.arrange::<ColKeySpine<_,_,_>>();
-                    let keys = keys.arrange::<ColKeySpine<_,_,_>>();
-                    keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
-                        .probe_with(&mut probe);
-                },
-                "old" => {
-                    use differential_dataflow::trace::implementations::ord_neu::OrdKeySpine;
-                    let data = data.arrange::<OrdKeySpine<_,_,_>>();
-                    let keys = keys.arrange::<OrdKeySpine<_,_,_>>();
-                    keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
-                        .probe_with(&mut probe);
-                },
-                "rhh" => {
-                    use differential_dataflow::trace::implementations::rhh::{HashWrapper, VecSpine};
-                    let data = data.map(|x| HashWrapper { inner: x }).arrange::<VecSpine<_,(),_,_>>();
-                    let keys = keys.map(|x| HashWrapper { inner: x }).arrange::<VecSpine<_,(),_,_>>();
-                    keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
-                        .probe_with(&mut probe);
-                },
+                // "new" => {
+                //     use differential_dataflow::trace::implementations::ord_neu::ColKeySpine;
+                //     let data = data.arrange::<ColKeySpine<_,_,_>>();
+                //     let keys = keys.arrange::<ColKeySpine<_,_,_>>();
+                //     keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
+                //         .probe_with(&mut probe);
+                // },
+                // "old" => {
+                //     use differential_dataflow::trace::implementations::ord_neu::OrdKeySpine;
+                //     let data = data.arrange::<OrdKeySpine<_,_,_>>();
+                //     let keys = keys.arrange::<OrdKeySpine<_,_,_>>();
+                //     keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
+                //         .probe_with(&mut probe);
+                // },
+                // "rhh" => {
+                //     use differential_dataflow::trace::implementations::rhh::{HashWrapper, VecSpine};
+                //     let data = data.map(|x| HashWrapper { inner: x }).arrange::<VecSpine<_,(),_,_>>();
+                //     let keys = keys.map(|x| HashWrapper { inner: x }).arrange::<VecSpine<_,(),_,_>>();
+                //     keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
+                //         .probe_with(&mut probe);
+                // },
                 "slc" => {
 
                     use differential_dataflow::trace::implementations::ord_neu::PreferredSpine;
@@ -58,14 +58,17 @@ fn main() {
 
                     let data =
                     data.map(|x| (x.clone().into_bytes(), x.into_bytes()))
-                        .arrange::<PreferredSpine<[u8],[u8],_,_>>()
-                        .reduce_abelian::<_, PreferredSpine<_,_,_,_>>("distinct", |_,_,output| output.push(((), 1)));
+                        .arrange::<PreferredSpine<[u8],[u8],_,_>>();
+                        // .reduce_abelian::<_, PreferredSpine<[u8],(),_,_>>("distinct", |_,_,output| output.push(((), 1)));
                     let keys =
                     keys.map(|x| (x.clone().into_bytes(), 7))
-                        .arrange::<PreferredSpine<[u8],u8,_,_>>()
-                        .reduce_abelian::<_, PreferredSpine<_,_,_,_>>("distinct", |_,_,output| output.push(((), 1)));
+                        .arrange::<PreferredSpine<[u8],u8,_,_>>();
+                        // .reduce_abelian::<_, PreferredSpine<[u8],(),_,_>>("distinct", |_,_,output| output.push(((), 1)));
 
-                    keys.join_core(&data, |_k,&(),&()| Option::<()>::None)
+                    join_traces(&keys, &data, |k,v1,v2,t,r1,r2| {
+                        println!("{:?}", k.text);
+                        Option::<((),isize,isize)>::None
+                    })
                         .probe_with(&mut probe);
                 },
                 _ => {

--- a/examples/spines.rs
+++ b/examples/spines.rs
@@ -30,20 +30,20 @@ fn main() {
             let (keys_input, keys) = scope.new_collection::<String, isize>();
 
             match mode.as_str() {
-                // "new" => {
-                //     use differential_dataflow::trace::implementations::ord_neu::ColKeySpine;
-                //     let data = data.arrange::<ColKeySpine<_,_,_>>();
-                //     let keys = keys.arrange::<ColKeySpine<_,_,_>>();
-                //     keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
-                //         .probe_with(&mut probe);
-                // },
-                // "old" => {
-                //     use differential_dataflow::trace::implementations::ord_neu::OrdKeySpine;
-                //     let data = data.arrange::<OrdKeySpine<_,_,_>>();
-                //     let keys = keys.arrange::<OrdKeySpine<_,_,_>>();
-                //     keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
-                //         .probe_with(&mut probe);
-                // },
+                "new" => {
+                    use differential_dataflow::trace::implementations::ord_neu::ColKeySpine;
+                    let data = data.arrange::<ColKeySpine<_,_,_>>();
+                    let keys = keys.arrange::<ColKeySpine<_,_,_>>();
+                    keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
+                        .probe_with(&mut probe);
+                },
+                "old" => {
+                    use differential_dataflow::trace::implementations::ord_neu::OrdKeySpine;
+                    let data = data.arrange::<OrdKeySpine<_,_,_>>();
+                    let keys = keys.arrange::<OrdKeySpine<_,_,_>>();
+                    keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
+                        .probe_with(&mut probe);
+                },
                 // "rhh" => {
                 //     use differential_dataflow::trace::implementations::rhh::{HashWrapper, VecSpine};
                 //     let data = data.map(|x| HashWrapper { inner: x }).arrange::<VecSpine<_,(),_,_>>();

--- a/src/algorithms/graphs/bfs.rs
+++ b/src/algorithms/graphs/bfs.rs
@@ -29,7 +29,7 @@ where
     G: Scope,
     G::Timestamp: Lattice+Ord,
     N: ExchangeData+Hash,
-    Tr: TraceReader<Key=N, Val=N, Time=G::Timestamp, Diff=isize>+Clone+'static,
+    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Time=G::Timestamp, Diff=isize>+Clone+'static,
 {
     // initialize roots as reaching themselves at distance 0
     let nodes = roots.map(|x| (x, 0));

--- a/src/algorithms/graphs/bijkstra.rs
+++ b/src/algorithms/graphs/bijkstra.rs
@@ -45,7 +45,7 @@ where
     G: Scope,
     G::Timestamp: Lattice+Ord,
     N: ExchangeData+Hash,
-    Tr: TraceReader<Key=N, Val=N, Time=G::Timestamp, Diff=isize>+Clone+'static,
+    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Time=G::Timestamp, Diff=isize>+Clone+'static,
 {
     forward
         .stream

--- a/src/algorithms/graphs/propagate.rs
+++ b/src/algorithms/graphs/propagate.rs
@@ -5,7 +5,6 @@ use std::hash::Hash;
 use timely::dataflow::*;
 
 use ::{Collection, ExchangeData};
-use ::operators::*;
 use ::lattice::Lattice;
 use ::difference::{Abelian, Multiply};
 use ::operators::arrange::arrangement::ArrangeByKey;
@@ -64,7 +63,7 @@ where
     R: Multiply<R, Output=R>,
     R: From<i8>,
     L: ExchangeData,
-    Tr: TraceReader<Key=N, Val=N, Time=G::Timestamp, Diff=R>+Clone+'static,
+    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Time=G::Timestamp, Diff=R>+Clone+'static,
     F: Fn(&L)->u64+Clone+'static,
 {
     // Morally the code performs the following iterative computation. However, in the interest of a simplified
@@ -90,6 +89,8 @@ where
 
         use timely::order::Product;
 
+        use operators::join::JoinCore;
+        
         let edges = edges.enter(scope);
         let nodes = nodes.enter_at(scope, move |r| 256 * (64 - (logic(&r.1)).leading_zeros() as usize));
 

--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -47,8 +47,10 @@ where
     Tr: TraceReader,
     Tr::Time: Lattice+Ord+Clone+'static,
 {
-    type Key = Tr::Key;
-    type Val = Tr::Val;
+    type Key<'a> = Tr::Key<'a>;
+    type KeyOwned = Tr::KeyOwned;
+    type Val<'a> = Tr::Val<'a>;
+    type ValOwned = Tr::ValOwned;
     type Time = Tr::Time;
     type Diff = Tr::Diff;
 

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -37,6 +37,8 @@ use trace::wrappers::enter_at::TraceEnter as TraceEnterAt;
 use trace::wrappers::enter_at::BatchEnter as BatchEnterAt;
 use trace::wrappers::filter::{TraceFilter, BatchFilter};
 
+use trace::cursor::MyTrait;
+
 use super::TraceAgent;
 
 /// An arranged collection of `(K,V)` values.
@@ -89,8 +91,6 @@ where
     pub fn enter<'a, TInner>(&self, child: &Child<'a, G, TInner>)
         -> Arranged<Child<'a, G, TInner>, TraceEnter<Tr, TInner>>
         where
-            Tr::Key: 'static,
-            Tr::Val: 'static,
             Tr::Diff: 'static,
             G::Timestamp: Clone+'static,
             TInner: Refines<G::Timestamp>+Lattice+Timestamp+Clone+'static,
@@ -108,8 +108,6 @@ where
     pub fn enter_region<'a>(&self, child: &Child<'a, G, G::Timestamp>)
         -> Arranged<Child<'a, G, G::Timestamp>, Tr>
         where
-            Tr::Key: 'static,
-            Tr::Val: 'static,
             Tr::Diff: 'static,
             G::Timestamp: Clone+'static,
     {
@@ -127,12 +125,10 @@ where
     pub fn enter_at<'a, TInner, F, P>(&self, child: &Child<'a, G, TInner>, logic: F, prior: P)
         -> Arranged<Child<'a, G, TInner>, TraceEnterAt<Tr, TInner, F, P>>
         where
-            Tr::Key: 'static,
-            Tr::Val: 'static,
             Tr::Diff: 'static,
             G::Timestamp: Clone+'static,
             TInner: Refines<G::Timestamp>+Lattice+Timestamp+Clone+'static,
-            F: FnMut(&Tr::Key, &Tr::Val, &G::Timestamp)->TInner+Clone+'static,
+            F: for <'b> FnMut(Tr::Key<'b>, Tr::Val<'b>, &G::Timestamp)->TInner+Clone+'static,
             P: FnMut(&TInner)->Tr::Time+Clone+'static,
         {
         let logic1 = logic.clone();
@@ -177,11 +173,9 @@ where
     pub fn filter<F>(&self, logic: F)
         -> Arranged<G, TraceFilter<Tr, F>>
         where
-            Tr::Key: 'static,
-            Tr::Val: 'static,
             Tr::Diff: 'static,
             G::Timestamp: Clone+'static,
-            F: FnMut(&Tr::Key, &Tr::Val)->bool+Clone+'static,
+            F: for<'a> FnMut(Tr::Key<'a>, Tr::Val<'a>)->bool+Clone+'static,
     {
         let logic1 = logic.clone();
         let logic2 = logic.clone();
@@ -198,7 +192,7 @@ where
     pub fn as_collection<D: Data, L>(&self, mut logic: L) -> Collection<G, D, Tr::Diff>
         where
             Tr::Diff: Semigroup,
-            L: FnMut(&Tr::Key, &Tr::Val) -> D+'static,
+            L: for<'a> FnMut(Tr::Key<'a>, Tr::Val<'a>) -> D+'static,
     {
         self.flat_map_ref(move |key, val| Some(logic(key,val)))
     }
@@ -212,7 +206,7 @@ where
             Tr::Diff: Semigroup,
             I: IntoIterator,
             I::Item: Data,
-            L: FnMut(&Tr::Key, &Tr::Val) -> I+'static,
+            L: for<'a> FnMut(Tr::Key<'a>, Tr::Val<'a>) -> I+'static,
     {
         Self::flat_map_batches(&self.stream, logic)
     }
@@ -229,7 +223,7 @@ where
         Tr::Diff: Semigroup,
         I: IntoIterator,
         I::Item: Data,
-        L: FnMut(&Tr::Key, &Tr::Val) -> I+'static,
+        L: for<'a> FnMut(Tr::Key<'a>, Tr::Val<'a>) -> I+'static,
     {
         stream.unary(Pipeline, "AsCollection", move |_,_| move |input, output| {
             input.for_each(|time, data| {
@@ -258,16 +252,16 @@ where
     ///
     /// This method consumes a stream of (key, time) queries and reports the corresponding stream of
     /// (key, value, time, diff) accumulations in the `self` trace.
-    pub fn lookup(&self, queries: &Stream<G, (Tr::Key, G::Timestamp)>) -> Stream<G, (Tr::Key, Tr::Val, G::Timestamp, Tr::Diff)>
+    pub fn lookup(&self, queries: &Stream<G, (Tr::KeyOwned, G::Timestamp)>) -> Stream<G, (Tr::KeyOwned, Tr::ValOwned, G::Timestamp, Tr::Diff)>
     where
         G::Timestamp: Data+Lattice+Ord+TotalOrder,
-        Tr::Key: ExchangeData+Hashable,
-        Tr::Val: ExchangeData,
+        Tr::KeyOwned: ExchangeData+Hashable,
+        Tr::ValOwned: ExchangeData,
         Tr::Diff: ExchangeData+Semigroup,
         Tr: 'static,
     {
         // while the arrangement is already correctly distributed, the query stream may not be.
-        let exchange = Exchange::new(move |update: &(Tr::Key,G::Timestamp)| update.0.hashed().into());
+        let exchange = Exchange::new(move |update: &(Tr::KeyOwned,G::Timestamp)| update.0.hashed().into());
         queries.binary_frontier(&self.stream, exchange, Pipeline, "TraceQuery", move |_capability, _info| {
 
             let mut trace = Some(self.trace.clone());
@@ -280,8 +274,8 @@ where
             let mut active = Vec::new();
             let mut retain = Vec::new();
 
-            let mut working: Vec<(G::Timestamp, Tr::Val, Tr::Diff)> = Vec::new();
-            let mut working2: Vec<(Tr::Val, Tr::Diff)> = Vec::new();
+            let mut working: Vec<(G::Timestamp, Tr::ValOwned, Tr::Diff)> = Vec::new();
+            let mut working2: Vec<(Tr::ValOwned, Tr::Diff)> = Vec::new();
 
             move |input1, input2, output| {
 
@@ -346,13 +340,13 @@ where
                                 same_key += 1;
                             }
 
-                            cursor.seek_key(&storage, key);
-                            if cursor.get_key(&storage) == Some(key) {
+                            cursor.seek_key_owned(&storage, key);
+                            if cursor.get_key(&storage).map(|k| k.equals(key)).unwrap_or(false) {
 
                                 let mut active = &active[active_finger .. same_key];
 
                                 while let Some(val) = cursor.get_val(&storage) {
-                                    cursor.map_times(&storage, |t,d| working.push((t.clone(), val.clone(), d.clone())));
+                                    cursor.map_times(&storage, |t,d| working.push((t.clone(), val.into_owned(), d.clone())));
                                     cursor.step_val(&storage);
                                 }
 

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -128,7 +128,7 @@ where
             Tr::Diff: 'static,
             G::Timestamp: Clone+'static,
             TInner: Refines<G::Timestamp>+Lattice+Timestamp+Clone+'static,
-            F: for <'b> FnMut(Tr::Key<'b>, Tr::Val<'b>, &G::Timestamp)->TInner+Clone+'static,
+            F: FnMut(Tr::Key<'_>, Tr::Val<'_>, &G::Timestamp)->TInner+Clone+'static,
             P: FnMut(&TInner)->Tr::Time+Clone+'static,
         {
         let logic1 = logic.clone();
@@ -175,7 +175,7 @@ where
         where
             Tr::Diff: 'static,
             G::Timestamp: Clone+'static,
-            F: for<'a> FnMut(Tr::Key<'a>, Tr::Val<'a>)->bool+Clone+'static,
+            F: FnMut(Tr::Key<'_>, Tr::Val<'_>)->bool+Clone+'static,
     {
         let logic1 = logic.clone();
         let logic2 = logic.clone();
@@ -192,7 +192,7 @@ where
     pub fn as_collection<D: Data, L>(&self, mut logic: L) -> Collection<G, D, Tr::Diff>
         where
             Tr::Diff: Semigroup,
-            L: for<'a> FnMut(Tr::Key<'a>, Tr::Val<'a>) -> D+'static,
+            L: FnMut(Tr::Key<'_>, Tr::Val<'_>) -> D+'static,
     {
         self.flat_map_ref(move |key, val| Some(logic(key,val)))
     }
@@ -206,7 +206,7 @@ where
             Tr::Diff: Semigroup,
             I: IntoIterator,
             I::Item: Data,
-            L: for<'a> FnMut(Tr::Key<'a>, Tr::Val<'a>) -> I+'static,
+            L: FnMut(Tr::Key<'_>, Tr::Val<'_>) -> I+'static,
     {
         Self::flat_map_batches(&self.stream, logic)
     }
@@ -223,7 +223,7 @@ where
         Tr::Diff: Semigroup,
         I: IntoIterator,
         I::Item: Data,
-        L: for<'a> FnMut(Tr::Key<'a>, Tr::Val<'a>) -> I+'static,
+        L: FnMut(Tr::Key<'_>, Tr::Val<'_>) -> I+'static,
     {
         stream.unary(Pipeline, "AsCollection", move |_,_| move |input, output| {
             input.for_each(|time, data| {

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -56,7 +56,7 @@ where
     /// As `consolidate` but with the ability to name the operator and specify the trace type.
     pub fn consolidate_named<Tr>(&self, name: &str) -> Self
     where
-        Tr: crate::trace::Trace+crate::trace::TraceReader<Key=D,Val=(),Time=G::Timestamp,Diff=R>+'static,
+        Tr: for<'a> crate::trace::Trace<Key<'a>=&'a D,Val<'a>=&'a (),Time=G::Timestamp,Diff=R>+'static,
         Tr::Batch: crate::trace::Batch,
         Tr::Batcher: Batcher<Item = ((D,()),G::Timestamp,R), Time = G::Timestamp>,
         Tr::Builder: Builder<Item = ((D,()),G::Timestamp,R), Time = G::Timestamp>,

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -55,14 +55,14 @@ where G::Timestamp: TotalOrder+Lattice+Ord {
     }
 }
 
-impl<G: Scope, K, T1> CountTotal<G, K, T1::Diff> for Arranged<G, T1>
+impl<G: Scope, T1> CountTotal<G, T1::KeyOwned, T1::Diff> for Arranged<G, T1>
 where
     G::Timestamp: TotalOrder+Lattice+Ord,
-    T1: for<'a> TraceReader<Key<'a>=&'a K, Val<'a>=&'a (), Time=G::Timestamp>+Clone+'static,
-    K: ExchangeData,
+    T1: for<'a> TraceReader<Val<'a>=&'a (), Time=G::Timestamp>+Clone+'static,
+    T1::KeyOwned: ExchangeData,
     T1::Diff: ExchangeData+Semigroup,
 {
-    fn count_total_core<R2: Semigroup + From<i8>>(&self) -> Collection<G, (K, T1::Diff), R2> {
+    fn count_total_core<R2: Semigroup + From<i8>>(&self) -> Collection<G, (T1::KeyOwned, T1::Diff), R2> {
 
         let mut trace = self.trace.clone();
         let mut buffer = Vec::new();
@@ -74,6 +74,7 @@ where
 
             move |input, output| {
 
+                use trace::cursor::MyTrait;
                 input.for_each(|capability, batches| {
                     batches.swap(&mut buffer);
                     let mut session = output.session(&capability);
@@ -97,14 +98,14 @@ where
 
                                 if let Some(count) = count.as_ref() {
                                     if !count.is_zero() {
-                                        session.give(((key.clone(), count.clone()), time.clone(), R2::from(-1i8)));
+                                        session.give(((key.into_owned(), count.clone()), time.clone(), R2::from(-1i8)));
                                     }
                                 }
                                 count.as_mut().map(|c| c.plus_equals(diff));
                                 if count.is_none() { count = Some(diff.clone()); }
                                 if let Some(count) = count.as_ref() {
                                     if !count.is_zero() {
-                                        session.give(((key.clone(), count.clone()), time.clone(), R2::from(1i8)));
+                                        session.give(((key.into_owned(), count.clone()), time.clone(), R2::from(1i8)));
                                     }
                                 }
                             });

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -55,14 +55,14 @@ where G::Timestamp: TotalOrder+Lattice+Ord {
     }
 }
 
-impl<G: Scope, T1> CountTotal<G, T1::Key, T1::Diff> for Arranged<G, T1>
+impl<G: Scope, K, T1> CountTotal<G, K, T1::Diff> for Arranged<G, T1>
 where
     G::Timestamp: TotalOrder+Lattice+Ord,
-    T1: TraceReader<Val=(), Time=G::Timestamp>+Clone+'static,
-    T1::Key: ExchangeData,
+    T1: for<'a> TraceReader<Key<'a>=&'a K, Val<'a>=&'a (), Time=G::Timestamp>+Clone+'static,
+    K: ExchangeData,
     T1::Diff: ExchangeData+Semigroup,
 {
-    fn count_total_core<R2: Semigroup + From<i8>>(&self) -> Collection<G, (T1::Key, T1::Diff), R2> {
+    fn count_total_core<R2: Semigroup + From<i8>>(&self) -> Collection<G, (K, T1::Diff), R2> {
 
         let mut trace = self.trace.clone();
         let mut buffer = Vec::new();

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -357,8 +357,8 @@ impl<G, K, V, T1> JoinCore<G, K, V, T1::Diff> for Arranged<G,T1>
         G: Scope,
         G::Timestamp: Lattice+Ord,
         T1: for<'a> TraceReader<Key<'a> = &'a K, Val<'a> = &'a V, Time=G::Timestamp>+Clone+'static,
-        K: Ord+'static + ?Sized,
-        V: Ord+'static + ?Sized,
+        K: Ord+'static,
+        V: Ord+'static,
         T1::Diff: Semigroup,
 {
     fn join_core<Tr2,I,L>(&self, other: &Arranged<G,Tr2>, mut result: L) -> Collection<G,I::Item,<T1::Diff as Multiply<Tr2::Diff>>::Output>
@@ -796,7 +796,7 @@ where
         }
     }
 
-    fn think<'b, F: FnMut(C1::Val<'a>,C2::Val<'a>,C1::Time,&C1::Diff,&C2::Diff)>(&'b mut self, mut results: F) {
+    fn think<F: FnMut(C1::Val<'a>,C2::Val<'a>,C1::Time,&C1::Diff,&C2::Diff)>(&mut self, mut results: F) {
 
         // for reasonably sized edits, do the dead-simple thing.
         if self.history1.edits.len() < 10 || self.history2.edits.len() < 10 {

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -91,7 +91,6 @@ struct ValueHistory<'storage, C: Cursor> where C::Time: Sized, C::Diff: Sized {
 
 impl<'storage, C: Cursor> ValueHistory<'storage, C>
 where
-    // C::Val: Ord+'storage,
     C::Time: Lattice+Ord+Clone,
     C::Diff: Semigroup,
 {
@@ -136,7 +135,7 @@ where
     }
 
     /// Organizes history based on current contents of edits.
-    fn replay<'history>(&'history mut self) -> HistoryReplay<'storage, 'history, C> where 'storage: 'history {
+    fn replay<'history>(&'history mut self) -> HistoryReplay<'storage, 'history, C> {
 
         self.buffer.clear();
         self.history.clear();
@@ -164,7 +163,6 @@ struct HistoryReplay<'storage, 'history, C>
 where
     'storage: 'history,
     C: Cursor,
-    // C::Val: Ord+'storage,
     C::Time: Lattice+Ord+Clone+'history,
     C::Diff: Semigroup+'history,
 {
@@ -175,13 +173,12 @@ impl<'storage, 'history, C> HistoryReplay<'storage, 'history, C>
 where
     'storage: 'history,
     C: Cursor,
-    // C::Val: Ord+'storage,
     C::Time: Lattice+Ord+Clone+'history,
     C::Diff: Semigroup+'history,
 {
     fn time(&self) -> Option<&C::Time> { self.replay.history.last().map(|x| &x.0) }
     fn meet(&self) -> Option<&C::Time> { self.replay.history.last().map(|x| &x.1) }
-    fn edit<'s>(&'s self) -> Option<(C::Val<'storage>, &'s C::Time, &'s C::Diff)> {
+    fn edit(&self) -> Option<(C::Val<'storage>, &C::Time, &C::Diff)> {
         self.replay.history.last().map(|&(ref t, _, v, e)| (self.replay.edits.values[v].0, t, &self.replay.edits.edits[e].1))
     }
 

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -121,11 +121,10 @@ where
         &'history mut self,
         cursor: &mut C,
         storage: &'storage C::Storage,
-        key: &C::Key,
+        key: C::Key<'storage>,
         logic: L
     ) -> HistoryReplay<'storage, 'history, C>
     where
-        C::Key: Eq,
         L: Fn(&C::Time)->C::Time,
     {
         self.clear();

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -24,7 +24,7 @@ use trace::Cursor;
 
 /// An accumulation of (value, time, diff) updates.
 struct EditList<'a, C: Cursor> where C::Time: Sized, C::Diff: Sized {
-    values: Vec<(&'a C::Val, usize)>,
+    values: Vec<(C::Val<'a>, usize)>,
     edits: Vec<(C::Time, C::Diff)>,
 }
 
@@ -64,19 +64,19 @@ impl<'a, C: Cursor> EditList<'a, C> where C::Time: Ord+Clone, C::Diff: Semigroup
     }
     /// Associates all edits pushed since the previous `seal_value` call with `value`.
     #[inline]
-    fn seal(&mut self, value: &'a C::Val) {
+    fn seal(&mut self, value: C::Val<'a>) {
         let prev = self.values.last().map(|x| x.1).unwrap_or(0);
         crate::consolidation::consolidate_from(&mut self.edits, prev);
         if self.edits.len() > prev {
             self.values.push((value, self.edits.len()));
         }
     }
-    fn map<F: FnMut(&C::Val, &C::Time, &C::Diff)>(&self, mut logic: F) {
+    fn map<F: FnMut(C::Val<'a>, &C::Time, &C::Diff)>(&self, mut logic: F) {
         for index in 0 .. self.values.len() {
             let lower = if index == 0 { 0 } else { self.values[index-1].1 };
             let upper = self.values[index].1;
             for edit in lower .. upper {
-                logic(&self.values[index].0, &self.edits[edit].0, &self.edits[edit].1);
+                logic(self.values[index].0, &self.edits[edit].0, &self.edits[edit].1);
             }
         }
     }
@@ -86,12 +86,12 @@ struct ValueHistory<'storage, C: Cursor> where C::Time: Sized, C::Diff: Sized {
 
     edits: EditList<'storage, C>,
     history: Vec<(C::Time, C::Time, usize, usize)>,     // (time, meet, value_index, edit_offset)
-    buffer: Vec<((&'storage C::Val, C::Time), C::Diff)>,   // where we accumulate / collapse updates.
+    buffer: Vec<((C::Val<'storage>, C::Time), C::Diff)>,   // where we accumulate / collapse updates.
 }
 
 impl<'storage, C: Cursor> ValueHistory<'storage, C>
 where
-    C::Val: Ord+'storage,
+    // C::Val: Ord+'storage,
     C::Time: Lattice+Ord+Clone,
     C::Diff: Semigroup,
 {
@@ -137,7 +137,7 @@ where
     }
 
     /// Organizes history based on current contents of edits.
-    fn replay<'history>(&'history mut self) -> HistoryReplay<'storage, 'history, C> {
+    fn replay<'history>(&'history mut self) -> HistoryReplay<'storage, 'history, C> where 'storage: 'history {
 
         self.buffer.clear();
         self.history.clear();
@@ -165,7 +165,7 @@ struct HistoryReplay<'storage, 'history, C>
 where
     'storage: 'history,
     C: Cursor,
-    C::Val: Ord+'storage,
+    // C::Val: Ord+'storage,
     C::Time: Lattice+Ord+Clone+'history,
     C::Diff: Semigroup+'history,
 {
@@ -176,17 +176,17 @@ impl<'storage, 'history, C> HistoryReplay<'storage, 'history, C>
 where
     'storage: 'history,
     C: Cursor,
-    C::Val: Ord+'storage,
+    // C::Val: Ord+'storage,
     C::Time: Lattice+Ord+Clone+'history,
     C::Diff: Semigroup+'history,
 {
     fn time(&self) -> Option<&C::Time> { self.replay.history.last().map(|x| &x.0) }
     fn meet(&self) -> Option<&C::Time> { self.replay.history.last().map(|x| &x.1) }
-    fn edit(&self) -> Option<(&C::Val, &C::Time, &C::Diff)> {
+    fn edit<'s>(&'s self) -> Option<(C::Val<'storage>, &'s C::Time, &'s C::Diff)> {
         self.replay.history.last().map(|&(ref t, _, v, e)| (self.replay.edits.values[v].0, t, &self.replay.edits.edits[e].1))
     }
 
-    fn buffer(&self) -> &[((&'storage C::Val, C::Time), C::Diff)] {
+    fn buffer(&self) -> &[((C::Val<'storage>, C::Time), C::Diff)] {
         &self.replay.buffer[..]
     }
 

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -102,17 +102,17 @@ where G::Timestamp: TotalOrder+Lattice+Ord {
     }
 }
 
-impl<G: Scope, T1> ThresholdTotal<G, T1::Key, T1::Diff> for Arranged<G, T1>
+impl<G: Scope, K, T1> ThresholdTotal<G, K, T1::Diff> for Arranged<G, T1>
 where
     G::Timestamp: TotalOrder+Lattice+Ord,
-    T1: TraceReader<Val=(), Time=G::Timestamp>+Clone+'static,
-    T1::Key: ExchangeData,
+    T1: for<'a> TraceReader<Key<'a>=&'a K, Val<'a>=&'a (), Time=G::Timestamp>+Clone+'static,
+    K: ExchangeData,
     T1::Diff: ExchangeData+Semigroup,
 {
-    fn threshold_semigroup<R2, F>(&self, mut thresh: F) -> Collection<G, T1::Key, R2>
+    fn threshold_semigroup<R2, F>(&self, mut thresh: F) -> Collection<G, K, R2>
     where
         R2: Semigroup,
-        F: FnMut(&T1::Key,&T1::Diff,Option<&T1::Diff>)->Option<R2>+'static,
+        F: for<'a> FnMut(T1::Key<'a>,&T1::Diff,Option<&T1::Diff>)->Option<R2>+'static,
     {
 
         let mut trace = self.trace.clone();

--- a/src/trace/cursor/cursor_list.rs
+++ b/src/trace/cursor/cursor_list.rs
@@ -130,7 +130,7 @@ impl<C: Cursor> Cursor for CursorList<C> {
         self.minimize_keys(storage);
     }
     #[inline]
-    fn seek_key<'a>(&mut self, storage: &Vec<C::Storage>, key: Self::Key<'a>) {
+    fn seek_key(&mut self, storage: &Vec<C::Storage>, key: Self::Key<'_>) {
         for index in 0 .. self.cursors.len() {
             self.cursors[index].seek_key(&storage[index], key);
         }
@@ -146,7 +146,7 @@ impl<C: Cursor> Cursor for CursorList<C> {
         self.minimize_vals(storage);
     }
     #[inline]
-    fn seek_val<'a>(&mut self, storage: &Vec<C::Storage>, val: Self::Val<'a>) {
+    fn seek_val(&mut self, storage: &Vec<C::Storage>, val: Self::Val<'_>) {
         for &index in self.min_key.iter() {
             self.cursors[index].seek_val(&storage[index], val);
         }

--- a/src/trace/cursor/cursor_list.rs
+++ b/src/trace/cursor/cursor_list.rs
@@ -13,11 +13,7 @@ pub struct CursorList<C> {
     min_val: Vec<usize>,
 }
 
-impl<C> CursorList<C>
-where
-    C: Cursor, 
-    C::Key: Ord, 
-{
+impl<C: Cursor> CursorList<C> {
     /// Creates a new cursor list from pre-existing cursors.
     pub fn new(cursors: Vec<C>, storage: &[C::Storage]) -> Self  {
         let mut result = CursorList {
@@ -88,11 +84,9 @@ where
     }
 }
 
-impl<C: Cursor> Cursor for CursorList<C>
-where
-    C::Key: Ord,
-{
-    type Key = C::Key;
+impl<C: Cursor> Cursor for CursorList<C> {
+    type Key<'a> = C::Key<'a>;
+    type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
     type ValOwned = C::ValOwned;
     type Time = C::Time;
@@ -108,7 +102,7 @@ where
 
     // accessors
     #[inline]
-    fn key<'a>(&self, storage: &'a Vec<C::Storage>) -> &'a Self::Key {
+    fn key<'a>(&self, storage: &'a Vec<C::Storage>) -> Self::Key<'a> {
         debug_assert!(self.key_valid(storage));
         debug_assert!(self.cursors[self.min_key[0]].key_valid(&storage[self.min_key[0]]));
         self.cursors[self.min_key[0]].key(&storage[self.min_key[0]])
@@ -136,7 +130,7 @@ where
         self.minimize_keys(storage);
     }
     #[inline]
-    fn seek_key(&mut self, storage: &Vec<C::Storage>, key: &Self::Key) {
+    fn seek_key<'a>(&mut self, storage: &Vec<C::Storage>, key: Self::Key<'a>) {
         for index in 0 .. self.cursors.len() {
             self.cursors[index].seek_key(&storage[index], key);
         }

--- a/src/trace/cursor/cursor_list.rs
+++ b/src/trace/cursor/cursor_list.rs
@@ -17,7 +17,6 @@ impl<C> CursorList<C>
 where
     C: Cursor, 
     C::Key: Ord, 
-    C::Val: Ord,
 {
     /// Creates a new cursor list from pre-existing cursors.
     pub fn new(cursors: Vec<C>, storage: &[C::Storage]) -> Self  {
@@ -92,10 +91,10 @@ where
 impl<C: Cursor> Cursor for CursorList<C>
 where
     C::Key: Ord,
-    C::Val: Ord,
 {
     type Key = C::Key;
-    type Val = C::Val;
+    type Val<'a> = C::Val<'a>;
+    type ValOwned = C::ValOwned;
     type Time = C::Time;
     type Diff = C::Diff;
 
@@ -115,7 +114,7 @@ where
         self.cursors[self.min_key[0]].key(&storage[self.min_key[0]])
     }
     #[inline]
-    fn val<'a>(&self, storage: &'a Vec<C::Storage>) -> &'a Self::Val {
+    fn val<'a>(&self, storage: &'a Vec<C::Storage>) -> Self::Val<'a> {
         debug_assert!(self.key_valid(storage));
         debug_assert!(self.val_valid(storage));
         debug_assert!(self.cursors[self.min_val[0]].val_valid(&storage[self.min_val[0]]));
@@ -153,7 +152,7 @@ where
         self.minimize_vals(storage);
     }
     #[inline]
-    fn seek_val(&mut self, storage: &Vec<C::Storage>, val: &Self::Val) {
+    fn seek_val<'a>(&mut self, storage: &Vec<C::Storage>, val: Self::Val<'a>) {
         for &index in self.min_key.iter() {
             self.cursors[index].seek_val(&storage[index], val);
         }

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -12,33 +12,56 @@ pub mod cursor_list;
 pub use self::cursor_list::CursorList;
 
 use std::borrow::Borrow;
+use std::cmp::Ordering;
+
 /// A type that may be converted into and compared with another type.
 ///
 /// The type must also be comparable with itself, and follow the same 
 /// order as if converting instances to `T` and comparing the results.
-pub trait MyTrait : Ord {
+pub trait MyTrait<'a> : Ord {
     /// Owned type into which this type can be converted.
     type Owned;
     /// Conversion from an instance of this type to the owned type.
-    fn to_owned(self) -> Self::Owned;
+    fn into_owned(self) -> Self::Owned;
+    ///
+    fn clone_onto(&self, other: &mut Self::Owned); 
     /// Indicates that `self <= other`; used for sorting.
-    fn less_equal(&self, other: &Self::Owned) -> bool;
+    fn compare(&self, other: &Self::Owned) -> Ordering;
+    /// `self <= other`
+    fn less_equals(&self, other: &Self::Owned) -> bool {
+        self.compare(other) != Ordering::Greater
+    }
+    /// `self == other`
+    fn equals(&self, other: &Self::Owned) -> bool {
+        self.compare(other) == Ordering::Equal
+    }
+    /// `self < other`
+    fn less_than(&self, other: &Self::Owned) -> bool {
+        self.compare(other) == Ordering::Less
+    }
+    /// Borrows an owned instance as onesself.
+    fn borrow_as(other: &'a Self::Owned) -> Self; 
 }
 
-impl<'a, T: Ord+ToOwned+?Sized> MyTrait for &'a T {
+impl<'a, T: Ord+ToOwned+?Sized> MyTrait<'a> for &'a T {
     type Owned = T::Owned;
-    fn to_owned(self) -> Self::Owned { self.to_owned() }
-    fn less_equal(&self, other: &Self::Owned) -> bool { self.le(&other.borrow()) }
+    fn into_owned(self) -> Self::Owned { self.to_owned() }
+    fn clone_onto(&self, other: &mut Self::Owned) { <T as ToOwned>::clone_into(self, other) }
+    fn compare(&self, other: &Self::Owned) -> Ordering { self.cmp(&other.borrow()) }
+    fn borrow_as(other: &'a Self::Owned) -> Self {
+        other.borrow()
+    }
 }
-
 
 /// A cursor for navigating ordered `(key, val, time, diff)` updates.
 pub trait Cursor {
 
     /// Key by which updates are indexed.
-    type Key: ?Sized;
+    type Key<'a>: Copy + Clone + MyTrait<'a, Owned = Self::KeyOwned>;
+    /// Owned version of the above.
+    type KeyOwned: Ord + Clone;
     /// Values associated with keys.
-    type Val<'a>: Copy + Clone + MyTrait<Owned = Self::ValOwned>;
+    type Val<'a>: Copy + Clone + MyTrait<'a, Owned = Self::ValOwned> + for<'b> PartialOrd<Self::Val<'b>>;
     /// Owned version of the above.
     type ValOwned: Ord + Clone;
     /// Timestamps associated with updates
@@ -59,12 +82,12 @@ pub trait Cursor {
     fn val_valid(&self, storage: &Self::Storage) -> bool;
 
     /// A reference to the current key. Asserts if invalid.
-    fn key<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Key;
+    fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a>;
     /// A reference to the current value. Asserts if invalid.
     fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a>;
 
     /// Returns a reference to the current key, if valid.
-    fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<&'a Self::Key> {
+    fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> {
         if self.key_valid(storage) { Some(self.key(storage)) } else { None }
     }
     /// Returns a reference to the current value, if valid.
@@ -79,7 +102,11 @@ pub trait Cursor {
     /// Advances the cursor to the next key.
     fn step_key(&mut self, storage: &Self::Storage);
     /// Advances the cursor to the specified key.
-    fn seek_key(&mut self, storage: &Self::Storage, key: &Self::Key);
+    fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>);
+    /// Convenience method to get access by reference to an owned key.
+    fn seek_key_owned<'a>(&mut self, storage: &Self::Storage, key: &'a Self::KeyOwned) {
+        self.seek_key(storage, <Self::Key<'a> as MyTrait<'a>>::borrow_as(key));
+    }
 
     /// Advances the cursor to the next value.
     fn step_val(&mut self, storage: &Self::Storage);
@@ -92,9 +119,8 @@ pub trait Cursor {
     fn rewind_vals(&mut self, storage: &Self::Storage);
 
     /// Rewinds the cursor and outputs its contents to a Vec
-    fn to_vec(&mut self, storage: &Self::Storage) -> Vec<((Self::Key, Self::ValOwned), Vec<(Self::Time, Self::Diff)>)>
+    fn to_vec(&mut self, storage: &Self::Storage) -> Vec<((Self::KeyOwned, Self::ValOwned), Vec<(Self::Time, Self::Diff)>)>
     where
-        Self::Key: Clone,
         Self::Time: Clone,
         Self::Diff: Clone,
     {
@@ -107,7 +133,7 @@ pub trait Cursor {
                 self.map_times(storage, |ts, r| {
                     kv_out.push((ts.clone(), r.clone()));
                 });
-                out.push(((self.key(storage).clone(), self.val(storage).to_owned()), kv_out));
+                out.push(((self.key(storage).into_owned(), self.val(storage).into_owned()), kv_out));
                 self.step_val(storage);
             }
             self.step_key(storage);

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -102,16 +102,16 @@ pub trait Cursor {
     /// Advances the cursor to the next key.
     fn step_key(&mut self, storage: &Self::Storage);
     /// Advances the cursor to the specified key.
-    fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>);
+    fn seek_key(&mut self, storage: &Self::Storage, key: Self::Key<'_>);
     /// Convenience method to get access by reference to an owned key.
-    fn seek_key_owned<'a>(&mut self, storage: &Self::Storage, key: &'a Self::KeyOwned) {
-        self.seek_key(storage, <Self::Key<'a> as MyTrait<'a>>::borrow_as(key));
+    fn seek_key_owned(&mut self, storage: &Self::Storage, key: &Self::KeyOwned) {
+        self.seek_key(storage, MyTrait::borrow_as(key));
     }
 
     /// Advances the cursor to the next value.
     fn step_val(&mut self, storage: &Self::Storage);
     /// Advances the cursor to the specified value.
-    fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>);
+    fn seek_val(&mut self, storage: &Self::Storage, val: Self::Val<'_>);
 
     /// Rewinds the cursor to the first key.
     fn rewind_keys(&mut self, storage: &Self::Storage);

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -6,10 +6,31 @@
 //! supports efficient seeking (via the `seek_key` and `seek_val` methods).
 
 // pub mod cursor_list;
-pub mod cursor_pair;
+// pub mod cursor_pair;
 pub mod cursor_list;
 
 pub use self::cursor_list::CursorList;
+
+use std::borrow::Borrow;
+/// A type that may be converted into and compared with another type.
+///
+/// The type must also be comparable with itself, and follow the same 
+/// order as if converting instances to `T` and comparing the results.
+pub trait MyTrait : Ord {
+    /// Owned type into which this type can be converted.
+    type Owned;
+    /// Conversion from an instance of this type to the owned type.
+    fn to_owned(self) -> Self::Owned;
+    /// Indicates that `self <= other`; used for sorting.
+    fn less_equal(&self, other: &Self::Owned) -> bool;
+}
+
+impl<'a, T: Ord+ToOwned+?Sized> MyTrait for &'a T {
+    type Owned = T::Owned;
+    fn to_owned(self) -> Self::Owned { self.to_owned() }
+    fn less_equal(&self, other: &Self::Owned) -> bool { self.le(&other.borrow()) }
+}
+
 
 /// A cursor for navigating ordered `(key, val, time, diff)` updates.
 pub trait Cursor {
@@ -17,9 +38,11 @@ pub trait Cursor {
     /// Key by which updates are indexed.
     type Key: ?Sized;
     /// Values associated with keys.
-    type Val: ?Sized;
+    type Val<'a>: Copy + Clone + MyTrait<Owned = Self::ValOwned>;
+    /// Owned version of the above.
+    type ValOwned: Ord + Clone;
     /// Timestamps associated with updates
-    type Time: ?Sized;
+    type Time;
     /// Associated update.
     type Diff: ?Sized;
 
@@ -38,14 +61,14 @@ pub trait Cursor {
     /// A reference to the current key. Asserts if invalid.
     fn key<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Key;
     /// A reference to the current value. Asserts if invalid.
-    fn val<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Val;
+    fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a>;
 
     /// Returns a reference to the current key, if valid.
     fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<&'a Self::Key> {
         if self.key_valid(storage) { Some(self.key(storage)) } else { None }
     }
     /// Returns a reference to the current value, if valid.
-    fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<&'a Self::Val> {
+    fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> {
         if self.val_valid(storage) { Some(self.val(storage)) } else { None }
     }
 
@@ -61,7 +84,7 @@ pub trait Cursor {
     /// Advances the cursor to the next value.
     fn step_val(&mut self, storage: &Self::Storage);
     /// Advances the cursor to the specified value.
-    fn seek_val(&mut self, storage: &Self::Storage, val: &Self::Val);
+    fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>);
 
     /// Rewinds the cursor to the first key.
     fn rewind_keys(&mut self, storage: &Self::Storage);
@@ -69,10 +92,9 @@ pub trait Cursor {
     fn rewind_vals(&mut self, storage: &Self::Storage);
 
     /// Rewinds the cursor and outputs its contents to a Vec
-    fn to_vec(&mut self, storage: &Self::Storage) -> Vec<((Self::Key, Self::Val), Vec<(Self::Time, Self::Diff)>)>
+    fn to_vec(&mut self, storage: &Self::Storage) -> Vec<((Self::Key, Self::ValOwned), Vec<(Self::Time, Self::Diff)>)>
     where
         Self::Key: Clone,
-        Self::Val: Clone,
         Self::Time: Clone,
         Self::Diff: Clone,
     {
@@ -85,7 +107,7 @@ pub trait Cursor {
                 self.map_times(storage, |ts, r| {
                     kv_out.push((ts.clone(), r.clone()));
                 });
-                out.push(((self.key(storage).clone(), self.val(storage).clone()), kv_out));
+                out.push(((self.key(storage).clone(), self.val(storage).to_owned()), kv_out));
                 self.step_val(storage);
             }
             self.step_key(storage);

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -53,7 +53,7 @@ pub mod rhh;
 pub use self::ord_neu::OrdValSpine as ValSpine;
 pub use self::ord_neu::OrdKeySpine as KeySpine;
 
-use std::borrow::{Borrow, ToOwned};
+use std::borrow::{ToOwned};
 
 use timely::container::columnation::{Columnation, TimelyStack};
 use lattice::Lattice;
@@ -61,14 +61,10 @@ use difference::Semigroup;
 
 /// A type that names constituent update types.
 pub trait Update {
-    /// We will be able to read out references to this type, and must supply `Key::Owned` as input.
-    type Key: Ord + ToOwned<Owned = Self::KeyOwned> + ?Sized;
     /// Key by which data are grouped.
-    type KeyOwned: Ord+Clone + Borrow<Self::Key>;
+    type Key: Ord + Clone + 'static;
     /// Values associated with the key.
-    type Val: Ord + ToOwned<Owned = Self::ValOwned> + ?Sized + 'static;
-    /// Values associated with the key, in owned form
-    type ValOwned: Ord+Clone + Borrow<Self::Val>;
+    type Val: Ord + Clone + 'static;
     /// Time at which updates occur.
     type Time: Ord+Lattice+timely::progress::Timestamp+Clone;
     /// Way in which updates occur.
@@ -77,15 +73,13 @@ pub trait Update {
 
 impl<K,V,T,R> Update for ((K, V), T, R)
 where
-    K: Ord+Clone,
+    K: Ord+Clone+'static,
     V: Ord+Clone+'static,
     T: Ord+Lattice+timely::progress::Timestamp+Clone,
     R: Semigroup+Clone,
 {
     type Key = K;
-    type KeyOwned = K;
     type Val = V;
-    type ValOwned = V;
     type Time = T;
     type Diff = R;
 }
@@ -96,15 +90,13 @@ pub trait Layout {
     type Target: Update + ?Sized;
     /// Container for update keys.
     type KeyContainer:
-        RetainFrom<<Self::Target as Update>::Key>+
-        BatchContainer<Item=<Self::Target as Update>::Key>;
+        BatchContainer<PushItem=<Self::Target as Update>::Key>;
     /// Container for update vals.
     type ValContainer:
-        RetainFrom<<Self::Target as Update>::Val>+
-        BatchContainer<Item=<Self::Target as Update>::Val>;
+        BatchContainer<PushItem=<Self::Target as Update>::Val>;
     /// Container for update vals.
     type UpdContainer:
-        BatchContainer<Item=(<Self::Target as Update>::Time, <Self::Target as Update>::Diff)>;
+        for<'a> BatchContainer<PushItem=(<Self::Target as Update>::Time, <Self::Target as Update>::Diff), ReadItem<'a> = &'a (<Self::Target as Update>::Time, <Self::Target as Update>::Diff)>;
 }
 
 /// A layout that uses vectors
@@ -114,8 +106,11 @@ pub struct Vector<U: Update> {
 
 impl<U: Update> Layout for Vector<U>
 where
-    U::Key: ToOwned<Owned = U::Key> + Sized + Clone,
-    U::Val: ToOwned<Owned = U::Val> + Sized + Clone,
+    U::Key: 'static,
+    U::Val: 'static,
+// where
+//     U::Key: ToOwned<Owned = U::Key> + Sized + Clone + 'static,
+//     U::Val: ToOwned<Owned = U::Val> + Sized + Clone + 'static,
 {
     type Target = U;
     type KeyContainer = Vec<U::Key>;
@@ -128,10 +123,10 @@ pub struct TStack<U: Update> {
     phantom: std::marker::PhantomData<U>,
 }
 
-impl<U: Update+Clone> Layout for TStack<U>
+impl<U: Update> Layout for TStack<U>
 where
-    U::Key: Columnation + ToOwned<Owned = U::Key>,
-    U::Val: Columnation + ToOwned<Owned = U::Val>,
+    U::Key: Columnation + 'static,
+    U::Val: Columnation + 'static,
     U::Time: Columnation,
     U::Diff: Columnation,
 {
@@ -146,15 +141,15 @@ where
 /// Examples include types that implement `Clone` who prefer 
 pub trait PreferredContainer : ToOwned {
     /// The preferred container for the type.
-    type Container: BatchContainer<Item=Self> + RetainFrom<Self>;
+    type Container: BatchContainer<PushItem=Self::Owned>;
 }
 
-impl<T: Clone> PreferredContainer for T {
+impl<T: Ord + Clone + 'static> PreferredContainer for T {
     type Container = Vec<T>;
 }
 
-impl<T: Clone> PreferredContainer for [T] {
-    type Container = SliceContainer<T>;
+impl<T: Ord + Clone + 'static> PreferredContainer for [T] {
+    type Container = SliceContainer2<T>;
 }
 
 /// An update and layout description based on preferred containers.
@@ -164,17 +159,15 @@ pub struct Preferred<K: ?Sized, V: ?Sized, T, D> {
 
 impl<K,V,T,R> Update for Preferred<K, V, T, R>
 where
-    K: Ord+ToOwned + ?Sized,
-    K::Owned: Ord+Clone,
-    V: Ord+ToOwned + ?Sized + 'static,
+    K: ToOwned + ?Sized,
+    K::Owned: Ord+Clone+'static,
+    V: ToOwned + ?Sized + 'static,
     V::Owned: Ord+Clone,
     T: Ord+Lattice+timely::progress::Timestamp+Clone,
     R: Semigroup+Clone,
 {
-    type Key = K;
-    type KeyOwned = K::Owned;
-    type Val = V;
-    type ValOwned = V::Owned;
+    type Key = K::Owned;
+    type Val = V::Owned;
     type Time = T;
     type Diff = R;
 }
@@ -182,7 +175,8 @@ where
 impl<K, V, T, D> Layout for Preferred<K, V, T, D>
 where
     K: Ord+ToOwned+PreferredContainer + ?Sized,
-    K::Owned: Ord+Clone,
+    K::Owned: Ord+Clone+'static,
+    // for<'a> K::Container: BatchContainer<ReadItem<'a> = &'a K>,
     V: Ord+ToOwned+PreferredContainer + ?Sized + 'static,
     V::Owned: Ord+Clone,
     T: Ord+Lattice+timely::progress::Timestamp+Clone,
@@ -195,35 +189,35 @@ where
 }
 
 
-/// A container that can retain/discard from some offset onward.
-pub trait RetainFrom<T: ?Sized> {
-    /// Retains elements from an index onwards that satisfy a predicate.
-    fn retain_from<P: FnMut(usize, &T)->bool>(&mut self, index: usize, predicate: P);
-}
+// /// A container that can retain/discard from some offset onward.
+// pub trait RetainFrom<T: ?Sized> {
+//     /// Retains elements from an index onwards that satisfy a predicate.
+//     fn retain_from<P: FnMut(usize, &T)->bool>(&mut self, index: usize, predicate: P);
+// }
 
-impl<T> RetainFrom<T> for Vec<T> {
-    fn retain_from<P: FnMut(usize, &T)->bool>(&mut self, index: usize, mut predicate: P) {
-        let mut write_position = index;
-        for position in index .. self.len() {
-            if predicate(position, &self[position]) {
-                self.swap(position, write_position);
-                write_position += 1;
-            }
-        }
-        self.truncate(write_position);
-    }
-}
+// impl<T> RetainFrom<T> for Vec<T> {
+//     fn retain_from<P: FnMut(usize, &T)->bool>(&mut self, index: usize, mut predicate: P) {
+//         let mut write_position = index;
+//         for position in index .. self.len() {
+//             if predicate(position, &self[position]) {
+//                 self.swap(position, write_position);
+//                 write_position += 1;
+//             }
+//         }
+//         self.truncate(write_position);
+//     }
+// }
 
-impl<T: Columnation> RetainFrom<T> for TimelyStack<T> {
-    fn retain_from<P: FnMut(usize, &T)->bool>(&mut self, index: usize, mut predicate: P) {
-        let mut position = index;
-        self.retain_from(index, |item| {
-            let result = predicate(position, item);
-            position += 1;
-            result
-        })
-    }
-}
+// impl<T: Columnation> RetainFrom<T> for TimelyStack<T> {
+//     fn retain_from<P: FnMut(usize, &T)->bool>(&mut self, index: usize, mut predicate: P) {
+//         let mut position = index;
+//         self.retain_from(index, |item| {
+//             let result = predicate(position, item);
+//             position += 1;
+//             result
+//         })
+//     }
+// }
 
 use std::convert::TryInto;
 
@@ -310,7 +304,7 @@ impl OffsetList {
     }
 }
 
-pub use self::containers::{BatchContainer, SliceContainer};
+pub use self::containers::{BatchContainer, SliceContainer, SliceContainer2};
 
 /// Containers for data that resemble `Vec<T>`, with leaner implementations.
 pub mod containers {
@@ -318,19 +312,24 @@ pub mod containers {
     use timely::container::columnation::{Columnation, TimelyStack};
 
     use std::borrow::{Borrow, ToOwned};
+    use trace::MyTrait;
 
     /// A general-purpose container resembling `Vec<T>`.
-    pub trait BatchContainer: Default {
+    pub trait BatchContainer: Default + 'static {
         /// The type of contained item.
         ///
         /// The container only supplies references to the item, so it needn't be sized.
-        type Item: ?Sized;
+        type PushItem;
+        /// The type that can be read back out of the container.
+        type ReadItem<'a>: Copy + MyTrait<'a, Owned = Self::PushItem> + for<'b> PartialOrd<Self::ReadItem<'b>>;
         /// Inserts an owned item.
-        fn push(&mut self, item: <Self::Item as ToOwned>::Owned) where Self::Item: ToOwned;
+        fn push(&mut self, item: Self::PushItem);
+        /// Inserts an owned item.
+        fn copy_push(&mut self, item: &Self::PushItem);
         /// Inserts a borrowed item.
-        fn copy(&mut self, item: &Self::Item);
+        fn copy<'a>(&mut self, item: Self::ReadItem<'a>);
         /// Extends from a slice of items.
-        fn copy_slice(&mut self, slice: &[<Self::Item as ToOwned>::Owned]) where Self::Item: ToOwned;
+        fn copy_slice(&mut self, slice: &[Self::PushItem]);
         /// Extends from a range of items in another`Self`.
         fn copy_range(&mut self, other: &Self, start: usize, end: usize);
         /// Creates a new container with sufficient capacity.
@@ -341,11 +340,11 @@ pub mod containers {
         fn merge_capacity(cont1: &Self, cont2: &Self) -> Self;
 
         /// Reference to the element at this position.
-        fn index(&self, index: usize) -> &Self::Item;
+        fn index<'a>(&'a self, index: usize) -> Self::ReadItem<'a>;
         /// Number of contained elements
         fn len(&self) -> usize;
         /// Returns the last item if the container is non-empty.
-        fn last(&self) -> Option<&Self::Item> {
+        fn last<'a>(&'a self) -> Option<Self::ReadItem<'a>> {
             if self.len() > 0 {
                 Some(self.index(self.len()-1))
             }
@@ -360,7 +359,7 @@ pub mod containers {
         /// stays false once it becomes false, a joint property of the predicate
         /// and the layout of `Self. This allows `advance` to use exponential search to
         /// count the number of elements in time logarithmic in the result.
-        fn advance<F: Fn(&Self::Item)->bool>(&self, start: usize, end: usize, function: F) -> usize {
+        fn advance<F: for<'a> Fn(Self::ReadItem<'a>)->bool>(&self, start: usize, end: usize, function: F) -> usize {
 
             let small_limit = 8;
 
@@ -401,15 +400,20 @@ pub mod containers {
 
     // All `T: Clone` also implement `ToOwned<Owned = T>`, but without the constraint Rust
     // struggles to understand why the owned type must be `T` (i.e. the one blanket impl).
-    impl<T: Clone + ToOwned<Owned = T>> BatchContainer for Vec<T> {
-        type Item = T;
+    impl<T: Ord + Clone + 'static> BatchContainer for Vec<T> {
+        type PushItem = T;
+        type ReadItem<'a> = &'a Self::PushItem;
+
         fn push(&mut self, item: T) {
             self.push(item);
+        }
+        fn copy_push(&mut self, item: &T) {
+            self.copy(item);
         }
         fn copy(&mut self, item: &T) {
             self.push(item.clone());
         }
-        fn copy_slice(&mut self, slice: &[T]) where T: Sized {
+        fn copy_slice(&mut self, slice: &[T]) {
             self.extend_from_slice(slice);
         }
         fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
@@ -424,7 +428,7 @@ pub mod containers {
         fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
             Vec::with_capacity(cont1.len() + cont2.len())
         }
-        fn index(&self, index: usize) -> &Self::Item {
+        fn index<'a>(&'a self, index: usize) -> Self::ReadItem<'a> {
             &self[index]
         }
         fn len(&self) -> usize {
@@ -434,15 +438,20 @@ pub mod containers {
 
     // The `ToOwned` requirement exists to satisfy `self.reserve_items`, who must for now
     // be presented with the actual contained type, rather than a type that borrows into it.
-    impl<T: Columnation + ToOwned<Owned = T>> BatchContainer for TimelyStack<T> {
-        type Item = T;
-        fn push(&mut self, item: <Self::Item as ToOwned>::Owned) where Self::Item: ToOwned {
+    impl<T: Ord + Columnation + ToOwned<Owned = T> + 'static> BatchContainer for TimelyStack<T> {
+        type PushItem = T;
+        type ReadItem<'a> = &'a Self::PushItem;
+
+        fn push(&mut self, item: Self::PushItem) {
             self.copy(item.borrow());
+        }
+        fn copy_push(&mut self, item: &Self::PushItem) {
+            self.copy(item);
         }
         fn copy(&mut self, item: &T) {
             self.copy(item);
         }
-        fn copy_slice(&mut self, slice: &[<Self::Item as ToOwned>::Owned]) where Self::Item: ToOwned {
+        fn copy_slice(&mut self, slice: &[Self::PushItem]) {
             self.reserve_items(slice.iter());
             for item in slice.iter() {
                 self.copy(item);
@@ -465,7 +474,7 @@ pub mod containers {
             new.reserve_regions(std::iter::once(cont1).chain(std::iter::once(cont2)));
             new
         }
-        fn index(&self, index: usize) -> &Self::Item {
+        fn index<'a>(&'a self, index: usize) -> Self::ReadItem<'a> {
             &self[index]
         }
         fn len(&self) -> usize {
@@ -486,23 +495,26 @@ pub mod containers {
 
     impl<B> BatchContainer for SliceContainer<B>
     where
-        B: Clone + Sized,
-        [B]: ToOwned<Owned = Vec<B>>,
+        B: Ord + Clone + Sized + 'static,
     {
-        type Item = [B];
-        fn push(&mut self, item: Vec<B>) where Self::Item: ToOwned {
+        type PushItem = Vec<B>;
+        type ReadItem<'a> = &'a [B];
+        fn push(&mut self, item: Vec<B>) {
             for x in item.into_iter() {
                 self.inner.push(x);
             }
             self.offsets.push(self.inner.len());
         }
-        fn copy(&mut self, item: &Self::Item) {
+        fn copy_push(&mut self, item: &Vec<B>) {
+            self.copy(&item[..]);
+        }
+        fn copy<'a>(&mut self, item: Self::ReadItem<'a>) {
             for x in item.iter() {
                 self.inner.copy(x);
             }
             self.offsets.push(self.inner.len());
         }
-        fn copy_slice(&mut self, slice: &[Vec<B>]) where Self::Item: ToOwned {
+        fn copy_slice(&mut self, slice: &[Vec<B>]) {
             for item in slice {
                 self.copy(item);
             }
@@ -530,7 +542,7 @@ pub mod containers {
                 inner: Vec::with_capacity(cont1.inner.len() + cont2.inner.len()),
             }
         }
-        fn index(&self, index: usize) -> &Self::Item {
+        fn index<'a>(&'a self, index: usize) -> Self::ReadItem<'a> {
             let lower = self.offsets[index];
             let upper = self.offsets[index+1];
             &self.inner[lower .. upper]
@@ -550,12 +562,154 @@ pub mod containers {
         }
     }
 
-    use trace::implementations::RetainFrom;
-    /// A container that can retain/discard from some offset onward.
-    impl<B> RetainFrom<[B]> for SliceContainer<B> {
-        /// Retains elements from an index onwards that satisfy a predicate.
-        fn retain_from<P: FnMut(usize, &[B])->bool>(&mut self, _index: usize, _predicate: P) {
-            unimplemented!()
+    /// A container that accepts slices `[B::Item]`.
+    pub struct SliceContainer2<B> {
+        text: String,
+        /// Offsets that bound each contained slice.
+        ///
+        /// The length will be one greater than the number of contained slices,
+        /// starting with zero and ending with `self.inner.len()`.
+        offsets: Vec<usize>,
+        /// An inner container for sequences of `B` that dereferences to a slice.
+        inner: Vec<B>,
+    }
+
+    /// Welcome to GATs!
+    pub struct Greetings<'a, B> {
+        /// Text that decorates the data.
+        pub text: Option<&'a str>,
+        /// The data itself.
+        pub slice: &'a [B],
+    }
+
+    impl<'a, B> Copy for Greetings<'a, B> { }
+    impl<'a, B> Clone for Greetings<'a, B> { 
+        fn clone(&self) -> Self {
+            Self {
+                text: self.text.clone(),
+                slice: self.slice,
+            }
         }
     }
+
+    use std::cmp::Ordering;
+    impl<'a, 'b, B: Ord> PartialEq<Greetings<'a, B>> for Greetings<'b, B> {
+        fn eq(&self, other: &Greetings<'a, B>) -> bool {
+            self.slice.eq(&other.slice[..])
+        }
+    }
+    impl<'a, B: Ord> Eq for Greetings<'a, B> { }
+    impl<'a, 'b, B: Ord> PartialOrd<Greetings<'a, B>> for Greetings<'b, B> {
+        fn partial_cmp(&self, other: &Greetings<'a, B>) -> Option<Ordering> {
+            self.slice.partial_cmp(&other.slice[..])
+        }
+    }
+    impl<'a, B: Ord> Ord for Greetings<'a, B> {
+        fn cmp(&self, other: &Self) -> Ordering {
+            self.partial_cmp(other).unwrap()
+        }
+    }
+
+    impl<'a, B: Ord + Clone> MyTrait<'a> for Greetings<'a, B> {
+        type Owned = Vec<B>;
+        fn into_owned(self) -> Self::Owned { self.slice.to_vec() }
+        fn clone_onto(&self, other: &mut Self::Owned) { 
+            self.slice.clone_into(other);
+        }
+        fn compare(&self, other: &Self::Owned) -> std::cmp::Ordering { 
+            self.slice.cmp(&other[..])
+        }
+        fn borrow_as(other: &'a Self::Owned) -> Self {
+            Self {
+                text: None,
+                slice: &other[..],
+            }
+        }
+    }
+    
+    
+
+    impl<B> BatchContainer for SliceContainer2<B>
+    where
+        B: Ord + Clone + Sized + 'static,
+    {
+        type PushItem = Vec<B>;
+        type ReadItem<'a> = Greetings<'a, B>;
+        fn push(&mut self, item: Vec<B>) {
+            for x in item.into_iter() {
+                self.inner.push(x);
+            }
+            self.offsets.push(self.inner.len());
+        }
+        fn copy_push(&mut self, item: &Vec<B>) {
+            self.copy(<_ as MyTrait>::borrow_as(item));
+        }
+        fn copy<'a>(&mut self, item: Self::ReadItem<'a>) {
+            for x in item.slice.iter() {
+                self.inner.copy(x);
+            }
+            self.offsets.push(self.inner.len());
+        }
+        fn copy_slice(&mut self, slice: &[Vec<B>]) {
+            for item in slice {
+                self.copy_push(item);
+            }
+        }
+        fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
+            for index in start .. end {
+                self.copy(other.index(index));
+            }
+        }
+        fn with_capacity(size: usize) -> Self {
+            let mut offsets = Vec::with_capacity(size + 1);
+            offsets.push(0);
+            Self {
+                text: format!("Hello!"),
+                offsets,
+                inner: Vec::with_capacity(size),
+            }
+        }
+        fn reserve(&mut self, _additional: usize) {
+        }
+        fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
+            let mut offsets = Vec::with_capacity(cont1.inner.len() + cont2.inner.len() + 1);
+            offsets.push(0);
+            Self {
+                text: format!("Hello!"),
+                offsets,
+                inner: Vec::with_capacity(cont1.inner.len() + cont2.inner.len()),
+            }
+        }
+        fn index<'a>(&'a self, index: usize) -> Self::ReadItem<'a> {
+            let lower = self.offsets[index];
+            let upper = self.offsets[index+1];
+            Greetings {
+                text: Some(&self.text),
+                slice: &self.inner[lower .. upper],
+            }
+        }
+        fn len(&self) -> usize {
+            self.offsets.len() - 1
+        }
+    }
+
+    /// Default implementation introduces a first offset.
+    impl<B> Default for SliceContainer2<B> {
+        fn default() -> Self {
+            Self {
+                text: format!("Hello!"),
+                offsets: vec![0],
+                inner: Default::default(),
+            }
+        }
+    }
+
+    // use trace::implementations::RetainFrom;
+    // /// A container that can retain/discard from some offset onward.
+    // impl<B> RetainFrom<[B]> for SliceContainer<B> {
+    //     /// Retains elements from an index onwards that satisfy a predicate.
+    //     fn retain_from<P: FnMut(usize, &[B])->bool>(&mut self, _index: usize, _predicate: P) {
+    //         unimplemented!()
+    //     }
+    // }
 }

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -66,7 +66,7 @@ pub trait Update {
     /// Key by which data are grouped.
     type KeyOwned: Ord+Clone + Borrow<Self::Key>;
     /// Values associated with the key.
-    type Val: Ord + ToOwned<Owned = Self::ValOwned> + ?Sized;
+    type Val: Ord + ToOwned<Owned = Self::ValOwned> + ?Sized + 'static;
     /// Values associated with the key, in owned form
     type ValOwned: Ord+Clone + Borrow<Self::Val>;
     /// Time at which updates occur.
@@ -78,7 +78,7 @@ pub trait Update {
 impl<K,V,T,R> Update for ((K, V), T, R)
 where
     K: Ord+Clone,
-    V: Ord+Clone,
+    V: Ord+Clone+'static,
     T: Ord+Lattice+timely::progress::Timestamp+Clone,
     R: Semigroup+Clone,
 {
@@ -166,7 +166,7 @@ impl<K,V,T,R> Update for Preferred<K, V, T, R>
 where
     K: Ord+ToOwned + ?Sized,
     K::Owned: Ord+Clone,
-    V: Ord+ToOwned + ?Sized,
+    V: Ord+ToOwned + ?Sized + 'static,
     V::Owned: Ord+Clone,
     T: Ord+Lattice+timely::progress::Timestamp+Clone,
     R: Semigroup+Clone,
@@ -183,7 +183,7 @@ impl<K, V, T, D> Layout for Preferred<K, V, T, D>
 where
     K: Ord+ToOwned+PreferredContainer + ?Sized,
     K::Owned: Ord+Clone,
-    V: Ord+ToOwned+PreferredContainer + ?Sized,
+    V: Ord+ToOwned+PreferredContainer + ?Sized + 'static,
     V::Owned: Ord+Clone,
     T: Ord+Lattice+timely::progress::Timestamp+Clone,
     D: Semigroup+Clone,

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -342,14 +342,15 @@ where
     <L::Target as Update>::Val: Sized + Clone,
 {
     type Key = <L::Target as Update>::Key;
-    type Val = <L::Target as Update>::Val;
+    type Val<'a> = &'a <L::Target as Update>::Val;
+    type ValOwned = <L::Target as Update>::ValOwned;
     type Time = <L::Target as Update>::Time;
     type Diff = <L::Target as Update>::Diff;
 
     type Storage = OrdValBatch<L>;
 
     fn key<'a>(&self, storage: &'a OrdValBatch<L>) -> &'a Self::Key { &self.cursor.key(&storage.layer) }
-    fn val<'a>(&self, storage: &'a OrdValBatch<L>) -> &'a Self::Val { &self.cursor.child.key(&storage.layer.vals) }
+    fn val<'a>(&self, storage: &'a OrdValBatch<L>) -> Self::Val<'a> { &self.cursor.child.key(&storage.layer.vals) }
     fn map_times<L2: FnMut(&Self::Time, &Self::Diff)>(&mut self, storage: &OrdValBatch<L>, mut logic: L2) {
         self.cursor.child.child.rewind(&storage.layer.vals.vals);
         while self.cursor.child.child.valid(&storage.layer.vals.vals) {
@@ -362,7 +363,7 @@ where
     fn step_key(&mut self, storage: &OrdValBatch<L>){ self.cursor.step(&storage.layer); }
     fn seek_key(&mut self, storage: &OrdValBatch<L>, key: &Self::Key) { self.cursor.seek(&storage.layer, key); }
     fn step_val(&mut self, storage: &OrdValBatch<L>) { self.cursor.child.step(&storage.layer.vals); }
-    fn seek_val(&mut self, storage: &OrdValBatch<L>, val: &Self::Val) { self.cursor.child.seek(&storage.layer.vals, val); }
+    fn seek_val<'a>(&mut self, storage: &OrdValBatch<L>, val: Self::Val<'a>) { self.cursor.child.seek(&storage.layer.vals, val); }
     fn rewind_keys(&mut self, storage: &OrdValBatch<L>) { self.cursor.rewind(&storage.layer); }
     fn rewind_vals(&mut self, storage: &OrdValBatch<L>) { self.cursor.child.rewind(&storage.layer.vals); }
 }
@@ -640,7 +641,8 @@ where
     <L::Target as Update>::Key: Sized,
 {
     type Key = <L::Target as Update>::Key;
-    type Val = ();
+    type Val<'a> = &'a ();
+    type ValOwned = ();
     type Time = <L::Target as Update>::Time;
     type Diff = <L::Target as Update>::Diff;
 

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -97,11 +97,11 @@ where
 
 // Type aliases to make certain types readable.
 type TDLayer<L> = OrderedLeaf<<<L as Layout>::Target as Update>::Time, <<L as Layout>::Target as Update>::Diff>;
-type VTDLayer<L> = OrderedLayer<<<L as Layout>::Target as Update>::Val, TDLayer<L>, <L as Layout>::ValContainer>;
+type VTDLayer<L> = OrderedLayer<<<L as Layout>::Target as Update>::ValOwned, TDLayer<L>, <L as Layout>::ValContainer>;
 type KTDLayer<L> = OrderedLayer<<<L as Layout>::Target as Update>::Key, TDLayer<L>, <L as Layout>::KeyContainer>;
 type KVTDLayer<L> = OrderedLayer<<<L as Layout>::Target as Update>::Key, VTDLayer<L>, <L as Layout>::KeyContainer>;
 type TDBuilder<L> = OrderedLeafBuilder<<<L as Layout>::Target as Update>::Time, <<L as Layout>::Target as Update>::Diff>;
-type VTDBuilder<L> = OrderedBuilder<<<L as Layout>::Target as Update>::Val, TDBuilder<L>, <L as Layout>::ValContainer>;
+type VTDBuilder<L> = OrderedBuilder<<<L as Layout>::Target as Update>::ValOwned, TDBuilder<L>, <L as Layout>::ValContainer>;
 type KTDBuilder<L> = OrderedBuilder<<<L as Layout>::Target as Update>::Key, TDBuilder<L>, <L as Layout>::KeyContainer>;
 type KVTDBuilder<L> = OrderedBuilder<<<L as Layout>::Target as Update>::Key, VTDBuilder<L>, <L as Layout>::KeyContainer>;
 
@@ -111,7 +111,7 @@ where
     <L::Target as Update>::Val: Sized + Clone,
 {
     type Key = <L::Target as Update>::Key;
-    type Val = <L::Target as Update>::Val;
+    type Val<'a> = <L::Target as Update>::Val<'a>;
     type Time = <L::Target as Update>::Time;
     type Diff = <L::Target as Update>::Diff;
 
@@ -342,7 +342,7 @@ where
     <L::Target as Update>::Val: Sized + Clone,
 {
     type Key = <L::Target as Update>::Key;
-    type Val<'a> = &'a <L::Target as Update>::Val;
+    type Val<'a> = <L::Target as Update>::Val<'a>;
     type ValOwned = <L::Target as Update>::ValOwned;
     type Time = <L::Target as Update>::Time;
     type Diff = <L::Target as Update>::Diff;
@@ -382,9 +382,9 @@ impl<L: Layout> Builder for OrdValBuilder<L>
 where
     <L::Target as Update>::Key: Sized + Clone,
     <L::Target as Update>::Val: Sized + Clone,
-    OrdValBatch<L>: Batch<Key=<L::Target as Update>::Key, Val=<L::Target as Update>::Val, Time=<L::Target as Update>::Time, Diff=<L::Target as Update>::Diff>
+    // OrdValBatch<L>: Batch<Key=<L::Target as Update>::Key, Val=<L::Target as Update>::Val, Time=<L::Target as Update>::Time, Diff=<L::Target as Update>::Diff>,
 {
-    type Item = ((<L::Target as Update>::Key, <L::Target as Update>::Val), <L::Target as Update>::Time, <L::Target as Update>::Diff);
+    type Item = ((<L::Target as Update>::Key, <L::Target as Update>::ValOwned), <L::Target as Update>::Time, <L::Target as Update>::Diff);
     type Time = <L::Target as Update>::Time;
     type Output = OrdValBatch<L>;
 
@@ -450,7 +450,7 @@ where
 impl<L: Layout> Batch for OrdKeyBatch<L>
 where
     <L::Target as Update>::Key: Sized + Clone,
-    L::Target: Update<Val = ()>,
+    L::Target: Update<ValOwned = ()>,
 {
     type Merger = OrdKeyMerger<L>;
 
@@ -679,7 +679,7 @@ where
 impl<L: Layout> Builder for OrdKeyBuilder<L>
 where
     <L::Target as Update>::Key: Sized + Clone,
-    OrdKeyBatch<L>: Batch<Key=<L::Target as Update>::Key, Val=(), Time=<L::Target as Update>::Time, Diff=<L::Target as Update>::Diff>
+    // OrdKeyBatch<L>: Batch<Key=<L::Target as Update>::Key, Val=(), Time=<L::Target as Update>::Time, Diff=<L::Target as Update>::Diff>,
 {
     type Item = ((<L::Target as Update>::Key, ()), <L::Target as Update>::Time, <L::Target as Update>::Diff);
     type Time = <L::Target as Update>::Time;

--- a/src/trace/implementations/ord.rs
+++ b/src/trace/implementations/ord.rs
@@ -363,7 +363,7 @@ where
     fn step_key(&mut self, storage: &OrdValBatch<L>){ self.cursor.step(&storage.layer); }
     fn seek_key(&mut self, storage: &OrdValBatch<L>, key: &Self::Key) { self.cursor.seek(&storage.layer, key); }
     fn step_val(&mut self, storage: &OrdValBatch<L>) { self.cursor.child.step(&storage.layer.vals); }
-    fn seek_val<'a>(&mut self, storage: &OrdValBatch<L>, val: Self::Val<'a>) { self.cursor.child.seek(&storage.layer.vals, val); }
+    fn seek_val(&mut self, storage: &OrdValBatch<L>, val: Self::Val<'a>) { self.cursor.child.seek(&storage.layer.vals, val); }
     fn rewind_keys(&mut self, storage: &OrdValBatch<L>) { self.cursor.rewind(&storage.layer); }
     fn rewind_vals(&mut self, storage: &OrdValBatch<L>) { self.cursor.child.rewind(&storage.layer.vals); }
 }

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -439,14 +439,15 @@ mod val_batch {
 
     impl<L: Layout> Cursor for OrdValCursor<L> {
         type Key = <L::Target as Update>::Key;
-        type Val = <L::Target as Update>::Val;
+        type Val<'a> = &'a <L::Target as Update>::Val;
+        type ValOwned = <L::Target as Update>::ValOwned;
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 
         type Storage = OrdValBatch<L>;
 
         fn key<'a>(&self, storage: &'a OrdValBatch<L>) -> &'a Self::Key { storage.storage.keys.index(self.key_cursor) }
-        fn val<'a>(&self, storage: &'a OrdValBatch<L>) -> &'a Self::Val { storage.storage.vals.index(self.val_cursor) }
+        fn val<'a>(&self, storage: &'a OrdValBatch<L>) -> Self::Val<'a> { storage.storage.vals.index(self.val_cursor) }
         fn map_times<L2: FnMut(&Self::Time, &Self::Diff)>(&mut self, storage: &OrdValBatch<L>, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_value(self.val_cursor);
             for index in lower .. upper {
@@ -477,7 +478,7 @@ mod val_batch {
                 self.val_cursor = storage.storage.values_for_key(self.key_cursor).1;
             }
         }
-        fn seek_val(&mut self, storage: &OrdValBatch<L>, val: &Self::Val) {
+        fn seek_val<'a>(&mut self, storage: &OrdValBatch<L>, val: Self::Val<'a>) {
             self.val_cursor += storage.storage.vals.advance(self.val_cursor, storage.storage.values_for_key(self.key_cursor).1, |x| x.lt(val));
         }
         fn rewind_keys(&mut self, storage: &OrdValBatch<L>) {

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -470,7 +470,7 @@ mod val_batch {
                 self.key_cursor = storage.storage.keys.len();
             }
         }
-        fn seek_key<'a>(&mut self, storage: &OrdValBatch<L>, key: Self::Key<'a>) {
+        fn seek_key(&mut self, storage: &OrdValBatch<L>, key: Self::Key<'_>) {
             self.key_cursor += storage.storage.keys.advance(self.key_cursor, storage.storage.keys.len(), |x| x.lt(&key));
             if self.key_valid(storage) {
                 self.rewind_vals(storage);
@@ -482,7 +482,7 @@ mod val_batch {
                 self.val_cursor = storage.storage.values_for_key(self.key_cursor).1;
             }
         }
-        fn seek_val<'a>(&mut self, storage: &OrdValBatch<L>, val: Self::Val<'a>) {
+        fn seek_val(&mut self, storage: &OrdValBatch<L>, val: Self::Val<'_>) {
             self.val_cursor += storage.storage.vals.advance(self.val_cursor, storage.storage.values_for_key(self.key_cursor).1, |x| x.lt(&val));
         }
         fn rewind_keys(&mut self, storage: &OrdValBatch<L>) {
@@ -940,7 +940,7 @@ mod key_batch {
                 self.key_cursor = storage.storage.keys.len();
             }
         }
-        fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>) {
+        fn seek_key(&mut self, storage: &Self::Storage, key: Self::Key<'_>) {
             self.key_cursor += storage.storage.keys.advance(self.key_cursor, storage.storage.keys.len(), |x| x.lt(&key));
             if self.key_valid(storage) {
                 self.rewind_vals(storage);
@@ -949,7 +949,7 @@ mod key_batch {
         fn step_val(&mut self, _storage: &Self::Storage) {
             self.val_stepped = true;
         }
-        fn seek_val<'a>(&mut self, _storage: &Self::Storage, _val: Self::Val<'a>) { }
+        fn seek_val(&mut self, _storage: &Self::Storage, _val: Self::Val<'_>) { }
         fn rewind_keys(&mut self, storage: &Self::Storage) {
             self.key_cursor = 0;
             if self.key_valid(storage) {

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -65,14 +65,14 @@ pub type PreferredSpine<K, V, T, R> = Spine<
 
 mod val_batch {
 
-    use std::borrow::Borrow;
     use std::convert::TryInto;
     use std::marker::PhantomData;
     use timely::progress::{Antichain, frontier::AntichainRef};
 
     use trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
     use trace::implementations::{BatchContainer, OffsetList};
-    
+    use trace::cursor::MyTrait;
+
     use super::{Layout, Update};
 
     /// An immutable collection of update tuples, from a contiguous interval of logical times.
@@ -137,8 +137,10 @@ mod val_batch {
     }
 
     impl<L: Layout> BatchReader for OrdValBatch<L> {
-        type Key = <L::Target as Update>::Key;
-        type Val = <L::Target as Update>::Val;
+        type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
+        type KeyOwned = <L::Target as Update>::Key;
+        type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
+        type ValOwned = <L::Target as Update>::Val;
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 
@@ -293,8 +295,8 @@ mod val_batch {
         /// if the updates cancel either directly or after compaction.
         fn merge_key(&mut self, source1: &OrdValStorage<L>, source2: &OrdValStorage<L>) {
             use ::std::cmp::Ordering;
-            match source1.keys.index(self.key_cursor1).cmp(source2.keys.index(self.key_cursor2)) {
-                Ordering::Less => {
+            match source1.keys.index(self.key_cursor1).cmp(&source2.keys.index(self.key_cursor2)) {
+                Ordering::Less => { 
                     self.copy_key(source1, self.key_cursor1);
                     self.key_cursor1 += 1;
                 },
@@ -332,7 +334,7 @@ mod val_batch {
                 // if they are non-empty post-consolidation, we write the value.
                 // We could multi-way merge and it wouldn't be very complicated.
                 use ::std::cmp::Ordering;
-                match source1.vals.index(lower1).cmp(source2.vals.index(lower2)) {
+                match source1.vals.index(lower1).cmp(&source2.vals.index(lower2)) {
                     Ordering::Less => { 
                         // Extend stash by updates, with logical compaction applied.
                         self.stash_updates_for_val(source1, lower1);
@@ -394,7 +396,7 @@ mod val_batch {
             let (lower, upper) = source.updates_for_value(index);
             for i in lower .. upper {
                 // NB: Here is where we would need to look back if `lower == upper`.
-                let (time, diff) = &source.updates.index(i);
+                let (time, diff) = &source.updates.index(i).into_owned();
                 use lattice::Lattice;
                 let mut new_time = time.clone();
                 new_time.advance_by(self.description.since().borrow());
@@ -409,8 +411,8 @@ mod val_batch {
             if !self.update_stash.is_empty() {
                 // If there is a single element, equal to a just-prior recorded update,
                 // we push nothing and report an unincremented offset to encode this case.
-                if self.update_stash.len() == 1 && self.update_stash.last() == self.result.updates.last() {
-                    // Just clear out update_stash, as we won't drain it here.
+                if self.update_stash.len() == 1 && self.result.updates.last().map(|ud| self.update_stash.last().unwrap().equals(ud)).unwrap_or(false) {
+                        // Just clear out update_stash, as we won't drain it here.
                     self.update_stash.clear();
                     self.singletons += 1;
                 }
@@ -438,15 +440,17 @@ mod val_batch {
     }
 
     impl<L: Layout> Cursor for OrdValCursor<L> {
-        type Key = <L::Target as Update>::Key;
-        type Val<'a> = &'a <L::Target as Update>::Val;
-        type ValOwned = <L::Target as Update>::ValOwned;
+
+        type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
+        type KeyOwned = <L::Target as Update>::Key;
+        type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
+        type ValOwned = <L::Target as Update>::Val;
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 
         type Storage = OrdValBatch<L>;
 
-        fn key<'a>(&self, storage: &'a OrdValBatch<L>) -> &'a Self::Key { storage.storage.keys.index(self.key_cursor) }
+        fn key<'a>(&self, storage: &'a OrdValBatch<L>) -> Self::Key<'a> { storage.storage.keys.index(self.key_cursor) }
         fn val<'a>(&self, storage: &'a OrdValBatch<L>) -> Self::Val<'a> { storage.storage.vals.index(self.val_cursor) }
         fn map_times<L2: FnMut(&Self::Time, &Self::Diff)>(&mut self, storage: &OrdValBatch<L>, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_value(self.val_cursor);
@@ -466,8 +470,8 @@ mod val_batch {
                 self.key_cursor = storage.storage.keys.len();
             }
         }
-        fn seek_key(&mut self, storage: &OrdValBatch<L>, key: &Self::Key) {
-            self.key_cursor += storage.storage.keys.advance(self.key_cursor, storage.storage.keys.len(), |x| x.lt(key));
+        fn seek_key<'a>(&mut self, storage: &OrdValBatch<L>, key: Self::Key<'a>) {
+            self.key_cursor += storage.storage.keys.advance(self.key_cursor, storage.storage.keys.len(), |x| x.lt(&key));
             if self.key_valid(storage) {
                 self.rewind_vals(storage);
             }
@@ -479,7 +483,7 @@ mod val_batch {
             }
         }
         fn seek_val<'a>(&mut self, storage: &OrdValBatch<L>, val: Self::Val<'a>) {
-            self.val_cursor += storage.storage.vals.advance(self.val_cursor, storage.storage.values_for_key(self.key_cursor).1, |x| x.lt(val));
+            self.val_cursor += storage.storage.vals.advance(self.val_cursor, storage.storage.values_for_key(self.key_cursor).1, |x| x.lt(&val));
         }
         fn rewind_keys(&mut self, storage: &OrdValBatch<L>) {
             self.key_cursor = 0;
@@ -531,12 +535,9 @@ mod val_batch {
         }
     }
 
-    impl<L: Layout> Builder for OrdValBuilder<L>
-    where
-        OrdValBatch<L>: Batch<Key=<L::Target as Update>::Key, Val=<L::Target as Update>::Val, Time=<L::Target as Update>::Time, Diff=<L::Target as Update>::Diff>,
-        <L::Target as Update>::KeyOwned: Borrow<<L::Target as Update>::Key>,
-    {
-        type Item = ((<L::Target as Update>::KeyOwned, <L::Target as Update>::ValOwned), <L::Target as Update>::Time, <L::Target as Update>::Diff);
+    impl<L: Layout> Builder for OrdValBuilder<L> {
+
+        type Item = ((<L::Target as Update>::Key, <L::Target as Update>::Val), <L::Target as Update>::Time, <L::Target as Update>::Diff);
         type Time = <L::Target as Update>::Time;
         type Output = OrdValBatch<L>;
 
@@ -559,9 +560,9 @@ mod val_batch {
         fn push(&mut self, ((key, val), time, diff): Self::Item) {
 
             // Perhaps this is a continuation of an already received key.
-            if self.result.keys.last() == Some(key.borrow()) {
+            if self.result.keys.last().map(|k| k.equals(&key)).unwrap_or(false) {
                 // Perhaps this is a continuation of an already received value.
-                if self.result.vals.last() == Some(val.borrow()) {
+                if self.result.vals.last().map(|v| v.equals(&val)).unwrap_or(false) {
                     self.push_update(time, diff);
                 } else {
                     // New value; complete representation of prior value.
@@ -585,9 +586,9 @@ mod val_batch {
         fn copy(&mut self, ((key, val), time, diff): &Self::Item) {
 
             // Perhaps this is a continuation of an already received key.
-            if self.result.keys.last() == Some(key.borrow()) {
+            if self.result.keys.last().map(|k| k.equals(key)).unwrap_or(false) {
                 // Perhaps this is a continuation of an already received value.
-                if self.result.vals.last() == Some(val.borrow()) {
+                if self.result.vals.last().map(|v| v.equals(val)).unwrap_or(false) {
                     // TODO: here we could look for repetition, and not push the update in that case.
                     // More logic (and state) would be required to correctly wrangle this.
                     self.push_update(time.clone(), diff.clone());
@@ -597,7 +598,7 @@ mod val_batch {
                     // Remove any pending singleton, and if it was set increment our count.
                     if self.singleton.take().is_some() { self.singletons += 1; }
                     self.push_update(time.clone(), diff.clone());
-                    self.result.vals.copy(val.borrow());
+                    self.result.vals.copy_push(val);
                 }
             } else {
                 // New key; complete representation of prior key.
@@ -606,8 +607,8 @@ mod val_batch {
                 if self.singleton.take().is_some() { self.singletons += 1; }
                 self.result.keys_offs.push(self.result.vals.len().try_into().ok().unwrap());
                 self.push_update(time.clone(), diff.clone());
-                self.result.vals.copy(val.borrow());
-                self.result.keys.copy(key.borrow());
+                self.result.vals.copy_push(val);
+                self.result.keys.copy_push(key);
             }
         }
 
@@ -630,13 +631,13 @@ mod val_batch {
 
 mod key_batch {
 
-    use std::borrow::Borrow;
     use std::convert::TryInto;
     use std::marker::PhantomData;
     use timely::progress::{Antichain, frontier::AntichainRef};
 
     use trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
     use trace::implementations::{BatchContainer, OffsetList};
+    use trace::cursor::MyTrait;
 
     use super::{Layout, Update};
 
@@ -692,8 +693,11 @@ mod key_batch {
     }
 
     impl<L: Layout> BatchReader for OrdKeyBatch<L> {
-        type Key = <L::Target as Update>::Key;
-        type Val = ();
+        
+        type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
+        type KeyOwned = <L::Target as Update>::Key;
+        type Val<'a> = &'a ();
+        type ValOwned = ();
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 
@@ -833,7 +837,7 @@ mod key_batch {
         /// if the updates cancel either directly or after compaction.
         fn merge_key(&mut self, source1: &OrdKeyStorage<L>, source2: &OrdKeyStorage<L>) {
             use ::std::cmp::Ordering;
-            match source1.keys.index(self.key_cursor1).cmp(source2.keys.index(self.key_cursor2)) {
+            match source1.keys.index(self.key_cursor1).cmp(&source2.keys.index(self.key_cursor2)) {
                 Ordering::Less => { 
                     self.copy_key(source1, self.key_cursor1);
                     self.key_cursor1 += 1;
@@ -906,14 +910,17 @@ mod key_batch {
     }
 
     impl<L: Layout> Cursor for OrdKeyCursor<L> {
-        type Key = <L::Target as Update>::Key;
-        type Val = ();
+
+        type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
+        type KeyOwned = <L::Target as Update>::Key;
+        type Val<'a> = &'a ();
+        type ValOwned = ();
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 
         type Storage = OrdKeyBatch<L>;
 
-        fn key<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Key { storage.storage.keys.index(self.key_cursor) }
+        fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { storage.storage.keys.index(self.key_cursor) }
         fn val<'a>(&self, _storage: &'a Self::Storage) -> &'a () { &() }
         fn map_times<L2: FnMut(&Self::Time, &Self::Diff)>(&mut self, storage: &Self::Storage, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_key(self.key_cursor);
@@ -933,8 +940,8 @@ mod key_batch {
                 self.key_cursor = storage.storage.keys.len();
             }
         }
-        fn seek_key(&mut self, storage: &Self::Storage, key: &Self::Key) {
-            self.key_cursor += storage.storage.keys.advance(self.key_cursor, storage.storage.keys.len(), |x| x.lt(key));
+        fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>) {
+            self.key_cursor += storage.storage.keys.advance(self.key_cursor, storage.storage.keys.len(), |x| x.lt(&key));
             if self.key_valid(storage) {
                 self.rewind_vals(storage);
             }
@@ -942,7 +949,7 @@ mod key_batch {
         fn step_val(&mut self, _storage: &Self::Storage) {
             self.val_stepped = true;
         }
-        fn seek_val(&mut self, _storage: &Self::Storage, _val: &Self::Val) { }
+        fn seek_val<'a>(&mut self, _storage: &Self::Storage, _val: Self::Val<'a>) { }
         fn rewind_keys(&mut self, storage: &Self::Storage) {
             self.key_cursor = 0;
             if self.key_valid(storage) {
@@ -993,12 +1000,9 @@ mod key_batch {
         }
     }
 
-    impl<L: Layout> Builder for OrdKeyBuilder<L>
-    where
-        OrdKeyBatch<L>: Batch<Key=<L::Target as Update>::Key, Val=(), Time=<L::Target as Update>::Time, Diff=<L::Target as Update>::Diff>,
-        <L::Target as Update>::KeyOwned: Borrow<<L::Target as Update>::Key>,
-    {
-        type Item = ((<L::Target as Update>::KeyOwned, ()), <L::Target as Update>::Time, <L::Target as Update>::Diff);
+    impl<L: Layout> Builder for OrdKeyBuilder<L> {
+
+        type Item = ((<L::Target as Update>::Key, ()), <L::Target as Update>::Time, <L::Target as Update>::Diff);
         type Time = <L::Target as Update>::Time;
         type Output = OrdKeyBatch<L>;
 
@@ -1019,7 +1023,7 @@ mod key_batch {
         fn push(&mut self, ((key, ()), time, diff): Self::Item) {
 
             // Perhaps this is a continuation of an already received key.
-            if self.result.keys.last() == Some(key.borrow()) {
+            if self.result.keys.last().map(|k| k.equals(&key)).unwrap_or(false) {
                 self.push_update(time, diff);
             } else {
                 // New key; complete representation of prior key.
@@ -1035,7 +1039,7 @@ mod key_batch {
         fn copy(&mut self, ((key, ()), time, diff): &Self::Item) {
 
             // Perhaps this is a continuation of an already received key.
-            if self.result.keys.last() == Some(key.borrow()) {
+            if self.result.keys.last().map(|k| k.equals(&key)).unwrap_or(false) {
                 self.push_update(time.clone(), diff.clone());
             } else {
                 // New key; complete representation of prior key.
@@ -1043,7 +1047,7 @@ mod key_batch {
                 // Remove any pending singleton, and if it was set increment our count.
                 if self.singleton.take().is_some() { self.singletons += 1; }
                 self.push_update(time.clone(), diff.clone());
-                self.result.keys.copy(key.borrow());
+                self.result.keys.copy_push(key);
             }
         }
 

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -38,6 +38,8 @@ pub type ColSpine<K, V, T, R> = Spine<
 /// A carrier trait indicating that the type's `Ord` and `PartialOrd` implementations are by `Hashable::hashed()`.
 pub trait HashOrdered: Hashable { }
 
+impl<'a, T: std::hash::Hash + HashOrdered> HashOrdered for &'a T { }
+
 /// A hash-ordered wrapper that modifies `Ord` and `PartialOrd`.
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Abomonation, Default)]
 pub struct HashWrapper<T: std::hash::Hash + Hashable> {
@@ -76,9 +78,12 @@ mod val_batch {
     use std::marker::PhantomData;
     use timely::progress::{Antichain, frontier::AntichainRef};
 
+    use hashable::Hashable;
+
     use trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
     use trace::implementations::{BatchContainer, OffsetList};
-    
+    use trace::cursor::MyTrait;
+
     use super::{Layout, Update, HashOrdered};
 
     /// Update tuples organized as a Robin Hood Hash map, ordered by `(hash(Key), Key, Val, Time)`.
@@ -95,11 +100,10 @@ mod val_batch {
     /// We will use the `Hashable` trait here, but any consistent hash function should work out ok. 
     /// We specifically want to use the highest bits of the result (we will) because the low bits have
     /// likely been spent shuffling the data between workers (by key), and are likely low entropy.
-    #[derive(Abomonation, Debug)]
+    #[derive(Abomonation)]
     pub struct RhhValStorage<L: Layout> 
     where 
-        <L::Target as Update>::Key: HashOrdered,
-        <L::Target as Update>::KeyOwned: Default + HashOrdered,
+        <L::Target as Update>::Key: Default + HashOrdered,
     {
 
         /// The requested capacity for `keys`. We use this when determining where a key with a certain hash
@@ -133,8 +137,7 @@ mod val_batch {
 
     impl<L: Layout> RhhValStorage<L> 
     where 
-        <L::Target as Update>::Key: HashOrdered,
-        <L::Target as Update>::KeyOwned: Default + HashOrdered,
+        <L::Target as Update>::Key: Default + HashOrdered,
     {
         /// Lower and upper bounds in `self.vals` corresponding to the key at `index`.
         fn values_for_key(&self, index: usize) -> (usize, usize) {
@@ -179,7 +182,7 @@ mod val_batch {
 
             // Now we insert the key. Even if it is no longer the desired location because of contention.
             // If an offset has been supplied we insert it, and otherwise leave it for future determination.
-            self.keys.copy(key);
+            self.keys.copy_push(key);
             if let Some(offset) = offset {
                 self.keys_offs.push(offset);
             }
@@ -187,16 +190,15 @@ mod val_batch {
         }
 
         /// Indicates both the desired location and the hash signature of the key.
-        fn desired_location(&self, key: &<L::Target as Update>::Key) -> usize {
-            use hashable::Hashable;
+        fn desired_location<K: Hashable>(&self, key: &K) -> usize {
             let hash: usize = key.hashed().into().try_into().unwrap();
             hash / self.divisor
         }
 
         /// Returns true if one should advance one's index in the search for `key`.
-        fn advance_key(&self, index: usize, key: &<L::Target as Update>::Key) -> bool {
+        fn advance_key<'a>(&self, index: usize, key: <L::KeyContainer as BatchContainer>::ReadItem<'a>) -> bool {
             // Ideally this short-circuits, as `self.keys[index]` is bogus data.
-            !self.live_key(index) || self.keys.index(index).lt(key)
+            !self.live_key(index) || self.keys.index(index).lt(&key)
         }
 
         /// Indicates that a key is valid, rather than dead space, by looking for a valid offset range.
@@ -229,8 +231,7 @@ mod val_batch {
     #[derive(Abomonation)]
     pub struct RhhValBatch<L: Layout> 
     where 
-        <L::Target as Update>::Key: HashOrdered,
-        <L::Target as Update>::KeyOwned: Default + HashOrdered,
+        <L::Target as Update>::Key: Default + HashOrdered,
     {
         /// The updates themselves.
         pub storage: RhhValStorage<L>,
@@ -246,11 +247,13 @@ mod val_batch {
 
     impl<L: Layout> BatchReader for RhhValBatch<L> 
     where 
-        <L::Target as Update>::Key: HashOrdered,
-        <L::Target as Update>::KeyOwned: Default + HashOrdered,
+        <L::Target as Update>::Key: Default + HashOrdered,
+        for<'a> <L::KeyContainer as BatchContainer>::ReadItem<'a>: HashOrdered,
     {
-        type Key = <L::Target as Update>::Key;
-        type Val = <L::Target as Update>::Val;
+        type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
+        type KeyOwned = <L::Target as Update>::Key;
+        type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
+        type ValOwned = <L::Target as Update>::Val;
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 
@@ -274,8 +277,8 @@ mod val_batch {
 
     impl<L: Layout> Batch for RhhValBatch<L> 
     where 
-        <L::Target as Update>::Key: HashOrdered,
-        <L::Target as Update>::KeyOwned: Default + HashOrdered,
+        <L::Target as Update>::Key: Default + HashOrdered,
+        for<'a> <L::KeyContainer as BatchContainer>::ReadItem<'a>: HashOrdered,
     {
         type Merger = RhhValMerger<L>;
 
@@ -287,8 +290,7 @@ mod val_batch {
     /// State for an in-progress merge.
     pub struct RhhValMerger<L: Layout> 
     where 
-        <L::Target as Update>::Key: HashOrdered,
-        <L::Target as Update>::KeyOwned: Default + HashOrdered,
+        <L::Target as Update>::Key: Default + HashOrdered,
     {
         /// Key position to merge next in the first batch.
         key_cursor1: usize,
@@ -299,6 +301,8 @@ mod val_batch {
         /// description
         description: Description<<L::Target as Update>::Time>,
 
+        /// Owned key for copying into.
+        key_owned: <<L::Target as Update>::Key as ToOwned>::Owned,
         /// Local stash of updates, to use for consolidation.
         ///
         /// We could emulate a `ChangeBatch` here, with related compaction smarts.
@@ -310,8 +314,7 @@ mod val_batch {
 
     impl<L: Layout> Merger<RhhValBatch<L>> for RhhValMerger<L>
     where
-        <L::Target as Update>::Key: HashOrdered,
-        <L::Target as Update>::KeyOwned: Default + HashOrdered,
+        <L::Target as Update>::Key: Default + HashOrdered,
         RhhValBatch<L>: Batch<Time=<L::Target as Update>::Time>,
     {
         fn new(batch1: &RhhValBatch<L>, batch2: &RhhValBatch<L>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
@@ -350,6 +353,7 @@ mod val_batch {
                 key_cursor2: 0,
                 result: storage,
                 description,
+                key_owned: Default::default(),
                 update_stash: Vec::new(),
                 singletons: 0,
             }
@@ -401,10 +405,8 @@ mod val_batch {
     // Helper methods in support of merging batches.
     impl<L: Layout> RhhValMerger<L> 
     where 
-        <L::Target as Update>::Key: HashOrdered,
-        <L::Target as Update>::KeyOwned: Default + HashOrdered,
+        <L::Target as Update>::Key: Default + HashOrdered,
     {
-
         /// Copy the next key in `source`.
         ///
         /// The method extracts the key in `source` at `cursor`, and merges it in to `self`.
@@ -427,7 +429,8 @@ mod val_batch {
 
             // If we have pushed any values, copy the key as well.
             if self.result.vals.len() > init_vals {
-                self.result.insert_key(source.keys.index(cursor), Some(self.result.vals.len().try_into().ok().unwrap()));
+                source.keys.index(cursor).clone_onto(&mut self.key_owned);
+                self.result.insert_key(&self.key_owned, Some(self.result.vals.len().try_into().ok().unwrap()));
             }           
         }
         /// Merge the next key in each of `source1` and `source2` into `self`, updating the appropriate cursors.
@@ -437,7 +440,7 @@ mod val_batch {
         fn merge_key(&mut self, source1: &RhhValStorage<L>, source2: &RhhValStorage<L>) {
 
             use ::std::cmp::Ordering;
-            match source1.keys.index(self.key_cursor1).cmp(source2.keys.index(self.key_cursor2)) {
+            match source1.keys.index(self.key_cursor1).cmp(&source2.keys.index(self.key_cursor2)) {
                 Ordering::Less => { 
                     self.copy_key(source1, self.key_cursor1);
                     self.key_cursor1 += 1;
@@ -447,7 +450,8 @@ mod val_batch {
                     let (lower1, upper1) = source1.values_for_key(self.key_cursor1);
                     let (lower2, upper2) = source2.values_for_key(self.key_cursor2);
                     if let Some(off) = self.merge_vals((source1, lower1, upper1), (source2, lower2, upper2)) {
-                        self.result.insert_key(source1.keys.index(self.key_cursor1), Some(off));
+                        source1.keys.index(self.key_cursor1).clone_onto(&mut self.key_owned);
+                        self.result.insert_key(&self.key_owned, Some(off));
                     }
                     // Increment cursors in either case; the keys are merged.
                     self.key_cursor1 += 1;
@@ -475,7 +479,7 @@ mod val_batch {
                 // if they are non-empty post-consolidation, we write the value.
                 // We could multi-way merge and it wouldn't be very complicated.
                 use ::std::cmp::Ordering;
-                match source1.vals.index(lower1).cmp(source2.vals.index(lower2)) {
+                match source1.vals.index(lower1).cmp(&source2.vals.index(lower2)) {
                     Ordering::Less => { 
                         // Extend stash by updates, with logical compaction applied.
                         self.stash_updates_for_val(source1, lower1);
@@ -538,8 +542,8 @@ mod val_batch {
             for i in lower .. upper {
                 // NB: Here is where we would need to look back if `lower == upper`.
                 let (time, diff) = &source.updates.index(i);
-                use lattice::Lattice;
                 let mut new_time = time.clone();
+                use lattice::Lattice;
                 new_time.advance_by(self.description.since().borrow());
                 self.update_stash.push((new_time, diff.clone()));
             }
@@ -552,7 +556,7 @@ mod val_batch {
             if !self.update_stash.is_empty() {
                 // If there is a single element, equal to a just-prior recorded update,
                 // we push nothing and report an unincremented offset to encode this case.
-                if self.update_stash.len() == 1 && self.update_stash.last() == self.result.updates.last() {
+                if self.update_stash.len() == 1 && self.result.updates.last().map(|l| l.equals(self.update_stash.last().unwrap())).unwrap_or(false) {
                     // Just clear out update_stash, as we won't drain it here.
                     self.update_stash.clear();
                     self.singletons += 1;
@@ -580,8 +584,7 @@ mod val_batch {
     /// the cursor, rather than internal state.
     pub struct RhhValCursor<L: Layout> 
     where 
-        <L::Target as Update>::Key: HashOrdered,
-        <L::Target as Update>::KeyOwned: Default + HashOrdered,
+        <L::Target as Update>::Key: Default + HashOrdered,
     {
         /// Absolute position of the current key.
         key_cursor: usize,
@@ -593,18 +596,19 @@ mod val_batch {
 
     impl<L: Layout> Cursor for RhhValCursor<L> 
     where 
-        <L::Target as Update>::Key: HashOrdered,
-        <L::Target as Update>::KeyOwned: Default + HashOrdered,
+        <L::Target as Update>::Key: Default + HashOrdered,
+        for<'a> <L::KeyContainer as BatchContainer>::ReadItem<'a>: HashOrdered,
     {
-        type Key = <L::Target as Update>::Key;
-        type Val<'a> = &'a <L::Target as Update>::Val;
-        type ValOwned = <L::Target as Update>::ValOwned;
+        type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
+        type KeyOwned = <L::Target as Update>::Key;
+        type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
+        type ValOwned = <L::Target as Update>::Val;
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 
         type Storage = RhhValBatch<L>;
 
-        fn key<'a>(&self, storage: &'a RhhValBatch<L>) -> &'a Self::Key { 
+        fn key<'a>(&self, storage: &'a RhhValBatch<L>) -> Self::Key<'a> { 
             storage.storage.keys.index(self.key_cursor) 
         }
         fn val<'a>(&self, storage: &'a RhhValBatch<L>) -> Self::Val<'a> { storage.storage.vals.index(self.val_cursor) }
@@ -629,9 +633,9 @@ mod val_batch {
                 self.key_cursor = storage.storage.keys.len();
             }
         }
-        fn seek_key(&mut self, storage: &RhhValBatch<L>, key: &Self::Key) {
+        fn seek_key<'a>(&mut self, storage: &RhhValBatch<L>, key: Self::Key<'a>) {
             // self.key_cursor += storage.storage.keys.advance(self.key_cursor, storage.storage.keys.len(), |x| x.lt(key));
-            let desired = storage.storage.desired_location(key);
+            let desired = storage.storage.desired_location(&key);
             // Advance the cursor, if `desired` is ahead of it.
             if self.key_cursor < desired {
                 self.key_cursor = desired;
@@ -656,7 +660,7 @@ mod val_batch {
             }
         }
         fn seek_val<'a>(&mut self, storage: &RhhValBatch<L>, val: Self::Val<'a>) {
-            self.val_cursor += storage.storage.vals.advance(self.val_cursor, storage.storage.values_for_key(self.key_cursor).1, |x| x.lt(val));
+            self.val_cursor += storage.storage.vals.advance(self.val_cursor, storage.storage.values_for_key(self.key_cursor).1, |x| x.lt(&val));
         }
         fn rewind_keys(&mut self, storage: &RhhValBatch<L>) {
             self.key_cursor = 0;
@@ -674,8 +678,7 @@ mod val_batch {
     /// A builder for creating layers from unsorted update tuples.
     pub struct RhhValBuilder<L: Layout> 
     where 
-        <L::Target as Update>::Key: HashOrdered,
-        <L::Target as Update>::KeyOwned: Default + HashOrdered,
+        <L::Target as Update>::Key: Default + HashOrdered,
     {
         result: RhhValStorage<L>,
         singleton: Option<(<L::Target as Update>::Time, <L::Target as Update>::Diff)>,
@@ -688,8 +691,7 @@ mod val_batch {
 
     impl<L: Layout> RhhValBuilder<L> 
     where 
-        <L::Target as Update>::Key: HashOrdered,
-        <L::Target as Update>::KeyOwned: Default + HashOrdered,
+        <L::Target as Update>::Key: Default + HashOrdered,
     {
         /// Pushes a single update, which may set `self.singleton` rather than push.
         ///
@@ -720,12 +722,10 @@ mod val_batch {
 
     impl<L: Layout> Builder for RhhValBuilder<L>
     where
-        <L::Target as Update>::Key: HashOrdered,
-        <L::Target as Update>::KeyOwned: Default + HashOrdered,
-        <L::Target as Update>::KeyOwned: Borrow<<L::Target as Update>::Key>,
-        RhhValBatch<L>: Batch<Key=<L::Target as Update>::Key, Val=<L::Target as Update>::Val, Time=<L::Target as Update>::Time, Diff=<L::Target as Update>::Diff>
+        <L::Target as Update>::Key: Default + HashOrdered,
+        // RhhValBatch<L>: Batch<Key=<L::Target as Update>::Key, Val=<L::Target as Update>::Val, Time=<L::Target as Update>::Time, Diff=<L::Target as Update>::Diff>,
     {
-        type Item = ((<L::Target as Update>::KeyOwned, <L::Target as Update>::ValOwned), <L::Target as Update>::Time, <L::Target as Update>::Diff);
+        type Item = ((<L::Target as Update>::Key, <L::Target as Update>::Val), <L::Target as Update>::Time, <L::Target as Update>::Diff);
         type Time = <L::Target as Update>::Time;
         type Output = RhhValBatch<L>;
 
@@ -760,9 +760,9 @@ mod val_batch {
         fn push(&mut self, ((key, val), time, diff): Self::Item) {
 
             // Perhaps this is a continuation of an already received key.
-            if self.result.keys.last() == Some(key.borrow()) {
+            if self.result.keys.last().map(|k| k.equals(&key)).unwrap_or(false) {
                 // Perhaps this is a continuation of an already received value.
-                if self.result.vals.last() == Some(val.borrow()) {
+                if self.result.vals.last().map(|v| v.equals(&val)).unwrap_or(false) {
                     self.push_update(time, diff);
                 } else {
                     // New value; complete representation of prior value.
@@ -787,9 +787,9 @@ mod val_batch {
         fn copy(&mut self, ((key, val), time, diff): &Self::Item) {
 
             // Perhaps this is a continuation of an already received key.
-            if self.result.keys.last() == Some(key.borrow()) {
+            if self.result.keys.last().map(|k| k.equals(key)).unwrap_or(false) {
                 // Perhaps this is a continuation of an already received value.
-                if self.result.vals.last() == Some(val.borrow()) {
+                if self.result.vals.last().map(|v| v.equals(val)).unwrap_or(false) {
                     // TODO: here we could look for repetition, and not push the update in that case.
                     // More logic (and state) would be required to correctly wrangle this.
                     self.push_update(time.clone(), diff.clone());
@@ -799,7 +799,7 @@ mod val_batch {
                     // Remove any pending singleton, and if it was set increment our count.
                     if self.singleton.take().is_some() { self.singletons += 1; }
                     self.push_update(time.clone(), diff.clone());
-                    self.result.vals.copy(val.borrow());
+                    self.result.vals.copy_push(val);
                 }
             } else {
                 // New key; complete representation of prior key.
@@ -808,9 +808,9 @@ mod val_batch {
                 if self.singleton.take().is_some() { self.singletons += 1; }
                 self.result.keys_offs.push(self.result.vals.len().try_into().ok().unwrap());
                 self.push_update(time.clone(), diff.clone());
-                self.result.vals.copy(val.borrow());
+                self.result.vals.copy_push(val);
                 // Insert the key, but with no specified offset.
-                self.result.insert_key(key.borrow(), None);
+                self.result.insert_key(key, None);
             }
         }
 

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -633,7 +633,7 @@ mod val_batch {
                 self.key_cursor = storage.storage.keys.len();
             }
         }
-        fn seek_key<'a>(&mut self, storage: &RhhValBatch<L>, key: Self::Key<'a>) {
+        fn seek_key(&mut self, storage: &RhhValBatch<L>, key: Self::Key<'_>) {
             // self.key_cursor += storage.storage.keys.advance(self.key_cursor, storage.storage.keys.len(), |x| x.lt(key));
             let desired = storage.storage.desired_location(&key);
             // Advance the cursor, if `desired` is ahead of it.
@@ -659,7 +659,7 @@ mod val_batch {
                 self.val_cursor = storage.storage.values_for_key(self.key_cursor).1;
             }
         }
-        fn seek_val<'a>(&mut self, storage: &RhhValBatch<L>, val: Self::Val<'a>) {
+        fn seek_val(&mut self, storage: &RhhValBatch<L>, val: Self::Val<'_>) {
             self.val_cursor += storage.storage.vals.advance(self.val_cursor, storage.storage.values_for_key(self.key_cursor).1, |x| x.lt(&val));
         }
         fn rewind_keys(&mut self, storage: &RhhValBatch<L>) {

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -597,7 +597,8 @@ mod val_batch {
         <L::Target as Update>::KeyOwned: Default + HashOrdered,
     {
         type Key = <L::Target as Update>::Key;
-        type Val = <L::Target as Update>::Val;
+        type Val<'a> = &'a <L::Target as Update>::Val;
+        type ValOwned = <L::Target as Update>::ValOwned;
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 
@@ -606,7 +607,7 @@ mod val_batch {
         fn key<'a>(&self, storage: &'a RhhValBatch<L>) -> &'a Self::Key { 
             storage.storage.keys.index(self.key_cursor) 
         }
-        fn val<'a>(&self, storage: &'a RhhValBatch<L>) -> &'a Self::Val { storage.storage.vals.index(self.val_cursor) }
+        fn val<'a>(&self, storage: &'a RhhValBatch<L>) -> Self::Val<'a> { storage.storage.vals.index(self.val_cursor) }
         fn map_times<L2: FnMut(&Self::Time, &Self::Diff)>(&mut self, storage: &RhhValBatch<L>, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_value(self.val_cursor);
             for index in lower .. upper {
@@ -654,7 +655,7 @@ mod val_batch {
                 self.val_cursor = storage.storage.values_for_key(self.key_cursor).1;
             }
         }
-        fn seek_val(&mut self, storage: &RhhValBatch<L>, val: &Self::Val) {
+        fn seek_val<'a>(&mut self, storage: &RhhValBatch<L>, val: Self::Val<'a>) {
             self.val_cursor += storage.storage.vals.advance(self.val_cursor, storage.storage.values_for_key(self.key_cursor).1, |x| x.lt(val));
         }
         fn rewind_keys(&mut self, storage: &RhhValBatch<L>) {

--- a/src/trace/implementations/spine_fueled.rs
+++ b/src/trace/implementations/spine_fueled.rs
@@ -112,13 +112,13 @@ where
 impl<B, BA, BU> TraceReader for Spine<B, BA, BU>
 where
     B: Batch+Clone+'static,
-    B::Key: Ord,           // Clone is required by `batch::advance_*` (in-place could remove).
-    B::Val: Ord,           // Clone is required by `batch::advance_*` (in-place could remove).
     B::Time: Lattice+timely::progress::Timestamp+Ord+Clone+Debug,
     B::Diff: Semigroup,
 {
-    type Key = B::Key;
-    type Val = B::Val;
+    type Key<'a> = B::Key<'a>;
+    type KeyOwned = B::KeyOwned;
+    type Val<'a> = B::Val<'a>;
+    type ValOwned = B::ValOwned;
     type Time = B::Time;
     type Diff = B::Diff;
 
@@ -260,8 +260,6 @@ where
 impl<B, BA, BU> Trace for Spine<B, BA, BU>
 where
     B: Batch+Clone+'static,
-    B::Key: Ord,
-    B::Val: Ord,
     B::Time: Lattice+timely::progress::Timestamp+Ord+Clone+Debug,
     B::Diff: Semigroup,
     BA: Batcher<Time = B::Time>,
@@ -403,8 +401,6 @@ where
 impl<B, BA, BU> Spine<B, BA, BU>
 where
     B: Batch,
-    B::Key: Ord,
-    B::Val: Ord,
     B::Time: Lattice+timely::progress::Timestamp+Ord+Clone+Debug,
     B::Diff: Semigroup,
 {

--- a/src/trace/wrappers/enter.rs
+++ b/src/trace/wrappers/enter.rs
@@ -181,7 +181,8 @@ where
     TInner: Refines<C::Time>+Lattice,
 {
     type Key = C::Key;
-    type Val = C::Val;
+    type Val<'a> = C::Val<'a>;
+    type ValOwned = C::ValOwned;
     type Time = TInner;
     type Diff = C::Diff;
 
@@ -191,7 +192,7 @@ where
     #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
 
     #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Key { self.cursor.key(storage) }
-    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Val { self.cursor.val(storage) }
+    #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
     #[inline]
     fn map_times<L: FnMut(&TInner, &Self::Diff)>(&mut self, storage: &Self::Storage, mut logic: L) {
@@ -204,7 +205,7 @@ where
     #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &Self::Key) { self.cursor.seek_key(storage, key) }
 
     #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
-    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: &Self::Val) { self.cursor.seek_val(storage, val) }
+    #[inline] fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>) { self.cursor.seek_val(storage, val) }
 
     #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
     #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
@@ -227,15 +228,16 @@ impl<B: BatchReader, TInner> BatchCursorEnter<B, TInner> {
     }
 }
 
-impl<TInner, B: BatchReader> Cursor for BatchCursorEnter<B, TInner>
+impl<TInner, C: Cursor<Storage=B, Time=B::Time>, B: BatchReader<Cursor=C>> Cursor for BatchCursorEnter<B, TInner>
 where
     B::Time: Timestamp,
     TInner: Refines<B::Time>+Lattice,
 {
-    type Key = B::Key;
-    type Val = B::Val;
+    type Key = C::Key;
+    type Val<'a> = C::Val<'a>;
+    type ValOwned = C::ValOwned;
     type Time = TInner;
-    type Diff = B::Diff;
+    type Diff = C::Diff;
 
     type Storage = BatchEnter<B, TInner>;
 
@@ -243,7 +245,7 @@ where
     #[inline] fn val_valid(&self, storage: &BatchEnter<B, TInner>) -> bool { self.cursor.val_valid(&storage.batch) }
 
     #[inline] fn key<'a>(&self, storage: &'a BatchEnter<B, TInner>) -> &'a Self::Key { self.cursor.key(&storage.batch) }
-    #[inline] fn val<'a>(&self, storage: &'a BatchEnter<B, TInner>) -> &'a Self::Val { self.cursor.val(&storage.batch) }
+    #[inline] fn val<'a>(&self, storage: &'a BatchEnter<B, TInner>) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
 
     #[inline]
     fn map_times<L: FnMut(&TInner, &Self::Diff)>(&mut self, storage: &BatchEnter<B, TInner>, mut logic: L) {
@@ -256,7 +258,7 @@ where
     #[inline] fn seek_key(&mut self, storage: &BatchEnter<B, TInner>, key: &Self::Key) { self.cursor.seek_key(&storage.batch, key) }
 
     #[inline] fn step_val(&mut self, storage: &BatchEnter<B, TInner>) { self.cursor.step_val(&storage.batch) }
-    #[inline] fn seek_val(&mut self, storage: &BatchEnter<B, TInner>, val: &Self::Val) { self.cursor.seek_val(&storage.batch, val) }
+    #[inline] fn seek_val<'a>(&mut self, storage: &BatchEnter<B, TInner>, val: Self::Val<'a>) { self.cursor.seek_val(&storage.batch, val) }
 
     #[inline] fn rewind_keys(&mut self, storage: &BatchEnter<B, TInner>) { self.cursor.rewind_keys(&storage.batch) }
     #[inline] fn rewind_vals(&mut self, storage: &BatchEnter<B, TInner>) { self.cursor.rewind_vals(&storage.batch) }

--- a/src/trace/wrappers/enter.rs
+++ b/src/trace/wrappers/enter.rs
@@ -36,14 +36,14 @@ impl<Tr, TInner> TraceReader for TraceEnter<Tr, TInner>
 where
     Tr: TraceReader,
     Tr::Batch: Clone,
-    Tr::Key: 'static,
-    Tr::Val: 'static,
     Tr::Time: Timestamp,
     Tr::Diff: 'static,
     TInner: Refines<Tr::Time>+Lattice,
 {
-    type Key = Tr::Key;
-    type Val = Tr::Val;
+    type Key<'a> = Tr::Key<'a>;
+    type KeyOwned = Tr::KeyOwned;
+    type Val<'a> = Tr::Val<'a>;
+    type ValOwned = Tr::ValOwned;
     type Time = TInner;
     type Diff = Tr::Diff;
 
@@ -126,8 +126,10 @@ where
     B::Time: Timestamp,
     TInner: Refines<B::Time>+Lattice,
 {
-    type Key = B::Key;
-    type Val = B::Val;
+    type Key<'a> = B::Key<'a>;
+    type KeyOwned = B::KeyOwned;
+    type Val<'a> = B::Val<'a>;
+    type ValOwned = B::ValOwned;
     type Time = TInner;
     type Diff = B::Diff;
 
@@ -180,7 +182,8 @@ where
     C::Time: Timestamp,
     TInner: Refines<C::Time>+Lattice,
 {
-    type Key = C::Key;
+    type Key<'a> = C::Key<'a>;
+    type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
     type ValOwned = C::ValOwned;
     type Time = TInner;
@@ -191,7 +194,7 @@ where
     #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
     #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
 
-    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Key { self.cursor.key(storage) }
+    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(storage) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
     #[inline]
@@ -202,7 +205,7 @@ where
     }
 
     #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &Self::Key) { self.cursor.seek_key(storage, key) }
+    #[inline] fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>) { self.cursor.seek_key(storage, key) }
 
     #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
     #[inline] fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>) { self.cursor.seek_val(storage, val) }
@@ -233,7 +236,8 @@ where
     B::Time: Timestamp,
     TInner: Refines<B::Time>+Lattice,
 {
-    type Key = C::Key;
+    type Key<'a> = C::Key<'a>;
+    type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
     type ValOwned = C::ValOwned;
     type Time = TInner;
@@ -244,7 +248,7 @@ where
     #[inline] fn key_valid(&self, storage: &BatchEnter<B, TInner>) -> bool { self.cursor.key_valid(&storage.batch) }
     #[inline] fn val_valid(&self, storage: &BatchEnter<B, TInner>) -> bool { self.cursor.val_valid(&storage.batch) }
 
-    #[inline] fn key<'a>(&self, storage: &'a BatchEnter<B, TInner>) -> &'a Self::Key { self.cursor.key(&storage.batch) }
+    #[inline] fn key<'a>(&self, storage: &'a BatchEnter<B, TInner>) -> Self::Key<'a> { self.cursor.key(&storage.batch) }
     #[inline] fn val<'a>(&self, storage: &'a BatchEnter<B, TInner>) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
 
     #[inline]
@@ -255,7 +259,7 @@ where
     }
 
     #[inline] fn step_key(&mut self, storage: &BatchEnter<B, TInner>) { self.cursor.step_key(&storage.batch) }
-    #[inline] fn seek_key(&mut self, storage: &BatchEnter<B, TInner>, key: &Self::Key) { self.cursor.seek_key(&storage.batch, key) }
+    #[inline] fn seek_key<'a>(&mut self, storage: &BatchEnter<B, TInner>, key: Self::Key<'a>) { self.cursor.seek_key(&storage.batch, key) }
 
     #[inline] fn step_val(&mut self, storage: &BatchEnter<B, TInner>) { self.cursor.step_val(&storage.batch) }
     #[inline] fn seek_val<'a>(&mut self, storage: &BatchEnter<B, TInner>, val: Self::Val<'a>) { self.cursor.seek_val(&storage.batch, val) }

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -52,7 +52,7 @@ where
     TInner: Refines<Tr::Time>+Lattice,
     Tr::Diff: 'static,
     F: 'static,
-    F: for<'a> FnMut(Tr::Key<'a>, Tr::Val<'a>, &Tr::Time)->TInner+Clone,
+    F: FnMut(Tr::Key<'_>, Tr::Val<'_>, &Tr::Time)->TInner+Clone,
     G: FnMut(&TInner)->Tr::Time+Clone+'static,
 {
     type Key<'a> = Tr::Key<'a>;
@@ -144,7 +144,7 @@ where
     B: BatchReader,
     B::Time: Timestamp,
     TInner: Refines<B::Time>+Lattice,
-    F: for <'a> FnMut(B::Key<'a>, <B::Cursor as Cursor>::Val<'a>, &B::Time)->TInner+Clone,
+    F: FnMut(B::Key<'_>, <B::Cursor as Cursor>::Val<'_>, &B::Time)->TInner+Clone,
 {
     type Key<'a> = B::Key<'a>;
     type KeyOwned = B::KeyOwned;
@@ -204,7 +204,7 @@ where
     C: Cursor,
     C::Time: Timestamp,
     TInner: Refines<C::Time>+Lattice,
-    F: for<'a> FnMut(C::Key<'a>, C::Val<'a>, &C::Time)->TInner,
+    F: FnMut(C::Key<'_>, C::Val<'_>, &C::Time)->TInner,
 {
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
@@ -232,10 +232,10 @@ where
     }
 
     #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-    #[inline] fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>) { self.cursor.seek_key(storage, key) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: Self::Key<'_>) { self.cursor.seek_key(storage, key) }
 
     #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
-    #[inline] fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>) { self.cursor.seek_val(storage, val) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: Self::Val<'_>) { self.cursor.seek_val(storage, val) }
 
     #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
     #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
@@ -260,12 +260,11 @@ impl<C, TInner, F> BatchCursorEnter<C, TInner, F> {
     }
 }
 
-// impl<TInner, C: Cursor<Storage=B, Time=B::Time, Key=B::Key>, B: BatchReader<Cursor=C>, F> Cursor for BatchCursorEnter<B, TInner, F>
 impl<TInner, C: Cursor, F> Cursor for BatchCursorEnter<C, TInner, F>
 where
     C::Time: Timestamp,
     TInner: Refines<C::Time>+Lattice,
-    F: for<'a> FnMut(C::Key<'a>, C::Val<'a>, &C::Time)->TInner,
+    F: FnMut(C::Key<'_>, C::Val<'_>, &C::Time)->TInner,
 {
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
@@ -293,10 +292,10 @@ where
     }
 
     #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
-    #[inline] fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>) { self.cursor.seek_key(&storage.batch, key) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: Self::Key<'_>) { self.cursor.seek_key(&storage.batch, key) }
 
     #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
-    #[inline] fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>) { self.cursor.seek_val(&storage.batch, val) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: Self::Val<'_>) { self.cursor.seek_val(&storage.batch, val) }
 
     #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
     #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }

--- a/src/trace/wrappers/filter.rs
+++ b/src/trace/wrappers/filter.rs
@@ -31,7 +31,7 @@ where
     Tr::Batch: Clone,
     Tr::Time: Timestamp,
     Tr::Diff: 'static,
-    F: for<'a> FnMut(Tr::Key<'a>, Tr::Val<'a>)->bool+Clone+'static,
+    F: FnMut(Tr::Key<'_>, Tr::Val<'_>)->bool+Clone+'static,
 {
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
@@ -87,7 +87,7 @@ impl<B, F> BatchReader for BatchFilter<B, F>
 where
     B: BatchReader,
     B::Time: Timestamp,
-    F: for<'a> FnMut(B::Key<'a>, B::Val<'a>)->bool+Clone+'static
+    F: FnMut(B::Key<'_>, B::Val<'_>)->bool+Clone+'static
 {
     type Key<'a> = B::Key<'a>;
     type KeyOwned = B::KeyOwned;
@@ -138,7 +138,7 @@ impl<C, F> Cursor for CursorFilter<C, F>
 where
     C: Cursor,
     C::Time: Timestamp,
-    F: for<'a> FnMut(C::Key<'a>, C::Val<'a>)->bool+'static
+    F: FnMut(C::Key<'_>, C::Val<'_>)->bool+'static
 {
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
@@ -165,10 +165,10 @@ where
     }
 
     #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-    #[inline] fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>) { self.cursor.seek_key(storage, key) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: Self::Key<'_>) { self.cursor.seek_key(storage, key) }
 
     #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
-    #[inline] fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>) { self.cursor.seek_val(storage, val) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: Self::Val<'_>) { self.cursor.seek_val(storage, val) }
 
     #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
     #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
@@ -194,7 +194,7 @@ impl<C, F> BatchCursorFilter<C, F> {
 impl<C: Cursor, F> Cursor for BatchCursorFilter<C, F>
 where
     C::Time: Timestamp,
-    F: for <'a> FnMut(C::Key<'a>, C::Val<'a>)->bool+'static,
+    F: FnMut(C::Key<'_>, C::Val<'_>)->bool+'static,
 {
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
@@ -221,10 +221,10 @@ where
     }
 
     #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
-    #[inline] fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>) { self.cursor.seek_key(&storage.batch, key) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: Self::Key<'_>) { self.cursor.seek_key(&storage.batch, key) }
 
     #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
-    #[inline] fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>) { self.cursor.seek_val(&storage.batch, val) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: Self::Val<'_>) { self.cursor.seek_val(&storage.batch, val) }
 
     #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
     #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }

--- a/src/trace/wrappers/freeze.rs
+++ b/src/trace/wrappers/freeze.rs
@@ -229,10 +229,10 @@ where
     }
 
     #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-    #[inline] fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>) { self.cursor.seek_key(storage, key) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: Self::Key<'_>) { self.cursor.seek_key(storage, key) }
 
     #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
-    #[inline] fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>) { self.cursor.seek_val(storage, val) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: Self::Val<'_>) { self.cursor.seek_val(storage, val) }
 
     #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
     #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
@@ -284,10 +284,10 @@ where
     }
 
     #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
-    #[inline] fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>) { self.cursor.seek_key(&storage.batch, key) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: Self::Key<'_>) { self.cursor.seek_key(&storage.batch, key) }
 
     #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
-    #[inline] fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>) { self.cursor.seek_val(&storage.batch, val) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: Self::Val<'_>) { self.cursor.seek_val(&storage.batch, val) }
 
     #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
     #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }

--- a/src/trace/wrappers/frontier.rs
+++ b/src/trace/wrappers/frontier.rs
@@ -43,13 +43,13 @@ impl<Tr> TraceReader for TraceFrontier<Tr>
 where
     Tr: TraceReader,
     Tr::Batch: Clone,
-    Tr::Key: 'static,
-    Tr::Val: 'static,
     Tr::Time: Timestamp+Lattice,
     Tr::Diff: 'static,
 {
-    type Key = Tr::Key;
-    type Val = Tr::Val;
+    type Key<'a> = Tr::Key<'a>;
+    type KeyOwned = Tr::KeyOwned;
+    type Val<'a> = Tr::Val<'a>;
+    type ValOwned = Tr::ValOwned;
     type Time = Tr::Time;
     type Diff = Tr::Diff;
 
@@ -105,8 +105,10 @@ where
     B: BatchReader,
     B::Time: Timestamp+Lattice,
 {
-    type Key = B::Key;
-    type Val = B::Val;
+    type Key<'a> = B::Key<'a>;
+    type KeyOwned = B::KeyOwned;
+    type Val<'a> = B::Val<'a>;
+    type ValOwned = B::ValOwned;
     type Time = B::Time;
     type Diff = B::Diff;
 
@@ -156,7 +158,8 @@ where
     C: Cursor<Time=T>,
     T: Timestamp+Lattice,
 {
-    type Key = C::Key;
+    type Key<'a> = C::Key<'a>;
+    type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
     type ValOwned = C::ValOwned;
     type Time = C::Time;
@@ -167,7 +170,7 @@ where
     #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
     #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(storage) }
 
-    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Key { self.cursor.key(storage) }
+    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(storage) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
     #[inline]
@@ -185,7 +188,7 @@ where
     }
 
     #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &Self::Key) { self.cursor.seek_key(storage, key) }
+    #[inline] fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>) { self.cursor.seek_key(storage, key) }
 
     #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
     #[inline] fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>) { self.cursor.seek_val(storage, val) }
@@ -218,7 +221,8 @@ where
     C::Time: Timestamp+Lattice,
     C::Storage: BatchReader,
 {
-    type Key = C::Key;
+    type Key<'a> = C::Key<'a>;
+    type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
     type ValOwned = C::ValOwned;
     type Time = C::Time;
@@ -229,7 +233,7 @@ where
     #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }
     #[inline] fn val_valid(&self, storage: &Self::Storage) -> bool { self.cursor.val_valid(&storage.batch) }
 
-    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> &'a Self::Key { self.cursor.key(&storage.batch) }
+    #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(&storage.batch) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
 
     #[inline]
@@ -247,7 +251,7 @@ where
     }
 
     #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
-    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: &Self::Key) { self.cursor.seek_key(&storage.batch, key) }
+    #[inline] fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>) { self.cursor.seek_key(&storage.batch, key) }
 
     #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
     #[inline] fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>) { self.cursor.seek_val(&storage.batch, val) }

--- a/src/trace/wrappers/frontier.rs
+++ b/src/trace/wrappers/frontier.rs
@@ -188,10 +188,10 @@ where
     }
 
     #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(storage) }
-    #[inline] fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>) { self.cursor.seek_key(storage, key) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: Self::Key<'_>) { self.cursor.seek_key(storage, key) }
 
     #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(storage) }
-    #[inline] fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>) { self.cursor.seek_val(storage, val) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: Self::Val<'_>) { self.cursor.seek_val(storage, val) }
 
     #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(storage) }
     #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(storage) }
@@ -251,10 +251,10 @@ where
     }
 
     #[inline] fn step_key(&mut self, storage: &Self::Storage) { self.cursor.step_key(&storage.batch) }
-    #[inline] fn seek_key<'a>(&mut self, storage: &Self::Storage, key: Self::Key<'a>) { self.cursor.seek_key(&storage.batch, key) }
+    #[inline] fn seek_key(&mut self, storage: &Self::Storage, key: Self::Key<'_>) { self.cursor.seek_key(&storage.batch, key) }
 
     #[inline] fn step_val(&mut self, storage: &Self::Storage) { self.cursor.step_val(&storage.batch) }
-    #[inline] fn seek_val<'a>(&mut self, storage: &Self::Storage, val: Self::Val<'a>) { self.cursor.seek_val(&storage.batch, val) }
+    #[inline] fn seek_val(&mut self, storage: &Self::Storage, val: Self::Val<'_>) { self.cursor.seek_val(&storage.batch, val) }
 
     #[inline] fn rewind_keys(&mut self, storage: &Self::Storage) { self.cursor.rewind_keys(&storage.batch) }
     #[inline] fn rewind_vals(&mut self, storage: &Self::Storage) { self.cursor.rewind_vals(&storage.batch) }

--- a/src/trace/wrappers/rc.rs
+++ b/src/trace/wrappers/rc.rs
@@ -96,8 +96,10 @@ where
     Tr::Time: Lattice+Ord+Clone+'static,
     Tr: TraceReader,
 {
-    type Key = Tr::Key;
-    type Val = Tr::Val;
+    type Key<'a> = Tr::Key<'a>;
+    type KeyOwned = Tr::KeyOwned;
+    type Val<'a> = Tr::Val<'a>;
+    type ValOwned = Tr::ValOwned;
     type Time = Tr::Time;
     type Diff = Tr::Diff;
 


### PR DESCRIPTION
This PR introduces support for Generic Associated Types for arrangement `Key` and `Val` associated types. The types are generic in a lifetime `'storage` that corresponds to the shared read-only storage from which they are read. Conventionally these types would be `&'a Key` and `&'a Val` for some standard key and value types, like `String`. By allowing them to vary with lifetimes, we can introduce new types that serve a smart pointers to the corresponding content. This allows for example encoded data returned with a shared codebook, or returning pairs of references rather than a reference to a pair (allowing more columnar support).

The changes are pervasive, but everywhere the theme is that `::Key` turns to `::Key<'a>` and `::Val` turns to `::Val<'a>`. More traits also now have an associated `KeyOwned` and `ValOwned` type; these are lifetime-less types that each of the lifetimed traits can be converted into. There is a helpful trait `MyTrait` (better name pending) which describes something like a generalization of `ToOwned`, without requiring a `Borrow` implementation, and some convenience methods.

The only "harm" I've found so far is that lifetime GATs can force some `'static` bound introductions where they didn't exist before. These are e.g. when you write `type Val<'a> = &'a T`, then `T` will need to be outlive all of the `Val<'a>` up to and including `Val<'static>`.