### PR TITLE
First cut at neu key-only spine

### DIFF
--- a/examples/spines.rs
+++ b/examples/spines.rs
@@ -31,14 +31,14 @@ fn main() {
 
             match mode.as_str() {
                 "new" => {
-                    use differential_dataflow::trace::implementations::ord::ColKeySpine;
+                    use differential_dataflow::trace::implementations::ord_neu::ColKeySpine;
                     let data = data.arrange::<ColKeySpine<_,_,_>>();
                     let keys = keys.arrange::<ColKeySpine<_,_,_>>();
                     keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
                         .probe_with(&mut probe);
                 },
                 "old" => {
-                    use differential_dataflow::trace::implementations::ord::OrdKeySpine;
+                    use differential_dataflow::trace::implementations::ord_neu::OrdKeySpine;
                     let data = data.arrange::<OrdKeySpine<_,_,_>>();
                     let keys = keys.arrange::<OrdKeySpine<_,_,_>>();
                     keys.join_core(&data, |_k, &(), &()| Option::<()>::None)

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -45,13 +45,13 @@ pub(crate) mod merge_batcher_col;
 
 pub use self::merge_batcher::MergeBatcher as Batcher;
 
-pub mod ord;
+// pub mod ord;
 pub mod ord_neu;
 pub mod rhh;
 
 // Opinionated takes on default spines.
-pub use self::ord::OrdValSpine as ValSpine;
-pub use self::ord::OrdKeySpine as KeySpine;
+pub use self::ord_neu::OrdValSpine as ValSpine;
+pub use self::ord_neu::OrdKeySpine as KeySpine;
 
 use std::borrow::{Borrow, ToOwned};
 

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -10,7 +10,7 @@
 pub mod cursor;
 pub mod description;
 pub mod implementations;
-pub mod layers;
+// pub mod layers;
 pub mod wrappers;
 
 use timely::communication::message::RefOrMut;


### PR DESCRIPTION
First cut at `ord_neu::OrdKeySpine`. Lots of copy/pasta, and opportunities for bugs. Though, many of them caught because the `vals` names went away. Should do some testing. Also, the PR removes `ord` and `layers`, which is an opinionated take. At least, comments them out and sets default traces to `ord_neu`. We can delete once we are more certain.