### PR TITLE
Make contents of OffsetList pub

### DIFF
--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -231,9 +231,9 @@ use std::convert::TryInto;
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Abomonation)]
 pub struct OffsetList {
     /// Offsets that fit within a `u32`.
-    smol: Vec<u32>,
+    pub smol: Vec<u32>,
     /// Offsets that either do not fit in a `u32`, or are inserted after some offset that did not fit.
-    chonk: Vec<u64>,
+    pub chonk: Vec<u64>,
 }
 
 impl OffsetList {


### PR DESCRIPTION
Make the contents of `OffsetList` pub. Although it's strange to have this as part of the public interface, it'll be useful to surface its size clients interested in it.