### PR TITLE
Reorganize arrangement methods

### DIFF
--- a/examples/graspan.rs
+++ b/examples/graspan.rs
@@ -17,7 +17,7 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::input::{Input, InputSession};
 use differential_dataflow::operators::arrange::{ArrangeByKey, ArrangeBySelf};
 use differential_dataflow::operators::iterate::Variable;
-use differential_dataflow::operators::{Threshold, JoinCore};
+use differential_dataflow::operators::Threshold;
 
 type Node = usize;
 type Edge = (Node, Node);

--- a/examples/spines.rs
+++ b/examples/spines.rs
@@ -54,16 +54,15 @@ fn main() {
                 "slc" => {
 
                     use differential_dataflow::trace::implementations::ord_neu::PreferredSpine;
-                    use differential_dataflow::operators::reduce::ReduceCore;
 
                     let data =
                     data.map(|x| (x.clone().into_bytes(), x.into_bytes()))
-                        .arrange::<PreferredSpine<[u8],[u8],_,_>>();
-                        // .reduce_abelian::<_, PreferredSpine<[u8],(),_,_>>("distinct", |_,_,output| output.push(((), 1)));
+                        .arrange::<PreferredSpine<[u8],[u8],_,_>>()
+                        .reduce_abelian::<_, PreferredSpine<[u8],(),_,_>>("distinct", |_,_,output| output.push(((), 1)));
                     let keys =
                     keys.map(|x| (x.clone().into_bytes(), 7))
-                        .arrange::<PreferredSpine<[u8],u8,_,_>>();
-                        // .reduce_abelian::<_, PreferredSpine<[u8],(),_,_>>("distinct", |_,_,output| output.push(((), 1)));
+                        .arrange::<PreferredSpine<[u8],u8,_,_>>()
+                        .reduce_abelian::<_, PreferredSpine<[u8],(),_,_>>("distinct", |_,_,output| output.push(((), 1)));
 
                     keys.join_core(&data, |k,_v1,_v2| {
                         println!("{:?}", k.text);

--- a/examples/spines.rs
+++ b/examples/spines.rs
@@ -24,7 +24,7 @@ fn main() {
         let mut probe = Handle::new();
         let (mut data_input, mut keys_input) = worker.dataflow(|scope| {
 
-            use differential_dataflow::operators::{arrange::Arrange, JoinCore, join::join_traces};
+            use differential_dataflow::operators::{arrange::Arrange};
 
             let (data_input, data) = scope.new_collection::<String, isize>();
             let (keys_input, keys) = scope.new_collection::<String, isize>();
@@ -65,7 +65,7 @@ fn main() {
                         .arrange::<PreferredSpine<[u8],u8,_,_>>();
                         // .reduce_abelian::<_, PreferredSpine<[u8],(),_,_>>("distinct", |_,_,output| output.push(((), 1)));
 
-                    join_traces(&keys, &data, |k,v1,v2,t,r1,r2| {
+                    keys.join_core(&data, |k,_v1,_v2| {
                         println!("{:?}", k.text);
                         Option::<((),isize,isize)>::None
                     })

--- a/src/algorithms/graphs/propagate.rs
+++ b/src/algorithms/graphs/propagate.rs
@@ -89,8 +89,6 @@ where
 
         use timely::order::Product;
 
-        use operators::join::JoinCore;
-        
         let edges = edges.enter(scope);
         let nodes = nodes.enter_at(scope, move |r| 256 * (64 - (logic(&r.1)).leading_zeros() as usize));
 

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -410,6 +410,48 @@ where
     }
 }
 
+
+use difference::Multiply;
+// Direct join implementations.
+impl<G: Scope, Tr> Arranged<G, Tr>
+where
+    G::Timestamp: Lattice+Ord,
+    Tr: TraceReader<Time=G::Timestamp> + Clone + 'static,
+    Tr::Diff: Semigroup,
+{
+    /// A direct implementation of the `JoinCore::join_core` method.
+    pub fn join_core<Tr2,I,L>(&self, other: &Arranged<G,Tr2>, mut result: L) -> Collection<G,I::Item,<Tr::Diff as Multiply<Tr2::Diff>>::Output>
+    where
+        Tr2: for<'a> TraceReader<Key<'a>=Tr::Key<'a>,Time=G::Timestamp>+Clone+'static,
+        Tr2::Diff: Semigroup,
+        Tr::Diff: Multiply<Tr2::Diff>,
+        <Tr::Diff as Multiply<Tr2::Diff>>::Output: Semigroup,
+        I: IntoIterator,
+        I::Item: Data,
+        L: FnMut(Tr::Key<'_>,Tr::Val<'_>,Tr2::Val<'_>)->I+'static
+    {
+        let result = move |k: Tr::Key<'_>, v1: Tr::Val<'_>, v2: Tr2::Val<'_>, t: &G::Timestamp, r1: &Tr::Diff, r2: &Tr2::Diff| {
+            let t = t.clone();
+            let r = (r1.clone()).multiply(r2);
+            result(k, v1, v2).into_iter().map(move |d| (d, t.clone(), r.clone()))
+        };
+        self.join_core_internal_unsafe(other, result)
+    }
+    /// A direct implementation of the `JoinCore::join_core_internal_unsafe` method.
+    pub fn join_core_internal_unsafe<Tr2,I,L,D,ROut> (&self, other: &Arranged<G,Tr2>, result: L) -> Collection<G,D,ROut>
+    where
+        Tr2: for<'a> TraceReader<Key<'a>=Tr::Key<'a>, Time=G::Timestamp>+Clone+'static,
+        Tr2::Diff: Semigroup,
+        D: Data,
+        ROut: Semigroup,
+        I: IntoIterator<Item=(D, G::Timestamp, ROut)>,
+        L: FnMut(Tr::Key<'_>, Tr::Val<'_>,Tr2::Val<'_>,&G::Timestamp,&Tr::Diff,&Tr2::Diff)->I+'static,
+    {
+        use operators::join::join_traces;
+        join_traces(self, other, result)
+    }
+}
+
 impl<'a, G: Scope, Tr> Arranged<Child<'a, G, G::Timestamp>, Tr>
 where
     G::Timestamp: Lattice+Ord,


### PR DESCRIPTION
With the introduction of Arrangement GATs, users of traces supporting non-standard gats (those other than `&K`) were unable to use the methods of `Join` and `Reduce`, on account of them requiring concrete `K` types to reference. The implementations of these same trait methods on arrangements are better done as inherent methods, which can reference the associated types of the traces in the arrangements. This removes the requirement to call out to free functions like `join_traces` and `reduce_trace`.