### PR TITLE
Bring differential to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,28 @@ repository = "https://github.com/TimelyDataflow/differential-dataflow.git"
 keywords = ["differential", "dataflow"]
 license = "MIT"
 readme = "README.md"
+edition="2021"
 
 [workspace]
-members = [".", "dogsdogsdogs"]
+members = [
+    ".",
+    # "advent_of_code_2017",
+    "dogsdogsdogs",
+    "experiments",
+    "interactive",
+    "server",
+    "server/dataflows/degr_dist",
+    "server/dataflows/neighborhood",
+    "server/dataflows/random_graph",
+    "server/dataflows/reachability",
+    #"tpchlike",
+    "doop"
+]
 
 [dev-dependencies]
 bincode = "1.3.1"
 rdkafka = "0.24"
-indexmap = "1.0.1"
+indexmap = "2.1"
 rand="0.4"
 byteorder="1"
 itertools="^0.7"
@@ -28,14 +42,16 @@ serde_json = "1.0"
 graph_map = "0.1"
 
 [dependencies]
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 abomonation = "0.7"
 abomonation_derive = "0.5"
+fnv="1.0.2"
+timely = {workspace = true}
+
+[workspace.dependencies]
 #timely = { version = "0.12", default-features = false }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
 #timely = { path = "../timely-dataflow/timely/", default-features = false }
-fnv="1.0.2"
 
 [features]
 default = ["timely/getopts"]

--- a/benches/sort-bench.rs
+++ b/benches/sort-bench.rs
@@ -2,10 +2,6 @@
 // #![feature(test)]
 // #![feature(collections)]
 //
-// extern crate differential_dataflow;
-// extern crate rand;
-// extern crate test;
-//
 // use rand::{Rng, SeedableRng, StdRng, Rand};
 // use test::Bencher;
 //

--- a/dogsdogsdogs/Cargo.toml
+++ b/dogsdogsdogs/Cargo.toml
@@ -3,11 +3,12 @@ name = "dogsdogsdogs"
 version = "0.1.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 license = "MIT"
+edition = "2021"
 
 [dependencies]
 abomonation = "0.7"
 abomonation_derive = "0.5"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
+timely = { workspace = true }
 differential-dataflow = { path = "../", default-features = false }
 serde = "1"
 serde_derive = "1"

--- a/dogsdogsdogs/examples/delta_query.rs
+++ b/dogsdogsdogs/examples/delta_query.rs
@@ -1,9 +1,3 @@
-extern crate timely;
-extern crate graph_map;
-extern crate differential_dataflow;
-
-extern crate dogsdogsdogs;
-
 use timely::dataflow::Scope;
 use timely::dataflow::operators::probe::Handle;
 use differential_dataflow::input::Input;

--- a/dogsdogsdogs/examples/delta_query2.rs
+++ b/dogsdogsdogs/examples/delta_query2.rs
@@ -1,9 +1,3 @@
-extern crate timely;
-extern crate graph_map;
-extern crate differential_dataflow;
-
-extern crate dogsdogsdogs;
-
 use timely::dataflow::Scope;
 use timely::order::Product;
 use timely::dataflow::operators::probe::Handle;

--- a/dogsdogsdogs/examples/delta_query_wcoj.rs
+++ b/dogsdogsdogs/examples/delta_query_wcoj.rs
@@ -1,9 +1,3 @@
-extern crate timely;
-extern crate graph_map;
-extern crate differential_dataflow;
-
-extern crate dogsdogsdogs;
-
 use timely::dataflow::Scope;
 use timely::dataflow::operators::probe::Handle;
 use differential_dataflow::input::Input;

--- a/dogsdogsdogs/examples/dogsdogsdogs.rs
+++ b/dogsdogsdogs/examples/dogsdogsdogs.rs
@@ -1,9 +1,3 @@
-extern crate timely;
-extern crate graph_map;
-extern crate differential_dataflow;
-
-extern crate dogsdogsdogs;
-
 use timely::dataflow::operators::{ToStream, Partition, Accumulate, Inspect, Probe};
 use timely::dataflow::operators::probe::Handle;
 use differential_dataflow::{Collection, AsCollection};

--- a/dogsdogsdogs/examples/ngo.rs
+++ b/dogsdogsdogs/examples/ngo.rs
@@ -1,7 +1,3 @@
-extern crate timely;
-extern crate graph_map;
-extern crate differential_dataflow;
-
 use std::hash::Hash;
 use timely::dataflow::*;
 use timely::dataflow::operators::*;

--- a/dogsdogsdogs/src/altneu.rs
+++ b/dogsdogsdogs/src/altneu.rs
@@ -11,7 +11,8 @@
 //! element of the second lattice, if neither first element equals
 //! the join.
 
-
+use abomonation_derive::Abomonation;
+use serde_derive::{Deserialize, Serialize};
 
 /// A pair of timestamps, partially ordered by the product order.
 #[derive(Debug, Hash, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Abomonation, Serialize, Deserialize)]

--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -1,12 +1,3 @@
-#[macro_use]
-extern crate abomonation_derive;
-extern crate abomonation;
-extern crate timely;
-extern crate differential_dataflow;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde;
-
 use std::hash::Hash;
 
 use timely::dataflow::Scope;

--- a/doop/Cargo.toml
+++ b/doop/Cargo.toml
@@ -2,8 +2,9 @@
 name = "doop"
 version = "0.1.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
+edition = "2021"
 
 [dependencies]
-indexmap = "1.0.1"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
+indexmap = "2.1"
+timely = {workspace = true}
 differential-dataflow = { path = "../" }

--- a/doop/src/main.rs
+++ b/doop/src/main.rs
@@ -1,10 +1,5 @@
 #![allow(non_snake_case)]
 
-extern crate indexmap;
-extern crate timely;
-extern crate differential_dataflow;
-
-
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::cell::RefCell;
@@ -17,7 +12,7 @@ use differential_dataflow::ExchangeData as Data;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::iterate::Variable;
-use differential_dataflow::operators::{Threshold, Join, JoinCore, Consolidate};
+use differential_dataflow::operators::{Threshold, Join, JoinCore};
 use differential_dataflow::operators::arrange::ArrangeByKey;
 
 // Type aliases for differential execution.

--- a/examples/accumulate.rs
+++ b/examples/accumulate.rs
@@ -1,7 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use differential_dataflow::input::Input;

--- a/examples/arrange.rs
+++ b/examples/arrange.rs
@@ -1,7 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::operators::*;

--- a/examples/bfs.rs
+++ b/examples/bfs.rs
@@ -1,7 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;

--- a/examples/capture-test.rs
+++ b/examples/capture-test.rs
@@ -1,10 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
-extern crate serde;
-extern crate rdkafka;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;

--- a/examples/compact.rs
+++ b/examples/compact.rs
@@ -1,6 +1,3 @@
-extern crate timely;
-extern crate differential_dataflow;
-
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::Threshold;
 

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -31,9 +31,6 @@
 //! Final graph: {(2, 1): 1, (3, 2): 1, (3, 4): 1, (4, 3): 1}
 //! ```
 
-extern crate differential_dataflow;
-extern crate timely;
-
 use std::fmt::Debug;
 use std::collections::BTreeMap;
 

--- a/examples/degrees.rs
+++ b/examples/degrees.rs
@@ -1,7 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use differential_dataflow::input::Input;

--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -1,7 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;

--- a/examples/freeze.rs
+++ b/examples/freeze.rs
@@ -1,6 +1,3 @@
-extern crate timely;
-extern crate differential_dataflow;
-
 use timely::dataflow::operators::probe::Handle;
 use timely::dataflow::operators::Map;
 

--- a/examples/graspan.rs
+++ b/examples/graspan.rs
@@ -1,7 +1,3 @@
-extern crate indexmap;
-extern crate timely;
-extern crate differential_dataflow;
-
 use std::io::{BufRead, BufReader};
 use std::fs::File;
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,7 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use differential_dataflow::input::Input;

--- a/examples/interpreted.rs
+++ b/examples/interpreted.rs
@@ -1,7 +1,3 @@
-extern crate timely;
-extern crate graph_map;
-extern crate differential_dataflow;
-
 use std::hash::Hash;
 use timely::dataflow::*;
 use timely::dataflow::operators::*;

--- a/examples/itembased_cf.rs
+++ b/examples/itembased_cf.rs
@@ -1,7 +1,3 @@
-extern crate timely;
-extern crate differential_dataflow;
-extern crate rand;
-
 use differential_dataflow::input::InputSession;
 use differential_dataflow::operators::{Join,CountTotal,Count};
 use differential_dataflow::operators::arrange::ArrangeByKey;

--- a/examples/monoid-bfs.rs
+++ b/examples/monoid-bfs.rs
@@ -1,16 +1,6 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
-#[macro_use]
-extern crate abomonation_derive;
-extern crate abomonation;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde;
-
-
+use abomonation_derive::Abomonation;
 use rand::{Rng, SeedableRng, StdRng};
+use serde::{Deserialize, Serialize};
 
 use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle;

--- a/examples/multitemporal.rs
+++ b/examples/multitemporal.rs
@@ -1,11 +1,3 @@
-#[macro_use]
-extern crate abomonation_derive;
-extern crate abomonation;
-
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
 use std::io::BufRead;
 
 use timely::dataflow::ProbeHandle;
@@ -144,7 +136,7 @@ fn main() {
 mod pair {
 
     /// A pair of timestamps, partially ordered by the product order.
-    #[derive(Hash, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Abomonation)]
+    #[derive(Hash, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Abomonation, Serialize, Deserialize)]
     pub struct Pair<S, T> {
         pub first: S,
         pub second: T,
@@ -211,6 +203,8 @@ mod pair {
     }
 
     use std::fmt::{Formatter, Error, Debug};
+    use abomonation_derive::Abomonation;
+    use serde::{Deserialize, Serialize};
 
     /// Debug implementation to avoid seeing fully qualified path names.
     impl<TOuter: Debug, TInner: Debug> Debug for Pair<TOuter, TInner> {
@@ -227,9 +221,11 @@ mod pair {
 /// from the rest of the library other than the traits it needs to implement. With this
 /// type and its implementations, you can use it as a timestamp type.
 mod vector {
+    use abomonation_derive::Abomonation;
+    use serde::{Deserialize, Serialize};
 
     /// A pair of timestamps, partially ordered by the product order.
-    #[derive(Hash, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Abomonation, Debug)]
+    #[derive(Hash, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Abomonation, Debug, Serialize, Deserialize)]
     pub struct Vector<T> {
         pub vector: Vec<T>,
     }

--- a/examples/pagerank.rs
+++ b/examples/pagerank.rs
@@ -1,7 +1,3 @@
-extern crate timely;
-extern crate graph_map;
-extern crate differential_dataflow;
-
 use timely::order::Product;
 use timely::dataflow::{*, operators::Filter};
 

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -1,8 +1,5 @@
 //! A demonstration of timely dataflow progress tracking, using differential dataflow operators.
 
-extern crate timely;
-extern crate differential_dataflow;
-
 use timely::PartialOrder;
 use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle;

--- a/examples/projekt.rs
+++ b/examples/projekt.rs
@@ -1,7 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
 use timely::dataflow::operators::probe::Handle;
 
 use differential_dataflow::input::InputSession;

--- a/examples/spines.rs
+++ b/examples/spines.rs
@@ -1,6 +1,3 @@
-extern crate timely;
-extern crate differential_dataflow;
-
 use timely::dataflow::operators::probe::Handle;
 
 use differential_dataflow::input::Input;

--- a/examples/stackoverflow.rs
+++ b/examples/stackoverflow.rs
@@ -1,6 +1,3 @@
-extern crate timely;
-extern crate differential_dataflow;
-
 use std::io::{BufRead, BufReader};
 use std::fs::File;
 

--- a/experiments/Cargo.toml
+++ b/experiments/Cargo.toml
@@ -2,6 +2,7 @@
 name = "experiments"
 version = "0.1.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
+edition = "2021"
 
 [dependencies]
 core_affinity = "0.5.9"
@@ -9,6 +10,7 @@ rand="0.3.13"
 abomonation = "0.7"
 abomonation_derive = "0.5"
 #timely = "0.7"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
+timely = { workspace = true }
 differential-dataflow = { path = "../" }
 graph_map = { git = "https://github.com/frankmcsherry/graph-map" }
+serde = { version = "1.0.190", features = ["derive"] }

--- a/experiments/src/bin/arrange.rs
+++ b/experiments/src/bin/arrange.rs
@@ -1,8 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-extern crate core_affinity;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::operators::{Exchange, Probe};

--- a/experiments/src/bin/attend.rs
+++ b/experiments/src/bin/attend.rs
@@ -1,8 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate graph_map;
-extern crate differential_dataflow;
-
 use std::time::Instant;
 
 use differential_dataflow::input::Input;

--- a/experiments/src/bin/deals-interactive.rs
+++ b/experiments/src/bin/deals-interactive.rs
@@ -1,12 +1,9 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
 use std::time::Instant;
 
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;
+use timely::WorkerConfig;
 
 use differential_dataflow::input::Input;
 use differential_dataflow::Collection;
@@ -33,7 +30,7 @@ fn main() {
 
     use timely::communication::allocator::zero_copy::allocator_process::ProcessBuilder;
     let allocators = ProcessBuilder::new_vector(workers);
-    timely::execute::execute_from(allocators, Box::new(()), move |worker| {
+    timely::execute::execute_from(allocators, Box::new(()), WorkerConfig::default(), move |worker| {
 
     // timely::execute_from_args(std::env::args().skip(1), move |worker| {
 

--- a/experiments/src/bin/graphs-interactive-alt.rs
+++ b/experiments/src/bin/graphs-interactive-alt.rs
@@ -1,8 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-extern crate core_affinity;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;

--- a/experiments/src/bin/graphs-interactive-neu-zwei.rs
+++ b/experiments/src/bin/graphs-interactive-neu-zwei.rs
@@ -1,8 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-extern crate core_affinity;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;

--- a/experiments/src/bin/graphs-interactive-neu.rs
+++ b/experiments/src/bin/graphs-interactive-neu.rs
@@ -1,8 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-extern crate core_affinity;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;

--- a/experiments/src/bin/graphs-interactive.rs
+++ b/experiments/src/bin/graphs-interactive.rs
@@ -1,8 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-extern crate core_affinity;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;
@@ -18,7 +13,6 @@ use differential_dataflow::operators::arrange::ArrangeByKey;
 use differential_dataflow::operators::arrange::ArrangeBySelf;
 
 type Node = usize;
-type Iter = usize;
 
 fn main() {
 
@@ -240,7 +234,7 @@ fn _bidijkstra<G: Scope>(
     goals: &Collection<G, (Node, Node)>) -> Collection<G, ((Node, Node), u32)>
 where G::Timestamp: Lattice+Ord {
 
-    goals.scope().iterative::<Iter,_,_>(|inner| {
+    goals.scope().iterative::<usize,_,_>(|inner| {
 
         // Our plan is to start evolving distances from both sources and destinations.
         // The evolution from a source or destination should continue as long as there

--- a/experiments/src/bin/graphs-single.rs
+++ b/experiments/src/bin/graphs-single.rs
@@ -1,5 +1,3 @@
-extern crate graph_map;
-
 use graph_map::GraphMMap;
 
 fn main() {

--- a/experiments/src/bin/graphs-static.rs
+++ b/experiments/src/bin/graphs-static.rs
@@ -1,10 +1,3 @@
-extern crate timely;
-extern crate differential_dataflow;
-extern crate graph_map;
-extern crate core_affinity;
-
-use std::rc::Rc;
-
 use timely::dataflow::*;
 
 use timely::order::Product;
@@ -16,7 +9,6 @@ use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::ArrangeByKey;
 use differential_dataflow::operators::arrange::ArrangeBySelf;
 use differential_dataflow::operators::iterate::SemigroupVariable;
-use differential_dataflow::trace::implementations::spine_fueled::Spine;
 use differential_dataflow::AsCollection;
 
 use graph_map::GraphMMap;
@@ -28,8 +20,8 @@ type Diff = i32;
 // use differential_dataflow::trace::implementations::graph::GraphBatch;
 // type GraphTrace = Spine<Node, Node, (), isize, Rc<GraphBatch<Node>>>;
 
-use differential_dataflow::trace::implementations::ord::OrdValBatch;
-type GraphTrace = Spine<Node, Node, (), Diff, Rc<OrdValBatch<Node, Node, (), Diff>>>;
+use differential_dataflow::trace::implementations::ValSpine;
+type GraphTrace = ValSpine<Node, Node, (), Diff>;
 
 fn main() {
 

--- a/experiments/src/bin/graphs.rs
+++ b/experiments/src/bin/graphs.rs
@@ -1,9 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
-use std::rc::Rc;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::*;
@@ -11,19 +5,15 @@ use timely::dataflow::*;
 use differential_dataflow::input::Input;
 use differential_dataflow::Collection;
 use differential_dataflow::operators::*;
-use differential_dataflow::trace::Trace;
 use differential_dataflow::operators::arrange::ArrangeByKey;
 use differential_dataflow::operators::arrange::ArrangeBySelf;
 
-use differential_dataflow::trace::implementations::spine_fueled::Spine;
-
 type Node = usize;
 
-use differential_dataflow::trace::implementations::ord::OrdValBatch;
-// use differential_dataflow::trace::implementations::ord::OrdValSpine;
+use differential_dataflow::trace::implementations::ValSpine;
 
 // type GraphTrace<N> = Spine<usize, N, (), isize, Rc<GraphBatch<N>>>;
-type GraphTrace = Spine<Node, Node, (), isize, Rc<OrdValBatch<Node, Node, (), isize>>>;
+type GraphTrace = ValSpine<Node, Node, (), isize>;
 
 fn main() {
 

--- a/experiments/src/bin/graspan-interactive.rs
+++ b/experiments/src/bin/graspan-interactive.rs
@@ -1,7 +1,3 @@
-extern crate timely;
-extern crate graph_map;
-extern crate differential_dataflow;
-
 use std::io::{BufRead, BufReader};
 use std::fs::File;
 

--- a/experiments/src/bin/graspan1.rs
+++ b/experiments/src/bin/graspan1.rs
@@ -1,7 +1,3 @@
-extern crate timely;
-extern crate graph_map;
-extern crate differential_dataflow;
-
 use std::io::{BufRead, BufReader};
 use std::fs::File;
 
@@ -10,7 +6,7 @@ use timely::order::Product;
 
 use differential_dataflow::difference::Present;
 use differential_dataflow::input::Input;
-use differential_dataflow::trace::implementations::ord::OrdValSpine;
+use differential_dataflow::trace::implementations::ValSpine;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::Arrange;
 use differential_dataflow::operators::iterate::SemigroupVariable;
@@ -18,7 +14,6 @@ use differential_dataflow::operators::iterate::SemigroupVariable;
 type Node = u32;
 type Time = ();
 type Iter = u32;
-type Offs = u32;
 
 fn main() {
 
@@ -36,7 +31,7 @@ fn main() {
             let (n_handle, nodes) = scope.new_collection();
             let (e_handle, edges) = scope.new_collection();
 
-            let edges = edges.arrange::<OrdValSpine<_,_,_,_,Offs>>();
+            let edges = edges.arrange::<ValSpine<_,_,_,_>>();
 
             // a N c  <-  a N b && b E c
             // N(a,c) <-  N(a,b), E(b, c)
@@ -51,7 +46,7 @@ fn main() {
                 let next =
                 labels.join_core(&edges, |_b, a, c| Some((*c, *a)))
                       .concat(&nodes)
-                      .arrange::<OrdValSpine<_,_,_,_,Offs>>()
+                      .arrange::<ValSpine<_,_,_,_>>()
                     //   .distinct_total_core::<Diff>();
                       .threshold_semigroup(|_,_,x| if x.is_none() { Some(Present) } else { None });
 

--- a/experiments/src/bin/graspan2.rs
+++ b/experiments/src/bin/graspan2.rs
@@ -1,7 +1,3 @@
-extern crate timely;
-extern crate graph_map;
-extern crate differential_dataflow;
-
 use std::io::{BufRead, BufReader};
 use std::fs::File;
 
@@ -20,7 +16,6 @@ use differential_dataflow::difference::Present;
 type Node = u32;
 type Time = ();
 type Iter = u32;
-type Offs = u32;
 
 fn main() {
     if std::env::args().any(|x| x == "optimized") {
@@ -52,7 +47,7 @@ fn unoptimized() {
                 .flat_map(|(a,b)| vec![a,b])
                 .concat(&dereference.flat_map(|(a,b)| vec![a,b]));
 
-            let dereference = dereference.arrange::<ValSpine<_,_,_,_,Offs>>();
+            let dereference = dereference.arrange::<ValSpine<_,_,_,_>>();
 
             let (value_flow, memory_alias, value_alias) =
             scope
@@ -65,14 +60,14 @@ fn unoptimized() {
                     let value_flow = SemigroupVariable::new(scope, Product::new(Default::default(), 1));
                     let memory_alias = SemigroupVariable::new(scope, Product::new(Default::default(), 1));
 
-                    let value_flow_arranged = value_flow.arrange::<ValSpine<_,_,_,_,Offs>>();
-                    let memory_alias_arranged = memory_alias.arrange::<ValSpine<_,_,_,_,Offs>>();
+                    let value_flow_arranged = value_flow.arrange::<ValSpine<_,_,_,_>>();
+                    let memory_alias_arranged = memory_alias.arrange::<ValSpine<_,_,_,_>>();
 
                     // VA(a,b) <- VF(x,a),VF(x,b)
                     // VA(a,b) <- VF(x,a),MA(x,y),VF(y,b)
                     let value_alias_next = value_flow_arranged.join_core(&value_flow_arranged, |_,&a,&b| Some((a,b)));
                     let value_alias_next = value_flow_arranged.join_core(&memory_alias_arranged, |_,&a,&b| Some((b,a)))
-                                                              .arrange::<ValSpine<_,_,_,_,Offs>>()
+                                                              .arrange::<ValSpine<_,_,_,_>>()
                                                               .join_core(&value_flow_arranged, |_,&a,&b| Some((a,b)))
                                                               .concat(&value_alias_next);
 
@@ -82,16 +77,16 @@ fn unoptimized() {
                     let value_flow_next =
                     assignment
                         .map(|(a,b)| (b,a))
-                        .arrange::<ValSpine<_,_,_,_,Offs>>()
+                        .arrange::<ValSpine<_,_,_,_>>()
                         .join_core(&memory_alias_arranged, |_,&a,&b| Some((b,a)))
                         .concat(&assignment.map(|(a,b)| (b,a)))
-                        .arrange::<ValSpine<_,_,_,_,Offs>>()
+                        .arrange::<ValSpine<_,_,_,_>>()
                         .join_core(&value_flow_arranged, |_,&a,&b| Some((a,b)))
                         .concat(&nodes.map(|n| (n,n)));
 
                     let value_flow_next =
                     value_flow_next
-                        .arrange::<KeySpine<_,_,_,Offs>>()
+                        .arrange::<KeySpine<_,_,_>>()
                         // .distinct_total_core::<Diff>()
                         .threshold_semigroup(|_,_,x| if x.is_none() { Some(Present) } else { None })
                         ;
@@ -100,12 +95,12 @@ fn unoptimized() {
                     let memory_alias_next: Collection<_,_,Present> =
                     value_alias_next
                         .join_core(&dereference, |_x,&y,&a| Some((y,a)))
-                        .arrange::<ValSpine<_,_,_,_,Offs>>()
+                        .arrange::<ValSpine<_,_,_,_>>()
                         .join_core(&dereference, |_y,&a,&b| Some((a,b)));
 
                     let memory_alias_next: Collection<_,_,Present>  =
                     memory_alias_next
-                        .arrange::<KeySpine<_,_,_,Offs>>()
+                        .arrange::<KeySpine<_,_,_>>()
                         // .distinct_total_core::<Diff>()
                         .threshold_semigroup(|_,_,x| if x.is_none() { Some(Present) } else { None })
                         ;
@@ -177,7 +172,7 @@ fn optimized() {
                 .flat_map(|(a,b)| vec![a,b])
                 .concat(&dereference.flat_map(|(a,b)| vec![a,b]));
 
-            let dereference = dereference.arrange::<ValSpine<_,_,_,_,Offs>>();
+            let dereference = dereference.arrange::<ValSpine<_,_,_,_>>();
 
             let (value_flow, memory_alias) =
             scope
@@ -190,8 +185,8 @@ fn optimized() {
                     let value_flow = SemigroupVariable::new(scope, Product::new(Default::default(), 1));
                     let memory_alias = SemigroupVariable::new(scope, Product::new(Default::default(), 1));
 
-                    let value_flow_arranged = value_flow.arrange::<ValSpine<_,_,_,_,Offs>>();
-                    let memory_alias_arranged = memory_alias.arrange::<ValSpine<_,_,_,_,Offs>>();
+                    let value_flow_arranged = value_flow.arrange::<ValSpine<_,_,_,_>>();
+                    let memory_alias_arranged = memory_alias.arrange::<ValSpine<_,_,_,_>>();
 
                     // VF(a,a) <-
                     // VF(a,b) <- A(a,x),VF(x,b)
@@ -199,13 +194,13 @@ fn optimized() {
                     let value_flow_next =
                     assignment
                         .map(|(a,b)| (b,a))
-                        .arrange::<ValSpine<_,_,_,_,Offs>>()
+                        .arrange::<ValSpine<_,_,_,_>>()
                         .join_core(&memory_alias_arranged, |_,&a,&b| Some((b,a)))
                         .concat(&assignment.map(|(a,b)| (b,a)))
-                        .arrange::<ValSpine<_,_,_,_,Offs>>()
+                        .arrange::<ValSpine<_,_,_,_>>()
                         .join_core(&value_flow_arranged, |_,&a,&b| Some((a,b)))
                         .concat(&nodes.map(|n| (n,n)))
-                        .arrange::<KeySpine<_,_,_,Offs>>()
+                        .arrange::<KeySpine<_,_,_>>()
                         // .distinct_total_core::<Diff>()
                         .threshold_semigroup(|_,_,x| if x.is_none() { Some(Present) } else { None })
                         ;
@@ -214,9 +209,9 @@ fn optimized() {
                     let value_flow_deref =
                     value_flow
                         .map(|(a,b)| (b,a))
-                        .arrange::<ValSpine<_,_,_,_,Offs>>()
+                        .arrange::<ValSpine<_,_,_,_>>()
                         .join_core(&dereference, |_x,&a,&b| Some((a,b)))
-                        .arrange::<ValSpine<_,_,_,_,Offs>>();
+                        .arrange::<ValSpine<_,_,_,_>>();
 
                     // MA(a,b) <- VFD(x,a),VFD(y,b)
                     // MA(a,b) <- VFD(x,a),MA(x,y),VFD(y,b)
@@ -227,10 +222,10 @@ fn optimized() {
                     let memory_alias_next =
                     memory_alias_arranged
                         .join_core(&value_flow_deref, |_x,&y,&a| Some((y,a)))
-                        .arrange::<ValSpine<_,_,_,_,Offs>>()
+                        .arrange::<ValSpine<_,_,_,_>>()
                         .join_core(&value_flow_deref, |_y,&a,&b| Some((a,b)))
                         .concat(&memory_alias_next)
-                        .arrange::<KeySpine<_,_,_,Offs>>()
+                        .arrange::<KeySpine<_,_,_>>()
                         // .distinct_total_core::<Diff>()
                         .threshold_semigroup(|_,_,x| if x.is_none() { Some(Present) } else { None })
                         ;

--- a/experiments/src/bin/multitemporal.rs
+++ b/experiments/src/bin/multitemporal.rs
@@ -1,11 +1,3 @@
-#[macro_use]
-extern crate abomonation_derive;
-extern crate abomonation;
-
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use timely::dataflow::ProbeHandle;
@@ -172,7 +164,7 @@ fn main() {
 mod pair {
 
     /// A pair of timestamps, partially ordered by the product order.
-    #[derive(Hash, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Abomonation)]
+    #[derive(Hash, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Abomonation, Serialize, Deserialize)]
     pub struct Pair<S, T> {
         pub first: S,
         pub second: T,
@@ -239,6 +231,8 @@ mod pair {
     }
 
     use std::fmt::{Formatter, Error, Debug};
+    use abomonation_derive::Abomonation;
+    use serde::{Deserialize, Serialize};
 
     /// Debug implementation to avoid seeing fully qualified path names.
     impl<TOuter: Debug, TInner: Debug> Debug for Pair<TOuter, TInner> {
@@ -255,9 +249,11 @@ mod pair {
 /// from the rest of the library other than the traits it needs to implement. With this
 /// type and its implementations, you can use it as a timestamp type.
 mod vector {
+    use abomonation_derive::Abomonation;
+    use serde::{Deserialize, Serialize};
 
     /// A pair of timestamps, partially ordered by the product order.
-    #[derive(Hash, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Abomonation, Debug)]
+    #[derive(Hash, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Abomonation, Debug, Serialize, Deserialize)]
     pub struct Vector<T> {
         pub vector: Vec<T>,
     }

--- a/experiments/src/bin/ysb.rs
+++ b/experiments/src/bin/ysb.rs
@@ -1,12 +1,7 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::Join;
-use differential_dataflow::operators::Consolidate;
 
 #[derive(Clone)]
 pub enum AdType {

--- a/interactive/Cargo.toml
+++ b/interactive/Cargo.toml
@@ -2,11 +2,11 @@
 name = "interactive"
 version = "0.1.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
+edition = "2021"
 
 [dependencies]
 bincode = "1"
-serde = "1"
-serde_derive = "1"
+serde = { version = "1", features = ["derive"]}
 differential-dataflow = { path = "../" }
 dogsdogsdogs = { path = "../dogsdogsdogs" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }

--- a/interactive/src/bin/client.rs
+++ b/interactive/src/bin/client.rs
@@ -1,5 +1,3 @@
-extern crate interactive;
-
 use std::time::Duration;
 use interactive::{Command, Plan};
 use interactive::concrete::{Session, Value};

--- a/interactive/src/bin/logging.rs
+++ b/interactive/src/bin/logging.rs
@@ -1,5 +1,3 @@
-extern crate interactive;
-
 use interactive::{Command, Plan};
 use interactive::concrete::Session;
 

--- a/interactive/src/bin/motifs.rs
+++ b/interactive/src/bin/motifs.rs
@@ -1,5 +1,3 @@
-extern crate interactive;
-
 use std::time::Duration;
 use interactive::{Command, Plan};
 use interactive::concrete::{Session, Value};

--- a/interactive/src/bin/projekt.rs
+++ b/interactive/src/bin/projekt.rs
@@ -1,5 +1,3 @@
-extern crate interactive;
-
 use std::time::Duration;
 use interactive::{Command, Plan};
 use interactive::concrete::{Session, Value};

--- a/interactive/src/bin/server.rs
+++ b/interactive/src/bin/server.rs
@@ -1,7 +1,3 @@
-extern crate timely;
-extern crate differential_dataflow;
-extern crate interactive;
-
 use std::sync::{Arc, Mutex};
 use std::sync::mpsc::Sender;
 use std::thread::Thread;
@@ -26,7 +22,7 @@ fn main() {
 
             use std::net::TcpListener;
             let listener = TcpListener::bind("127.0.0.1:8000".to_string()).expect("failed to bind listener");
-            for mut stream in listener.incoming() {
+            for stream in listener.incoming() {
                 let mut stream = stream.expect("listener error");
                 let send = send.clone();
                 let thread = thread.clone();

--- a/interactive/src/command.rs
+++ b/interactive/src/command.rs
@@ -2,6 +2,7 @@
 
 use std::hash::Hash;
 use std::io::Write;
+use serde::{Deserialize, Serialize};
 
 use timely::communication::Allocate;
 use timely::worker::Worker;
@@ -70,7 +71,7 @@ where
 
                     use timely::dataflow::operators::Probe;
                     use differential_dataflow::operators::arrange::ArrangeBySelf;
-                    use plan::Render;
+                    use crate::plan::Render;
 
                     let mut collections = std::collections::HashMap::new();
                     // let mut arrangements = std::collections::HashMap::new();

--- a/interactive/src/concrete.rs
+++ b/interactive/src/concrete.rs
@@ -1,6 +1,7 @@
 //! An example value type.
 
 use std::time::Duration;
+use serde::{Deserialize, Serialize};
 use super::{Datum, VectorFrom, Command};
 
 /// A session.

--- a/interactive/src/lib.rs
+++ b/interactive/src/lib.rs
@@ -6,14 +6,6 @@
 
 #![forbid(missing_docs)]
 
-extern crate bincode;
-extern crate timely;
-extern crate differential_dataflow;
-extern crate dogsdogsdogs;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-
 pub mod plan;
 pub use plan::Plan;
 

--- a/interactive/src/plan/filter.rs
+++ b/interactive/src/plan/filter.rs
@@ -1,12 +1,12 @@
 //! Predicate expression plan.
 
 use std::hash::Hash;
-
+use serde::{Deserialize, Serialize};
 use timely::dataflow::Scope;
 
 use differential_dataflow::{Collection, ExchangeData};
-use plan::{Plan, Render};
-use {TraceManager, Time, Diff, Datum};
+use crate::plan::{Plan, Render};
+use crate::{TraceManager, Time, Diff, Datum};
 
 /// What to compare against.
 ///

--- a/interactive/src/plan/join.rs
+++ b/interactive/src/plan/join.rs
@@ -1,14 +1,13 @@
 //! Equijoin expression plan.
 
 use std::hash::Hash;
+use serde::{Deserialize, Serialize};
 
 use timely::dataflow::Scope;
 
-use differential_dataflow::operators::JoinCore;
-
 use differential_dataflow::{Collection, ExchangeData};
-use plan::{Plan, Render};
-use {TraceManager, Time, Diff, Datum};
+use crate::plan::{Plan, Render};
+use crate::{TraceManager, Time, Diff, Datum};
 
 /// A plan stage joining two source relations on the specified
 /// symbols. Throws if any of the join symbols isn't bound by both

--- a/interactive/src/plan/map.rs
+++ b/interactive/src/plan/map.rs
@@ -1,12 +1,13 @@
 //! Projection expression plan.
 
 use std::hash::Hash;
+use serde::{Deserialize, Serialize};
 
 use timely::dataflow::Scope;
 
 use differential_dataflow::{Collection, ExchangeData};
-use plan::{Plan, Render};
-use {TraceManager, Time, Diff, Datum};
+use crate::plan::{Plan, Render};
+use crate::{TraceManager, Time, Diff, Datum};
 
 /// A plan which retains values at specified locations.
 ///

--- a/interactive/src/plan/mod.rs
+++ b/interactive/src/plan/mod.rs
@@ -1,11 +1,12 @@
 //! Types and traits for implementing query plans.
 
 use std::hash::Hash;
+use serde::{Deserialize, Serialize};
 
 use timely::dataflow::Scope;
 use differential_dataflow::{Collection, ExchangeData};
 
-use {TraceManager, Time, Diff};
+use crate::{TraceManager, Time, Diff};
 
 // pub mod count;
 pub mod filter;
@@ -156,7 +157,6 @@ impl<V: ExchangeData+Hash+Datum> Render for Plan<V> {
                 Plan::Map(expressions) => expressions.render(scope, collections, arrangements),
                 Plan::Distinct(distinct) => {
 
-                    use differential_dataflow::operators::reduce::ReduceCore;
                     use differential_dataflow::operators::arrange::ArrangeBySelf;
                     use differential_dataflow::trace::implementations::KeySpine;
 
@@ -196,7 +196,6 @@ impl<V: ExchangeData+Hash+Datum> Render for Plan<V> {
                         trace.import(scope).as_collection(|k,&()| k.clone())
                     }
                     else {
-                        use differential_dataflow::operators::Consolidate;
                         consolidate.render(scope, collections, arrangements).consolidate()
                     }
                 },

--- a/interactive/src/plan/sfw.rs
+++ b/interactive/src/plan/sfw.rs
@@ -25,15 +25,15 @@
 //! indices rather than whole-collection indices.
 
 use std::hash::Hash;
+use serde::{Deserialize, Serialize};
 
 use timely::dataflow::Scope;
 
-use differential_dataflow::operators::Consolidate;
 use differential_dataflow::operators::arrange::{ArrangeBySelf, ArrangeByKey};
 
 use differential_dataflow::{Collection, ExchangeData};
-use plan::{Plan, Render};
-use {TraceManager, Time, Diff, Datum};
+use crate::plan::{Plan, Render};
+use crate::{TraceManager, Time, Diff, Datum};
 
 /// A multiway join of muliple relations.
 ///
@@ -249,11 +249,11 @@ impl<V: ExchangeData+Hash+Datum> Render for MultiwayJoin<V> {
                     // tuple in the cursor.
                     changes =
                     if join_idx < index {
-                        let arrangement = trace.import(scope).enter_at(inner, |_,_,t| AltNeu::alt(t.clone()), unimplemented!());
+                        let arrangement = trace.import(scope).enter_at(inner, |_,_,t| AltNeu::alt(t.clone()), |_| unimplemented!());
                         dogsdogsdogs::operators::propose(&changes, arrangement, key_selector)
                     }
                     else {
-                        let arrangement = trace.import(scope).enter_at(inner, |_,_,t| AltNeu::neu(t.clone()), unimplemented!());
+                        let arrangement = trace.import(scope).enter_at(inner, |_,_,t| AltNeu::neu(t.clone()), |_| unimplemented!());
                         dogsdogsdogs::operators::propose(&changes, arrangement, key_selector)
                     }
                     .map(|(mut prefix, extensions)| { prefix.extend(extensions.into_iter()); prefix })

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dd_server"
 version = "0.1.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
+edition = "2021"
 
 [dependencies.differential-dataflow]
 path="../"

--- a/server/dataflows/degr_dist/Cargo.toml
+++ b/server/dataflows/degr_dist/Cargo.toml
@@ -2,9 +2,10 @@
 name = "degr_dist"
 version = "0.1.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
+edition = "2021"
 
 [dependencies]
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
+timely = { workspace = true }
 differential-dataflow = { path = "../../../" }
 dd_server = { path = "../../" }
 

--- a/server/dataflows/degr_dist/src/lib.rs
+++ b/server/dataflows/degr_dist/src/lib.rs
@@ -1,7 +1,3 @@
-extern crate timely;
-extern crate differential_dataflow;
-extern crate dd_server;
-
 use std::rc::Rc;
 use std::cell::RefCell;
 

--- a/server/dataflows/neighborhood/Cargo.toml
+++ b/server/dataflows/neighborhood/Cargo.toml
@@ -2,6 +2,7 @@
 name = "neighborhood"
 version = "0.1.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
+edition = "2021"
 
 [dependencies]
 differential-dataflow = { path = "../../../" }

--- a/server/dataflows/neighborhood/src/lib.rs
+++ b/server/dataflows/neighborhood/src/lib.rs
@@ -1,12 +1,8 @@
-extern crate differential_dataflow;
-extern crate dd_server;
-
 use std::rc::Rc;
 use std::cell::RefCell;
 
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::JoinCore;
-use differential_dataflow::operators::Consolidate;
 
 use dd_server::{Environment, TraceHandle};
 

--- a/server/dataflows/random_graph/Cargo.toml
+++ b/server/dataflows/random_graph/Cargo.toml
@@ -2,9 +2,10 @@
 name = "random_graph"
 version = "0.1.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
+edition = "2021"
 
 [dependencies]
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
+timely = {workspace = true}
 differential-dataflow = { path = "../../../" }
 dd_server = { path = "../../" }
 rand="0.3.13"

--- a/server/dataflows/reachability/Cargo.toml
+++ b/server/dataflows/reachability/Cargo.toml
@@ -2,6 +2,7 @@
 name = "reachability"
 version = "0.1.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
+edition = "2021"
 
 [dependencies]
 differential-dataflow = { path = "../../../" }

--- a/server/dataflows/reachability/src/lib.rs
+++ b/server/dataflows/reachability/src/lib.rs
@@ -1,11 +1,8 @@
-extern crate differential_dataflow;
-extern crate dd_server;
-
 use std::rc::Rc;
 use std::cell::RefCell;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::operators::{Iterate, JoinCore, Threshold};
+use differential_dataflow::operators::{Iterate, Threshold};
 use differential_dataflow::operators::arrange::ArrangeBySelf;
 
 use dd_server::{Environment, TraceHandle};

--- a/server/src/bin/server.rs
+++ b/server/src/bin/server.rs
@@ -1,7 +1,3 @@
-extern crate libloading;
-extern crate timely;
-extern crate dd_server;
-
 use std::io::BufRead;
 use std::io::Write;
 
@@ -68,7 +64,7 @@ fn main() {
                                 let library_path = &command[0];
                                 let symbol_name = &command[1];
 
-                                if let Ok(lib) = Library::new(library_path) {
+                                if let Ok(lib) = unsafe { Library::new(library_path) } {
                                     worker.dataflow_core("dataflow", None, lib, |lib, child| {
                                         let result = unsafe {
                                             lib.get::<Symbol<unsafe fn(Environment)->Result<(),String>>>(symbol_name.as_bytes())

--- a/src/algorithms/graphs/bfs.rs
+++ b/src/algorithms/graphs/bfs.rs
@@ -4,9 +4,9 @@ use std::hash::Hash;
 
 use timely::dataflow::*;
 
-use ::{Collection, ExchangeData};
-use ::operators::*;
-use ::lattice::Lattice;
+use crate::{Collection, ExchangeData};
+use crate::operators::*;
+use crate::lattice::Lattice;
 
 /// Returns pairs (node, dist) indicating distance of each node from a root.
 pub fn bfs<G, N>(edges: &Collection<G, (N,N)>, roots: &Collection<G, N>) -> Collection<G, (N,u32)>
@@ -15,7 +15,7 @@ where
     G::Timestamp: Lattice+Ord,
     N: ExchangeData+Hash,
 {
-    use operators::arrange::arrangement::ArrangeByKey;
+    use crate::operators::arrange::arrangement::ArrangeByKey;
     let edges = edges.arrange_by_key();
     bfs_arranged(&edges, roots)
 }

--- a/src/algorithms/graphs/bijkstra.rs
+++ b/src/algorithms/graphs/bijkstra.rs
@@ -5,10 +5,10 @@ use std::hash::Hash;
 use timely::order::Product;
 use timely::dataflow::*;
 
-use ::{Collection, ExchangeData};
-use ::operators::*;
-use ::lattice::Lattice;
-use ::operators::iterate::Variable;
+use crate::{Collection, ExchangeData};
+use crate::operators::*;
+use crate::lattice::Lattice;
+use crate::operators::iterate::Variable;
 
 /// Returns the subset of `goals` that can reach each other in `edges`, with distance.
 ///
@@ -26,7 +26,7 @@ where
     G::Timestamp: Lattice+Ord,
     N: ExchangeData+Hash,
 {
-    use operators::arrange::arrangement::ArrangeByKey;
+    use crate::operators::arrange::arrangement::ArrangeByKey;
     let forward = edges.arrange_by_key();
     let reverse = edges.map(|(x,y)| (y,x)).arrange_by_key();
     bidijkstra_arranged(&forward, &reverse, goals)

--- a/src/algorithms/graphs/propagate.rs
+++ b/src/algorithms/graphs/propagate.rs
@@ -4,10 +4,10 @@ use std::hash::Hash;
 
 use timely::dataflow::*;
 
-use ::{Collection, ExchangeData};
-use ::lattice::Lattice;
-use ::difference::{Abelian, Multiply};
-use ::operators::arrange::arrangement::ArrangeByKey;
+use crate::{Collection, ExchangeData};
+use crate::lattice::Lattice;
+use crate::difference::{Abelian, Multiply};
+use crate::operators::arrange::arrangement::ArrangeByKey;
 
 /// Propagates labels forward, retaining the minimum label.
 ///
@@ -46,8 +46,8 @@ where
     propagate_core(&edges.arrange_by_key(), nodes, logic)
 }
 
-use trace::TraceReader;
-use operators::arrange::arrangement::Arranged;
+use crate::trace::TraceReader;
+use crate::operators::arrange::arrangement::Arranged;
 
 /// Propagates labels forward, retaining the minimum label.
 ///

--- a/src/algorithms/graphs/scc.rs
+++ b/src/algorithms/graphs/scc.rs
@@ -5,10 +5,10 @@ use std::hash::Hash;
 
 use timely::dataflow::*;
 
-use ::{Collection, ExchangeData};
-use ::operators::*;
-use ::lattice::Lattice;
-use ::difference::{Abelian, Multiply};
+use crate::{Collection, ExchangeData};
+use crate::operators::*;
+use crate::lattice::Lattice;
+use crate::difference::{Abelian, Multiply};
 
 use super::propagate::propagate;
 

--- a/src/algorithms/graphs/sequential.rs
+++ b/src/algorithms/graphs/sequential.rs
@@ -4,10 +4,10 @@ use std::hash::Hash;
 
 use timely::dataflow::*;
 
-use ::{Collection, ExchangeData};
-use ::lattice::Lattice;
-use ::operators::*;
-use hashable::Hashable;
+use crate::{Collection, ExchangeData};
+use crate::lattice::Lattice;
+use crate::operators::*;
+use crate::hashable::Hashable;
 
 fn _color<G, N>(edges: &Collection<G, (N,N)>) -> Collection<G,(N,Option<u32>)>
 where

--- a/src/algorithms/identifiers.rs
+++ b/src/algorithms/identifiers.rs
@@ -2,10 +2,10 @@
 
 use timely::dataflow::Scope;
 
-use ::{Collection, ExchangeData, Hashable};
-use ::lattice::Lattice;
-use ::operators::*;
-use ::difference::Abelian;
+use crate::{Collection, ExchangeData, Hashable};
+use crate::lattice::Lattice;
+use crate::operators::*;
+use crate::difference::Abelian;
 
 /// Assign unique identifiers to elements of a collection.
 pub trait Identifiers<G: Scope, D: ExchangeData, R: ExchangeData+Abelian> {
@@ -13,9 +13,6 @@ pub trait Identifiers<G: Scope, D: ExchangeData, R: ExchangeData+Abelian> {
     ///
     /// # Example
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::algorithms::identifiers::Identifiers;
     /// use differential_dataflow::operators::Threshold;
@@ -59,7 +56,7 @@ where
         // very rare, and maintaining winners in both the input and output
         // of `reduce` is an unneccesary duplication.
 
-        use collection::AsCollection;
+        use crate::collection::AsCollection;
 
         let init = self.map(|record| (0, record));
         timely::dataflow::operators::generic::operator::empty(&init.scope())
@@ -99,15 +96,15 @@ mod tests {
         // a version with a crippled hash function to see that even if
         // there are collisions, everyone gets a unique identifier.
 
-        use ::input::Input;
-        use ::operators::{Threshold, Reduce};
-        use ::operators::iterate::Iterate;
+        use crate::input::Input;
+        use crate::operators::{Threshold, Reduce};
+        use crate::operators::iterate::Iterate;
 
         ::timely::example(|scope| {
 
             let input = scope.new_collection_from(1 .. 4).1;
 
-            use collection::AsCollection;
+            use crate::collection::AsCollection;
 
             let init = input.map(|record| (0, record));
             timely::dataflow::operators::generic::operator::empty(&init.scope())

--- a/src/algorithms/prefix_sum.rs
+++ b/src/algorithms/prefix_sum.rs
@@ -2,9 +2,9 @@
 
 use timely::dataflow::Scope;
 
-use ::{Collection, ExchangeData};
-use ::lattice::Lattice;
-use ::operators::*;
+use crate::{Collection, ExchangeData};
+use crate::lattice::Lattice;
+use crate::operators::*;
 
 /// Extension trait for the prefix_sum method.
 pub trait PrefixSum<G: Scope, K, D> {

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -10,6 +10,8 @@
 //! this file.
 
 use std::time::Duration;
+use abomonation_derive::Abomonation;
+use serde::{Deserialize, Serialize};
 
 /// A message in the CDC V2 protocol.
 #[derive(Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Abomonation)]

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -17,9 +17,9 @@ use timely::dataflow::scopes::{Child, child::Iterative};
 use timely::dataflow::{Scope, Stream};
 use timely::dataflow::operators::*;
 
-use ::difference::{Semigroup, Abelian, Multiply};
-use lattice::Lattice;
-use hashable::Hashable;
+use crate::difference::{Semigroup, Abelian, Multiply};
+use crate::lattice::Lattice;
+use crate::hashable::Hashable;
 
 /// A mutable collection of values of type `D`
 ///
@@ -60,9 +60,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -91,9 +88,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -120,9 +114,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -146,9 +137,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -175,9 +163,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -207,9 +192,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -241,9 +223,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -279,9 +258,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// #Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -315,9 +291,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use timely::dataflow::Scope;
     /// use differential_dataflow::input::Input;
     ///
@@ -352,9 +325,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use timely::dataflow::Scope;
     /// use differential_dataflow::input::Input;
     ///
@@ -433,9 +403,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -462,9 +429,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -512,9 +476,6 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -527,8 +488,8 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     /// }
     /// ```
     pub fn assert_empty(&self)
-    where D: ::ExchangeData+Hashable,
-          R: ::ExchangeData+Hashable,
+    where D: crate::ExchangeData+Hashable,
+          R: crate::ExchangeData+Hashable,
           G::Timestamp: Lattice+Ord,
     {
         self.consolidate()
@@ -554,9 +515,6 @@ where
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use timely::dataflow::Scope;
     /// use differential_dataflow::input::Input;
     ///
@@ -607,9 +565,6 @@ impl<G: Scope, D: Data, R: Abelian> Collection<G, D, R> where G::Timestamp: Data
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -643,9 +598,6 @@ impl<G: Scope, D: Data, R: Abelian> Collection<G, D, R> where G::Timestamp: Data
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -662,8 +614,8 @@ impl<G: Scope, D: Data, R: Abelian> Collection<G, D, R> where G::Timestamp: Data
     /// }
     /// ```
     pub fn assert_eq(&self, other: &Self)
-    where D: ::ExchangeData+Hashable,
-          R: ::ExchangeData+Hashable,
+    where D: crate::ExchangeData+Hashable,
+          R: crate::ExchangeData+Hashable,
           G::Timestamp: Lattice+Ord
     {
         self.negate()
@@ -692,9 +644,6 @@ impl<G: Scope, D: Data, R: Semigroup> AsCollection<G, D, R> for Stream<G, (D, G:
 /// # Examples
 ///
 /// ```
-/// extern crate timely;
-/// extern crate differential_dataflow;
-///
 /// use differential_dataflow::input::Input;
 ///
 /// fn main() {

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -6,7 +6,7 @@
 //! dataflow collections would then track for each record the total of counts and heights, which allows
 //! us to track something like the average.
 
-use ::Data;
+use crate::Data;
 
 #[deprecated]
 pub use self::Abelian as Diff;
@@ -140,6 +140,8 @@ wrapping_implementation!(std::num::Wrapping<isize>);
 
 pub use self::present::Present;
 mod present {
+    use abomonation_derive::Abomonation;
+    use serde::{Deserialize, Serialize};
 
     /// A zero-sized difference that indicates the presence of a record.
     ///

--- a/src/dynamic/mod.rs
+++ b/src/dynamic/mod.rs
@@ -20,11 +20,11 @@ use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::progress::Antichain;
 
-use difference::Semigroup;
-use {Collection, Data};
-use collection::AsCollection;
-use dynamic::pointstamp::PointStamp;
-use dynamic::pointstamp::PointStampSummary;
+use crate::difference::Semigroup;
+use crate::{Collection, Data};
+use crate::collection::AsCollection;
+use crate::dynamic::pointstamp::PointStamp;
+use crate::dynamic::pointstamp::PointStampSummary;
 
 impl<G, D, R, T, TOuter> Collection<G, D, R>
 where

--- a/src/dynamic/pointstamp.rs
+++ b/src/dynamic/pointstamp.rs
@@ -11,6 +11,7 @@
 //! (as iteration within a scope requires leaving contained scopes), and then to any number of appended
 //! default coordinates (which is effectively just *setting* the coordinate).
 
+use abomonation_derive::Abomonation;
 use serde::{Deserialize, Serialize};
 
 /// A sequence of timestamps, partially ordered by the product order.
@@ -172,7 +173,7 @@ impl<T: Timestamp> Timestamp for PointStamp<T> {
 
 // Implement differential dataflow's `Lattice` trait.
 // This extends the `PartialOrder` implementation with additional structure.
-use lattice::Lattice;
+use crate::lattice::Lattice;
 impl<T: Lattice + Timestamp + Clone> Lattice for PointStamp<T> {
     fn join(&self, other: &Self) -> Self {
         let min_len = ::std::cmp::min(self.vector.len(), other.vector.len());

--- a/src/input.rs
+++ b/src/input.rs
@@ -11,9 +11,9 @@ use timely::dataflow::operators::Input as TimelyInput;
 use timely::dataflow::operators::input::Handle;
 use timely::dataflow::scopes::ScopeParent;
 
-use ::Data;
-use ::difference::Semigroup;
-use collection::{Collection, AsCollection};
+use crate::Data;
+use crate::difference::Semigroup;
+use crate::collection::{Collection, AsCollection};
 
 /// Create a new collection and input handle to control the collection.
 pub trait Input : TimelyInput {
@@ -22,9 +22,6 @@ pub trait Input : TimelyInput {
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use timely::Config;
     /// use differential_dataflow::input::Input;
     ///
@@ -53,9 +50,6 @@ pub trait Input : TimelyInput {
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use timely::Config;
     /// use differential_dataflow::input::Input;
     ///
@@ -84,9 +78,6 @@ pub trait Input : TimelyInput {
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use timely::Config;
     /// use differential_dataflow::input::Input;
     ///
@@ -112,7 +103,7 @@ pub trait Input : TimelyInput {
     where I: IntoIterator<Item=(D,<Self as ScopeParent>::Timestamp,R)>+'static, D: Data, R: Semigroup+Data;
 }
 
-use lattice::Lattice;
+use crate::lattice::Lattice;
 impl<G: TimelyInput> Input for G where <G as ScopeParent>::Timestamp: Lattice {
     fn new_collection<D, R>(&mut self) -> (InputSession<<G as ScopeParent>::Timestamp, D, R>, Collection<G, D, R>)
     where D: Data, R: Semigroup{
@@ -147,9 +138,6 @@ impl<G: TimelyInput> Input for G where <G as ScopeParent>::Timestamp: Lattice {
 /// # Examples
 ///
 /// ```
-/// extern crate timely;
-/// extern crate differential_dataflow;
-///
 /// use timely::Config;
 /// use differential_dataflow::input::Input;
 ///

--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -15,8 +15,6 @@ pub trait Lattice : PartialOrder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate timely;
-    /// # extern crate differential_dataflow;
     /// # use timely::PartialOrder;
     /// # use timely::order::Product;
     /// # use differential_dataflow::lattice::Lattice;
@@ -36,8 +34,6 @@ pub trait Lattice : PartialOrder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate timely;
-    /// # extern crate differential_dataflow;
     /// # use timely::PartialOrder;
     /// # use timely::order::Product;
     /// # use differential_dataflow::lattice::Lattice;
@@ -59,8 +55,6 @@ pub trait Lattice : PartialOrder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate timely;
-    /// # extern crate differential_dataflow;
     /// # use timely::PartialOrder;
     /// # use timely::order::Product;
     /// # use differential_dataflow::lattice::Lattice;
@@ -80,8 +74,6 @@ pub trait Lattice : PartialOrder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate timely;
-    /// # extern crate differential_dataflow;
     /// # use timely::PartialOrder;
     /// # use timely::order::Product;
     /// # use differential_dataflow::lattice::Lattice;
@@ -111,8 +103,6 @@ pub trait Lattice : PartialOrder {
     /// # Examples
     ///
     /// ```
-    /// # extern crate timely;
-    /// # extern crate differential_dataflow;
     /// # use timely::PartialOrder;
     /// # use timely::order::Product;
     /// # use differential_dataflow::lattice::Lattice;
@@ -257,8 +247,6 @@ implement_lattice!((), ());
 /// # Examples
 ///
 /// ```
-/// # extern crate timely;
-/// # extern crate differential_dataflow;
 /// # use timely::PartialOrder;
 /// # use timely::order::Product;
 /// # use differential_dataflow::lattice::Lattice;
@@ -289,8 +277,6 @@ pub fn antichain_join<T: Lattice>(one: &[T], other: &[T]) -> Antichain<T> {
 /// # Examples
 ///
 /// ```
-/// # extern crate timely;
-/// # extern crate differential_dataflow;
 /// # use timely::PartialOrder;
 /// # use timely::order::Product;
 /// # use timely::progress::Antichain;
@@ -323,8 +309,6 @@ pub fn antichain_join_into<T: Lattice>(one: &[T], other: &[T], upper: &mut Antic
 /// # Examples
 ///
 /// ```
-/// # extern crate timely;
-/// # extern crate differential_dataflow;
 /// # use timely::PartialOrder;
 /// # use timely::order::Product;
 /// # use differential_dataflow::lattice::Lattice;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,16 +92,6 @@ impl<T: timely::Data + Ord + Debug> Data for T { }
 pub trait ExchangeData : timely::ExchangeData + Ord + Debug { }
 impl<T: timely::ExchangeData + Ord + Debug> ExchangeData for T { }
 
-extern crate fnv;
-extern crate timely;
-
-#[macro_use]
-extern crate abomonation_derive;
-extern crate abomonation;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde;
-
 pub mod hashable;
 pub mod operators;
 pub mod algorithms;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,7 @@
 //! Loggers and logging events for differential dataflow.
 
+use abomonation_derive::Abomonation;
+
 /// Logger for differential dataflow events.
 pub type Logger = ::timely::logging::Logger<DifferentialEvent>;
 

--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -10,10 +10,9 @@ use timely::progress::Timestamp;
 use timely::progress::{Antichain, frontier::AntichainRef};
 use timely::dataflow::operators::CapabilitySet;
 
-use lattice::Lattice;
-use trace::{Trace, TraceReader, Batch, BatchReader};
-
-use trace::wrappers::rc::TraceBox;
+use crate::lattice::Lattice;
+use crate::trace::{Trace, TraceReader, Batch, BatchReader};
+use crate::trace::wrappers::rc::TraceBox;
 
 use timely::scheduling::Activator;
 
@@ -39,7 +38,7 @@ where
     temp_antichain: Antichain<Tr::Time>,
 
     operator: OperatorInfo,
-    logging: Option<::logging::Logger>,
+    logging: Option<crate::logging::Logger>,
 }
 
 impl<Tr> TraceReader for TraceAgent<Tr>
@@ -92,7 +91,7 @@ where
     Tr::Time: Timestamp+Lattice,
 {
     /// Creates a new agent from a trace reader.
-    pub fn new(trace: Tr, operator: OperatorInfo, logging: Option<::logging::Logger>) -> (Self, TraceWriter<Tr>)
+    pub fn new(trace: Tr, operator: OperatorInfo, logging: Option<crate::logging::Logger>) -> (Self, TraceWriter<Tr>)
     where
         Tr: Trace,
         Tr::Batch: Batch,
@@ -102,7 +101,7 @@ where
 
         if let Some(logging) = &logging {
             logging.log(
-                ::logging::TraceShare { operator: operator.global_id, diff: 1 }
+                crate::logging::TraceShare { operator: operator.global_id, diff: 1 }
             );
         }
 
@@ -203,9 +202,6 @@ where
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use timely::Config;
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::arrange::ArrangeBySelf;
@@ -259,9 +255,6 @@ where
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use timely::Config;
     /// use timely::dataflow::ProbeHandle;
     /// use timely::dataflow::operators::Probe;
@@ -368,9 +361,6 @@ where
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use timely::Config;
     /// use timely::progress::frontier::AntichainRef;
     /// use timely::dataflow::ProbeHandle;
@@ -563,7 +553,7 @@ where
 
         if let Some(logging) = &self.logging {
             logging.log(
-                ::logging::TraceShare { operator: self.operator.global_id, diff: 1 }
+                crate::logging::TraceShare { operator: self.operator.global_id, diff: 1 }
             );
         }
 
@@ -593,7 +583,7 @@ where
 
         if let Some(logging) = &self.logging {
             logging.log(
-                ::logging::TraceShare { operator: self.operator.global_id, diff: -1 }
+                crate::logging::TraceShare { operator: self.operator.global_id, diff: -1 }
             );
         }
 

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -26,11 +26,11 @@ use timely::progress::Timestamp;
 use timely::progress::{Antichain, frontier::AntichainRef};
 use timely::dataflow::operators::Capability;
 
-use ::{Data, ExchangeData, Collection, AsCollection, Hashable};
-use ::difference::Semigroup;
-use lattice::Lattice;
-use trace::{self, Trace, TraceReader, Batch, BatchReader, Batcher, Builder, Cursor};
-use trace::implementations::{KeySpine, ValSpine};
+use crate::{Data, ExchangeData, Collection, AsCollection, Hashable};
+use crate::difference::Semigroup;
+use crate::lattice::Lattice;
+use crate::trace::{self, Trace, TraceReader, Batch, BatchReader, Batcher, Builder, Cursor};
+use crate::trace::implementations::{KeySpine, ValSpine};
 
 use trace::wrappers::enter::{TraceEnter, BatchEnter,};
 use trace::wrappers::enter_at::TraceEnter as TraceEnterAt;
@@ -149,9 +149,6 @@ where
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::arrange::ArrangeByKey;
     ///
@@ -411,7 +408,7 @@ where
 }
 
 
-use difference::Multiply;
+use crate::difference::Multiply;
 // Direct join implementations.
 impl<G: Scope, Tr> Arranged<G, Tr>
 where
@@ -447,13 +444,13 @@ where
         I: IntoIterator<Item=(D, G::Timestamp, ROut)>,
         L: FnMut(Tr::Key<'_>, Tr::Val<'_>,Tr2::Val<'_>,&G::Timestamp,&Tr::Diff,&Tr2::Diff)->I+'static,
     {
-        use operators::join::join_traces;
+        use crate::operators::join::join_traces;
         join_traces(self, other, result)
     }
 }
 
 // Direct reduce implementations.
-use difference::Abelian;
+use crate::difference::Abelian;
 impl<G: Scope, T1> Arranged<G, T1>
 where
     G::Timestamp: Lattice+Ord,
@@ -489,7 +486,7 @@ where
         T2::Builder: Builder<Output=T2::Batch, Item = ((T1::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
         L: FnMut(T1::Key<'_>, &[(T1::Val<'_>, T1::Diff)], &mut Vec<(<T2::Cursor as Cursor>::ValOwned,T2::Diff)>, &mut Vec<(<T2::Cursor as Cursor>::ValOwned, T2::Diff)>)+'static,
     {
-        use operators::reduce::reduce_trace;
+        use crate::operators::reduce::reduce_trace;
         reduce_trace(self, name, logic)
     }
 }
@@ -620,7 +617,7 @@ where
                 let logger = {
                     let scope = self.scope();
                     let register = scope.log_register();
-                    register.get::<::logging::DifferentialEvent>("differential/arrange")
+                    register.get::<crate::logging::DifferentialEvent>("differential/arrange")
                 };
 
                 // Where we will deposit received updates, and from which we extract batches.

--- a/src/operators/arrange/mod.rs
+++ b/src/operators/arrange/mod.rs
@@ -45,7 +45,7 @@ use std::collections::VecDeque;
 
 use timely::scheduling::Activator;
 use timely::progress::Antichain;
-use trace::TraceReader;
+use crate::trace::TraceReader;
 
 /// Operating instructions on how to replay a trace.
 pub enum TraceReplayInstruction<Tr>

--- a/src/operators/arrange/upsert.rs
+++ b/src/operators/arrange/upsert.rs
@@ -34,9 +34,6 @@
 //! # Example
 //!
 //! ```rust
-//! extern crate timely;
-//! extern crate differential_dataflow;
-//!
 //! fn main() {
 //!
 //!     // define a new timely dataflow computation.
@@ -115,13 +112,11 @@ use timely::progress::Timestamp;
 use timely::progress::Antichain;
 use timely::dataflow::operators::Capability;
 
-use ::{ExchangeData, Hashable};
-use lattice::Lattice;
-use trace::{self, Trace, TraceReader, Batch, Cursor};
-
-use trace::Builder;
-
-use operators::arrange::arrangement::Arranged;
+use crate::lattice::Lattice;
+use crate::operators::arrange::arrangement::Arranged;
+use crate::trace::Builder;
+use crate::trace::{self, Trace, TraceReader, Batch, Cursor};
+use crate::{ExchangeData, Hashable};
 
 use super::TraceAgent;
 
@@ -163,7 +158,7 @@ where
             let logger = {
                 let scope = stream.scope();
                 let register = scope.log_register();
-                register.get::<::logging::DifferentialEvent>("differential/arrange")
+                register.get::<crate::logging::DifferentialEvent>("differential/arrange")
             };
 
             // Tracks the lower envelope of times in `priority_queue`.

--- a/src/operators/arrange/writer.rs
+++ b/src/operators/arrange/writer.rs
@@ -6,11 +6,12 @@
 use std::rc::{Rc, Weak};
 use std::cell::RefCell;
 
-use lattice::Lattice;
-use trace::{Trace, Batch, BatchReader};
 use timely::progress::{Antichain, Timestamp};
 
-use trace::wrappers::rc::TraceBox;
+use crate::lattice::Lattice;
+use crate::trace::{Trace, Batch, BatchReader};
+use crate::trace::wrappers::rc::TraceBox;
+
 
 use super::TraceAgentQueueWriter;
 use super::TraceReplayInstruction;
@@ -95,7 +96,7 @@ where
     /// Inserts an empty batch up to `upper`.
     pub fn seal(&mut self, upper: Antichain<Tr::Time>) {
         if self.upper != upper {
-            use trace::Builder;
+            use crate::trace::Builder;
             let builder = Tr::Builder::new();
             let batch = builder.done(self.upper.clone(), upper, Antichain::from_elem(Tr::Time::minimum()));
             self.insert(batch, None);

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -8,12 +8,12 @@
 
 use timely::dataflow::Scope;
 
-use ::{Collection, ExchangeData, Hashable};
-use ::difference::Semigroup;
+use crate::{Collection, ExchangeData, Hashable};
+use crate::difference::Semigroup;
 
-use Data;
-use lattice::Lattice;
-use trace::{Batcher, Builder};
+use crate::Data;
+use crate::lattice::Lattice;
+use crate::trace::{Batcher, Builder};
 
 /// Methods which require data be arrangeable.
 impl<G, D, R> Collection<G, D, R>
@@ -31,9 +31,6 @@ where
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -49,7 +46,7 @@ where
     /// }
     /// ```
     pub fn consolidate(&self) -> Self {
-        use trace::implementations::KeySpine;
+        use crate::trace::implementations::KeySpine;
         self.consolidate_named::<KeySpine<_,_,_>>("Consolidate")
     }
 
@@ -61,7 +58,7 @@ where
         Tr::Batcher: Batcher<Item = ((D,()),G::Timestamp,R), Time = G::Timestamp>,
         Tr::Builder: Builder<Item = ((D,()),G::Timestamp,R), Time = G::Timestamp>,
     {
-        use operators::arrange::arrangement::Arrange;
+        use crate::operators::arrange::arrangement::Arrange;
         self.map(|k| (k, ()))
             .arrange_named::<Tr>(name)
             .as_collection(|d: &D, _| d.clone())
@@ -78,9 +75,6 @@ where
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     ///
     /// fn main() {
@@ -99,7 +93,7 @@ where
 
         use timely::dataflow::channels::pact::Pipeline;
         use timely::dataflow::operators::Operator;
-        use collection::AsCollection;
+        use crate::collection::AsCollection;
 
         self.inner
             .unary(Pipeline, "ConsolidateStream", |_cap, _info| {

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -5,13 +5,13 @@ use timely::dataflow::*;
 use timely::dataflow::operators::Operator;
 use timely::dataflow::channels::pact::Pipeline;
 
-use lattice::Lattice;
-use ::{ExchangeData, Collection};
-use ::difference::Semigroup;
-use hashable::Hashable;
-use collection::AsCollection;
-use operators::arrange::{Arranged, ArrangeBySelf};
-use trace::{BatchReader, Cursor, TraceReader};
+use crate::lattice::Lattice;
+use crate::{ExchangeData, Collection};
+use crate::difference::Semigroup;
+use crate::hashable::Hashable;
+use crate::collection::AsCollection;
+use crate::operators::arrange::{Arranged, ArrangeBySelf};
+use crate::trace::{BatchReader, Cursor, TraceReader};
 
 /// Extension trait for the `count` differential dataflow method.
 pub trait CountTotal<G: Scope, K: ExchangeData, R: Semigroup> where G::Timestamp: TotalOrder+Lattice+Ord {
@@ -20,9 +20,6 @@ pub trait CountTotal<G: Scope, K: ExchangeData, R: Semigroup> where G::Timestamp
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::CountTotal;
     ///
@@ -74,7 +71,7 @@ where
 
             move |input, output| {
 
-                use trace::cursor::MyTrait;
+                use crate::trace::cursor::MyTrait;
                 input.for_each(|capability, batches| {
                     batches.swap(&mut buffer);
                     let mut session = output.session(&capability);

--- a/src/operators/iterate.rs
+++ b/src/operators/iterate.rs
@@ -41,9 +41,9 @@ use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::operators::{Feedback, ConnectLoop, Map};
 use timely::dataflow::operators::feedback::Handle;
 
-use ::{Data, Collection};
-use ::difference::{Semigroup, Abelian};
-use lattice::Lattice;
+use crate::{Data, Collection};
+use crate::difference::{Semigroup, Abelian};
+use crate::lattice::Lattice;
 
 /// An extension trait for the `iterate` method.
 pub trait Iterate<G: Scope, D: Data, R: Semigroup> {
@@ -58,9 +58,6 @@ pub trait Iterate<G: Scope, D: Data, R: Semigroup> {
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::Iterate;
     ///
@@ -136,9 +133,6 @@ impl<G: Scope, D: Ord+Data+Debug, R: Semigroup> Iterate<G, D, R> for G {
 /// The following example is equivalent to the example for the `Iterate` trait.
 ///
 /// ```
-/// extern crate timely;
-/// extern crate differential_dataflow;
-///
 /// use timely::order::Product;
 /// use timely::dataflow::Scope;
 ///

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -13,15 +13,15 @@ use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Capability;
 use timely::dataflow::channels::pushers::tee::Tee;
 
-use hashable::Hashable;
-use ::{Data, ExchangeData, Collection, AsCollection};
-use ::difference::{Semigroup, Abelian, Multiply};
-use lattice::Lattice;
-use operators::arrange::{Arranged, ArrangeByKey, ArrangeBySelf};
-use trace::{BatchReader, Cursor};
-use operators::ValueHistory;
+use crate::hashable::Hashable;
+use crate::{Data, ExchangeData, Collection, AsCollection};
+use crate::difference::{Semigroup, Abelian, Multiply};
+use crate::lattice::Lattice;
+use crate::operators::arrange::{Arranged, ArrangeByKey, ArrangeBySelf};
+use crate::trace::{BatchReader, Cursor};
+use crate::operators::ValueHistory;
 
-use trace::TraceReader;
+use crate::trace::TraceReader;
 
 /// Join implementations for `(key,val)` data.
 pub trait Join<G: Scope, K: Data, V: Data, R: Semigroup> {
@@ -33,9 +33,6 @@ pub trait Join<G: Scope, K: Data, V: Data, R: Semigroup> {
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::Join;
     ///
@@ -67,9 +64,6 @@ pub trait Join<G: Scope, K: Data, V: Data, R: Semigroup> {
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::Join;
     ///
@@ -97,9 +91,6 @@ pub trait Join<G: Scope, K: Data, V: Data, R: Semigroup> {
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::Join;
     ///
@@ -131,9 +122,6 @@ pub trait Join<G: Scope, K: Data, V: Data, R: Semigroup> {
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::Join;
     ///
@@ -232,9 +220,6 @@ pub trait JoinCore<G: Scope, K: 'static + ?Sized, V: 'static + ?Sized, R: Semigr
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::arrange::ArrangeByKey;
     /// use differential_dataflow::operators::join::JoinCore;
@@ -280,9 +265,6 @@ pub trait JoinCore<G: Scope, K: 'static + ?Sized, V: 'static + ?Sized, R: Semigr
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::arrange::ArrangeByKey;
     /// use differential_dataflow::operators::join::JoinCore;

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -18,9 +18,9 @@ pub mod join;
 pub mod count;
 pub mod threshold;
 
-use ::difference::Semigroup;
-use lattice::Lattice;
-use trace::Cursor;
+use crate::difference::Semigroup;
+use crate::lattice::Lattice;
+use crate::trace::Cursor;
 
 /// An accumulation of (value, time, diff) updates.
 struct EditList<'a, C: Cursor> where C::Time: Sized, C::Diff: Sized {

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -5,9 +5,9 @@
 //! to the key and the list of values.
 //! The function is expected to populate a list of output values.
 
-use hashable::Hashable;
-use ::{Data, ExchangeData, Collection};
-use ::difference::{Semigroup, Abelian};
+use crate::hashable::Hashable;
+use crate::{Data, ExchangeData, Collection};
+use crate::difference::{Semigroup, Abelian};
 
 use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
@@ -17,13 +17,13 @@ use timely::dataflow::operators::Operator;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Capability;
 
-use operators::arrange::{Arranged, ArrangeByKey, ArrangeBySelf, TraceAgent};
-use lattice::Lattice;
-use trace::{Batch, BatchReader, Cursor, Trace, Builder, ExertionLogic};
-use trace::cursor::CursorList;
-use trace::implementations::{KeySpine, ValSpine};
+use crate::operators::arrange::{Arranged, ArrangeByKey, ArrangeBySelf, TraceAgent};
+use crate::lattice::Lattice;
+use crate::trace::{Batch, BatchReader, Cursor, Trace, Builder, ExertionLogic};
+use crate::trace::cursor::CursorList;
+use crate::trace::implementations::{KeySpine, ValSpine};
 
-use trace::TraceReader;
+use crate::trace::TraceReader;
 
 /// Extension trait for the `reduce` differential dataflow method.
 pub trait Reduce<G: Scope, K: Data, V: Data, R: Semigroup> where G::Timestamp: Lattice+Ord {
@@ -43,9 +43,6 @@ pub trait Reduce<G: Scope, K: Data, V: Data, R: Semigroup> where G::Timestamp: L
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::Reduce;
     ///
@@ -108,9 +105,6 @@ pub trait Threshold<G: Scope, K: Data, R1: Semigroup> where G::Timestamp: Lattic
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::Threshold;
     ///
@@ -135,9 +129,6 @@ pub trait Threshold<G: Scope, K: Data, R1: Semigroup> where G::Timestamp: Lattic
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::Threshold;
     ///
@@ -190,9 +181,6 @@ pub trait Count<G: Scope, K: Data, R: Semigroup> where G::Timestamp: Lattice+Ord
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::Count;
     ///
@@ -248,9 +236,6 @@ pub trait ReduceCore<G: Scope, K: ToOwned + ?Sized, V: ToOwned + ?Sized, R: Semi
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::reduce::ReduceCore;
     /// use differential_dataflow::trace::Trace;
@@ -354,7 +339,7 @@ where
             let logger = {
                 let scope = trace.stream.scope();
                 let register = scope.log_register();
-                register.get::<::logging::DifferentialEvent>("differential/arrange")
+                register.get::<crate::logging::DifferentialEvent>("differential/arrange")
             };
 
             let activator = Some(trace.stream.scope().activator_for(&operator_info.address[..]));
@@ -501,7 +486,7 @@ where
                         while batch_cursor.key_valid(batch_storage) || exposed_position < exposed.len() {
 
                             use std::borrow::Borrow;
-                            use trace::cursor::MyTrait;
+                            use crate::trace::cursor::MyTrait;
                             
                             // Determine the next key we will work on; could be synthetic, could be from a batch.
                             let key1 = exposed.get(exposed_position).map(|x| <_ as MyTrait>::borrow_as(&x.0));
@@ -687,10 +672,10 @@ where
 /// Implementation based on replaying historical and new updates together.
 mod history_replay {
 
-    use ::difference::Semigroup;
-    use lattice::Lattice;
-    use trace::Cursor;
-    use operators::ValueHistory;
+    use crate::difference::Semigroup;
+    use crate::lattice::Lattice;
+    use crate::trace::Cursor;
+    use crate::operators::ValueHistory;
     use timely::progress::Antichain;
 
     use timely::PartialOrder;
@@ -927,7 +912,7 @@ mod history_replay {
                         meet.as_ref().map(|meet| output_replay.advance_buffer_by(&meet));
                         for &((value, ref time), ref diff) in output_replay.buffer().iter() {
                             if time.less_equal(&next_time) {
-                                use trace::cursor::MyTrait;
+                                use crate::trace::cursor::MyTrait;
                                 self.output_buffer.push((<_ as MyTrait>::into_owned(value), diff.clone()));
                             }
                             else {

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -8,13 +8,13 @@ use timely::dataflow::*;
 use timely::dataflow::operators::Operator;
 use timely::dataflow::channels::pact::Pipeline;
 
-use lattice::Lattice;
-use ::{ExchangeData, Collection};
-use ::difference::{Semigroup, Abelian};
-use hashable::Hashable;
-use collection::AsCollection;
-use operators::arrange::{Arranged, ArrangeBySelf};
-use trace::{BatchReader, Cursor, TraceReader};
+use crate::lattice::Lattice;
+use crate::{ExchangeData, Collection};
+use crate::difference::{Semigroup, Abelian};
+use crate::hashable::Hashable;
+use crate::collection::AsCollection;
+use crate::operators::arrange::{Arranged, ArrangeBySelf};
+use crate::trace::{BatchReader, Cursor, TraceReader};
 
 /// Extension trait for the `distinct` differential dataflow method.
 pub trait ThresholdTotal<G: Scope, K: ExchangeData, R: ExchangeData+Semigroup> where G::Timestamp: TotalOrder+Lattice+Ord {
@@ -29,9 +29,6 @@ pub trait ThresholdTotal<G: Scope, K: ExchangeData, R: ExchangeData+Semigroup> w
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::ThresholdTotal;
     ///
@@ -60,9 +57,6 @@ pub trait ThresholdTotal<G: Scope, K: ExchangeData, R: ExchangeData+Semigroup> w
     /// # Examples
     ///
     /// ```
-    /// extern crate timely;
-    /// extern crate differential_dataflow;
-    ///
     /// use differential_dataflow::input::Input;
     /// use differential_dataflow::operators::ThresholdTotal;
     ///

--- a/src/trace/description.rs
+++ b/src/trace/description.rs
@@ -55,6 +55,7 @@
 //! will often be a logic bug, as `since` does not advance without a corresponding advance in
 //! times at which data may possibly be sent.
 
+use abomonation_derive::Abomonation;
 use timely::{PartialOrder, progress::Antichain};
 use serde::{Serialize, Deserialize};
 

--- a/src/trace/implementations/huffman_container.rs
+++ b/src/trace/implementations/huffman_container.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use trace::implementations::{BatchContainer, OffsetList};
+use crate::trace::implementations::{BatchContainer, OffsetList};
 
 use self::wrapper::Wrapped;
 use self::encoded::Encoded;
@@ -52,7 +52,7 @@ where
         }
     }
     fn copy_push(&mut self, item: &Vec<B>) {
-        use trace::MyTrait;
+        use crate::trace::MyTrait;
         self.copy(<_ as MyTrait>::borrow_as(item));
     }
     fn copy<'a>(&mut self, item: Self::ReadItem<'a>) {
@@ -159,7 +159,7 @@ impl<B: Ord+Clone> Default for HuffmanContainer<B> {
 
 mod wrapper {
 
-    use trace::MyTrait;
+    use crate::trace::MyTrait;
     use super::Encoded;
 
     pub struct Wrapped<'a, B: Ord> {

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -5,9 +5,9 @@ use std::collections::VecDeque;
 use timely::communication::message::RefOrMut;
 use timely::progress::{frontier::Antichain, Timestamp};
 
-use ::difference::Semigroup;
+use crate::difference::Semigroup;
 
-use trace::{Batcher, Builder};
+use crate::trace::{Batcher, Builder};
 
 /// Creates batches from unordered tuples.
 pub struct MergeBatcher<K, V, T, D> {

--- a/src/trace/implementations/merge_batcher_col.rs
+++ b/src/trace/implementations/merge_batcher_col.rs
@@ -5,9 +5,9 @@ use timely::communication::message::RefOrMut;
 use timely::container::columnation::{Columnation, TimelyStack};
 use timely::progress::{frontier::Antichain, Timestamp};
 
-use ::difference::Semigroup;
+use crate::difference::Semigroup;
 
-use trace::{Batcher, Builder};
+use crate::trace::{Batcher, Builder};
 
 /// Creates batches from unordered tuples.
 pub struct ColumnatedMergeBatcher<K, V, T, D>

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -40,8 +40,8 @@
 
 pub mod spine_fueled;
 
-mod merge_batcher;
-pub(crate) mod merge_batcher_col;
+pub mod merge_batcher;
+pub mod merge_batcher_col;
 
 pub use self::merge_batcher::MergeBatcher as Batcher;
 
@@ -56,8 +56,8 @@ pub use self::ord_neu::OrdKeySpine as KeySpine;
 use std::borrow::{ToOwned};
 
 use timely::container::columnation::{Columnation, TimelyStack};
-use lattice::Lattice;
-use difference::Semigroup;
+use crate::lattice::Lattice;
+use crate::difference::Semigroup;
 
 /// A type that names constituent update types.
 pub trait Update {
@@ -220,6 +220,7 @@ where
 // }
 
 use std::convert::TryInto;
+use abomonation_derive::Abomonation;
 
 /// A list of unsigned integers that uses `u32` elements as long as they are small enough, and switches to `u64` once they are not.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Abomonation)]
@@ -312,7 +313,7 @@ pub mod containers {
     use timely::container::columnation::{Columnation, TimelyStack};
 
     use std::borrow::{Borrow, ToOwned};
-    use trace::MyTrait;
+    use crate::trace::MyTrait;
 
     /// A general-purpose container resembling `Vec<T>`.
     pub trait BatchContainer: Default + 'static {

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -10,10 +10,10 @@
 
 use std::rc::Rc;
 
-use trace::implementations::spine_fueled::Spine;
-use trace::implementations::merge_batcher::MergeBatcher;
-use trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
-use trace::rc_blanket_impls::RcBuilder;
+use crate::trace::implementations::spine_fueled::Spine;
+use crate::trace::implementations::merge_batcher::MergeBatcher;
+use crate::trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
+use crate::trace::rc_blanket_impls::RcBuilder;
 
 use super::{Update, Layout, Vector, TStack, Preferred};
 
@@ -67,11 +67,12 @@ mod val_batch {
 
     use std::convert::TryInto;
     use std::marker::PhantomData;
+    use abomonation_derive::Abomonation;
     use timely::progress::{Antichain, frontier::AntichainRef};
 
-    use trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
-    use trace::implementations::{BatchContainer, OffsetList};
-    use trace::cursor::MyTrait;
+    use crate::trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
+    use crate::trace::implementations::{BatchContainer, OffsetList};
+    use crate::trace::cursor::MyTrait;
 
     use super::{Layout, Update};
 
@@ -195,7 +196,7 @@ mod val_batch {
         fn new(batch1: &OrdValBatch<L>, batch2: &OrdValBatch<L>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
 
             assert!(batch1.upper() == batch2.lower());
-            use lattice::Lattice;
+            use crate::lattice::Lattice;
             let mut since = batch1.description().since().join(batch2.description().since());
             since = since.join(&compaction_frontier.to_owned());
 
@@ -397,7 +398,7 @@ mod val_batch {
             for i in lower .. upper {
                 // NB: Here is where we would need to look back if `lower == upper`.
                 let (time, diff) = &source.updates.index(i).into_owned();
-                use lattice::Lattice;
+                use crate::lattice::Lattice;
                 let mut new_time = time.clone();
                 new_time.advance_by(self.description.since().borrow());
                 self.update_stash.push((new_time, diff.clone()));
@@ -406,7 +407,7 @@ mod val_batch {
 
         /// Consolidates `self.updates_stash` and produces the offset to record, if any.
         fn consolidate_updates(&mut self) -> Option<usize> {
-            use consolidation;
+            use crate::consolidation;
             consolidation::consolidate(&mut self.update_stash);
             if !self.update_stash.is_empty() {
                 // If there is a single element, equal to a just-prior recorded update,
@@ -633,11 +634,12 @@ mod key_batch {
 
     use std::convert::TryInto;
     use std::marker::PhantomData;
+    use abomonation_derive::Abomonation;
     use timely::progress::{Antichain, frontier::AntichainRef};
 
-    use trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
-    use trace::implementations::{BatchContainer, OffsetList};
-    use trace::cursor::MyTrait;
+    use crate::trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
+    use crate::trace::implementations::{BatchContainer, OffsetList};
+    use crate::trace::cursor::MyTrait;
 
     use super::{Layout, Update};
 
@@ -752,7 +754,7 @@ mod key_batch {
         fn new(batch1: &OrdKeyBatch<L>, batch2: &OrdKeyBatch<L>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
 
             assert!(batch1.upper() == batch2.lower());
-            use lattice::Lattice;
+            use crate::lattice::Lattice;
             let mut since = batch1.description().since().join(batch2.description().since());
             since = since.join(&compaction_frontier.to_owned());
 
@@ -867,7 +869,7 @@ mod key_batch {
             for i in lower .. upper {
                 // NB: Here is where we would need to look back if `lower == upper`.
                 let (time, diff) = &source.updates.index(i);
-                use lattice::Lattice;
+                use crate::lattice::Lattice;
                 let mut new_time = time.clone();
                 new_time.advance_by(self.description.since().borrow());
                 self.update_stash.push((new_time, diff.clone()));
@@ -876,7 +878,7 @@ mod key_batch {
 
         /// Consolidates `self.updates_stash` and produces the offset to record, if any.
         fn consolidate_updates(&mut self) -> Option<usize> {
-            use consolidation;
+            use crate::consolidation;
             consolidation::consolidate(&mut self.update_stash);
             if !self.update_stash.is_empty() {
                 // If there is a single element, equal to a just-prior recorded update,

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -7,11 +7,11 @@
 
 use std::rc::Rc;
 
-use Hashable;
-use trace::implementations::spine_fueled::Spine;
-use trace::implementations::merge_batcher::MergeBatcher;
-use trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
-use trace::rc_blanket_impls::RcBuilder;
+use crate::Hashable;
+use crate::trace::implementations::spine_fueled::Spine;
+use crate::trace::implementations::merge_batcher::MergeBatcher;
+use crate::trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
+use crate::trace::rc_blanket_impls::RcBuilder;
 
 use super::{Update, Layout, Vector, TStack};
 
@@ -48,7 +48,9 @@ pub struct HashWrapper<T: std::hash::Hash + Hashable> {
 }
 
 use std::cmp::Ordering;
-impl<T: PartialOrd + std::hash::Hash + Hashable> PartialOrd for HashWrapper<T> 
+use abomonation_derive::Abomonation;
+
+impl<T: PartialOrd + std::hash::Hash + Hashable> PartialOrd for HashWrapper<T>
 where <T as Hashable>::Output: PartialOrd {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         let this_hash = self.inner.hashed();
@@ -76,13 +78,14 @@ mod val_batch {
     use std::borrow::Borrow;
     use std::convert::TryInto;
     use std::marker::PhantomData;
+    use abomonation_derive::Abomonation;
     use timely::progress::{Antichain, frontier::AntichainRef};
 
-    use hashable::Hashable;
+    use crate::hashable::Hashable;
 
-    use trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
-    use trace::implementations::{BatchContainer, OffsetList};
-    use trace::cursor::MyTrait;
+    use crate::trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
+    use crate::trace::implementations::{BatchContainer, OffsetList};
+    use crate::trace::cursor::MyTrait;
 
     use super::{Layout, Update, HashOrdered};
 
@@ -320,7 +323,7 @@ mod val_batch {
         fn new(batch1: &RhhValBatch<L>, batch2: &RhhValBatch<L>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
 
             assert!(batch1.upper() == batch2.lower());
-            use lattice::Lattice;
+            use crate::lattice::Lattice;
             let mut since = batch1.description().since().join(batch2.description().since());
             since = since.join(&compaction_frontier.to_owned());
 
@@ -543,7 +546,7 @@ mod val_batch {
                 // NB: Here is where we would need to look back if `lower == upper`.
                 let (time, diff) = &source.updates.index(i);
                 let mut new_time = time.clone();
-                use lattice::Lattice;
+                use crate::lattice::Lattice;
                 new_time.advance_by(self.description.since().borrow());
                 self.update_stash.push((new_time, diff.clone()));
             }
@@ -551,7 +554,7 @@ mod val_batch {
 
         /// Consolidates `self.updates_stash` and produces the offset to record, if any.
         fn consolidate_updates(&mut self) -> Option<usize> {
-            use consolidation;
+            use crate::consolidation;
             consolidation::consolidate(&mut self.update_stash);
             if !self.update_stash.is_empty() {
                 // If there is a single element, equal to a just-prior recorded update,

--- a/src/trace/implementations/spine_fueled.rs
+++ b/src/trace/implementations/spine_fueled.rs
@@ -71,12 +71,12 @@
 
 use std::fmt::Debug;
 
-use ::logging::Logger;
-use ::difference::Semigroup;
-use lattice::Lattice;
-use trace::{Batch, Batcher, Builder, BatchReader, Trace, TraceReader, ExertionLogic};
-use trace::cursor::CursorList;
-use trace::Merger;
+use crate::logging::Logger;
+use crate::difference::Semigroup;
+use crate::lattice::Lattice;
+use crate::trace::{Batch, Batcher, Builder, BatchReader, Trace, TraceReader, ExertionLogic};
+use crate::trace::cursor::CursorList;
+use crate::trace::Merger;
 
 use ::timely::dataflow::operators::generic::OperatorInfo;
 use ::timely::progress::{Antichain, frontier::AntichainRef};
@@ -272,7 +272,7 @@ where
 
     fn new(
         info: ::timely::dataflow::operators::generic::OperatorInfo,
-        logging: Option<::logging::Logger>,
+        logging: Option<crate::logging::Logger>,
         activator: Option<timely::scheduling::activate::Activator>,
     ) -> Self {
         Self::with_effort(1, info, logging, activator)
@@ -314,7 +314,7 @@ where
     fn insert(&mut self, batch: Self::Batch) {
 
         // Log the introduction of a batch.
-        self.logger.as_ref().map(|l| l.log(::logging::BatchEvent {
+        self.logger.as_ref().map(|l| l.log(crate::logging::BatchEvent {
             operator: self.operator.global_id,
             length: batch.len()
         }));
@@ -364,23 +364,23 @@ where
             for batch in self.merging.drain(..) {
                 match batch {
                     MergeState::Single(Some(batch)) => {
-                        logger.log(::logging::DropEvent {
+                        logger.log(crate::logging::DropEvent {
                             operator: self.operator.global_id,
                             length: batch.len(),
                         });
                     },
                     MergeState::Double(MergeVariant::InProgress(batch1, batch2, _)) => {
-                        logger.log(::logging::DropEvent {
+                        logger.log(crate::logging::DropEvent {
                             operator: self.operator.global_id,
                             length: batch1.len(),
                         });
-                        logger.log(::logging::DropEvent {
+                        logger.log(crate::logging::DropEvent {
                             operator: self.operator.global_id,
                             length: batch2.len(),
                         });
                     },
                     MergeState::Double(MergeVariant::Complete(Some((batch, _)))) => {
-                        logger.log(::logging::DropEvent {
+                        logger.log(crate::logging::DropEvent {
                             operator: self.operator.global_id,
                             length: batch.len(),
                         });
@@ -389,7 +389,7 @@ where
                 }
             }
             for batch in self.pending.drain(..) {
-                logger.log(::logging::DropEvent {
+                logger.log(crate::logging::DropEvent {
                     operator: self.operator.global_id,
                     length: batch.len(),
                 });
@@ -443,7 +443,7 @@ where
     pub fn with_effort(
         mut effort: usize,
         operator: OperatorInfo,
-        logger: Option<::logging::Logger>,
+        logger: Option<crate::logging::Logger>,
         activator: Option<timely::scheduling::activate::Activator>,
     ) -> Self {
 
@@ -679,7 +679,7 @@ where
             MergeState::Single(old) => {
                 // Log the initiation of a merge.
                 self.logger.as_ref().map(|l| l.log(
-                    ::logging::MergeEvent {
+                    crate::logging::MergeEvent {
                         operator: self.operator.global_id,
                         scale: index,
                         length1: old.as_ref().map(|b| b.len()).unwrap_or(0),
@@ -702,7 +702,7 @@ where
             if let Some((input1, input2)) = inputs {
                 // Log the completion of a merge from existing parts.
                 self.logger.as_ref().map(|l| l.log(
-                    ::logging::MergeEvent {
+                    crate::logging::MergeEvent {
                         operator: self.operator.global_id,
                         scale: index,
                         length1: input1.len(),

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -16,7 +16,7 @@ use timely::communication::message::RefOrMut;
 use timely::progress::{Antichain, frontier::AntichainRef};
 use timely::progress::Timestamp;
 
-use trace::cursor::MyTrait;
+use crate::trace::cursor::MyTrait;
 
 // use ::difference::Semigroup;
 pub use self::cursor::Cursor;
@@ -220,7 +220,7 @@ where <Self as TraceReader>::Batch: Batch {
     /// Allocates a new empty trace.
     fn new(
         info: ::timely::dataflow::operators::generic::OperatorInfo,
-        logging: Option<::logging::Logger>,
+        logging: Option<crate::logging::Logger>,
         activator: Option<timely::scheduling::activate::Activator>,
     ) -> Self;
 
@@ -483,9 +483,6 @@ pub mod rc_blanket_impls {
 
 /// Blanket implementations for reference counted batches.
 pub mod abomonated_blanket_impls {
-
-    extern crate abomonation;
-
     use abomonation::{Abomonation, measure};
     use abomonation::abomonated::Abomonated;
     use timely::progress::{Antichain, frontier::AntichainRef};

--- a/src/trace/wrappers/enter.rs
+++ b/src/trace/wrappers/enter.rs
@@ -5,9 +5,9 @@ use timely::progress::timestamp::Refines;
 use timely::progress::Timestamp;
 use timely::progress::{Antichain, frontier::AntichainRef};
 
-use lattice::Lattice;
-use trace::{TraceReader, BatchReader, Description};
-use trace::cursor::Cursor;
+use crate::lattice::Lattice;
+use crate::trace::{TraceReader, BatchReader, Description};
+use crate::trace::cursor::Cursor;
 
 /// Wrapper to provide trace to nested scope.
 pub struct TraceEnter<Tr, TInner>

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -4,9 +4,9 @@ use timely::progress::timestamp::Refines;
 use timely::progress::Timestamp;
 use timely::progress::{Antichain, frontier::AntichainRef};
 
-use lattice::Lattice;
-use trace::{TraceReader, BatchReader, Description};
-use trace::cursor::Cursor;
+use crate::lattice::Lattice;
+use crate::trace::{TraceReader, BatchReader, Description};
+use crate::trace::cursor::Cursor;
 
 /// Wrapper to provide trace to nested scope.
 ///

--- a/src/trace/wrappers/filter.rs
+++ b/src/trace/wrappers/filter.rs
@@ -3,8 +3,8 @@
 use timely::progress::Timestamp;
 use timely::progress::frontier::AntichainRef;
 
-use trace::{TraceReader, BatchReader, Description};
-use trace::cursor::Cursor;
+use crate::trace::{TraceReader, BatchReader, Description};
+use crate::trace::cursor::Cursor;
 
 /// Wrapper to provide trace to nested scope.
 pub struct TraceFilter<Tr, F> {

--- a/src/trace/wrappers/freeze.rs
+++ b/src/trace/wrappers/freeze.rs
@@ -23,10 +23,10 @@ use timely::dataflow::Scope;
 use timely::dataflow::operators::Map;
 use timely::progress::frontier::AntichainRef;
 
-use operators::arrange::Arranged;
-use lattice::Lattice;
-use trace::{TraceReader, BatchReader, Description};
-use trace::cursor::Cursor;
+use crate::operators::arrange::Arranged;
+use crate::lattice::Lattice;
+use crate::trace::{TraceReader, BatchReader, Description};
+use crate::trace::cursor::Cursor;
 
 /// Freezes updates to an arrangement using a supplied function.
 ///

--- a/src/trace/wrappers/frontier.rs
+++ b/src/trace/wrappers/frontier.rs
@@ -9,8 +9,8 @@
 use timely::progress::Timestamp;
 use timely::progress::{Antichain, frontier::AntichainRef};
 
-use trace::{TraceReader, BatchReader, Description};
-use trace::cursor::Cursor;
+use crate::trace::{TraceReader, BatchReader, Description};
+use crate::trace::cursor::Cursor;
 use crate::lattice::Lattice;
 
 /// Wrapper to provide trace to nested scope.

--- a/src/trace/wrappers/rc.rs
+++ b/src/trace/wrappers/rc.rs
@@ -16,8 +16,8 @@ use std::cell::RefCell;
 
 use timely::progress::{Antichain, frontier::{AntichainRef, MutableAntichain}};
 
-use lattice::Lattice;
-use trace::TraceReader;
+use crate::lattice::Lattice;
+use crate::trace::TraceReader;
 
 /// A wrapper around a trace which tracks the frontiers of all referees.
 ///

--- a/tests/bfs.rs
+++ b/tests/bfs.rs
@@ -1,7 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use std::sync::{Arc, Mutex};

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -1,7 +1,3 @@
-extern crate timely;
-extern crate itertools;
-extern crate differential_dataflow;
-
 use timely::dataflow::operators::*;
 use timely::dataflow::operators::capture::Extract;
 use timely::progress::frontier::AntichainRef;

--- a/tests/join.rs
+++ b/tests/join.rs
@@ -1,6 +1,3 @@
-extern crate timely;
-extern crate differential_dataflow;
-
 use timely::dataflow::operators::{ToStream, Capture, Map};
 use timely::dataflow::operators::capture::Extract;
 use differential_dataflow::AsCollection;

--- a/tests/reduce.rs
+++ b/tests/reduce.rs
@@ -1,6 +1,3 @@
-extern crate timely;
-extern crate differential_dataflow;
-
 use timely::dataflow::operators::{ToStream, Capture, Map};
 use timely::dataflow::operators::capture::Extract;
 use differential_dataflow::AsCollection;

--- a/tests/scc.rs
+++ b/tests/scc.rs
@@ -1,7 +1,3 @@
-extern crate rand;
-extern crate timely;
-extern crate differential_dataflow;
-
 use rand::{Rng, SeedableRng, StdRng};
 
 use std::sync::{Arc, Mutex};

--- a/tests/trace.rs
+++ b/tests/trace.rs
@@ -1,6 +1,3 @@
-extern crate timely;
-extern crate differential_dataflow;
-
 use timely::dataflow::operators::generic::OperatorInfo;
 use timely::progress::{Antichain, frontier::AntichainRef};
 


### PR DESCRIPTION
What started as a simple change to visibility .. went sideways. This PR does the following:
* It adds `edition = "2021"` to all crates in the workspace.
* It adds all crates as workspace members to the root `Cargo.toml`. Advent-of-code 2017 and tpchlike are commented because they don't compile anymore, and I didn't want to spend time on fixing.
* It changes includes and `extern crate` definitions to the new language level.
* It changes the dependency on Timely to a workspace dependency, which makes it easier to point to a different Timely version globally.

The motivation is twofold: It's good to update to a more recent language level, and it increases build/test coverage for code in the repository.

It also makes the merge batcher variants pub, so one can define a new spine type outside Differential.