### PR TITLE
Introduce trait constraints; simplify elsewhere

### DIFF
--- a/dogsdogsdogs/src/operators/count.rs
+++ b/dogsdogsdogs/src/operators/count.rs
@@ -19,9 +19,8 @@ pub fn count<G, Tr, R, F, P>(
     index: usize,
 ) -> Collection<G, (P, usize, usize), R>
 where
-    G: Scope,
-    G::Timestamp: Lattice,
-    Tr: TraceReader<ValOwned=(), Time=G::Timestamp, Diff=isize>+Clone+'static,
+    G: Scope<Timestamp=Tr::Time>,
+    Tr: TraceReader<ValOwned=(), Diff=isize>+Clone+'static,
     Tr::KeyOwned: Hashable + Default,
     R: Monoid+Multiply<Output = R>+ExchangeData,
     F: Fn(&P)->Tr::KeyOwned+Clone+'static,

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -76,13 +76,11 @@ pub fn half_join<G, V, R, Tr, FF, CF, DOut, S>(
     mut output_func: S,
 ) -> Collection<G, (DOut, G::Timestamp), <R as Mul<Tr::Diff>>::Output>
 where
-    G: Scope,
-    G::Timestamp: Lattice,
-    Tr::KeyOwned: Ord + Hashable + ExchangeData,
+    G: Scope<Timestamp = Tr::Time>,
+    Tr::KeyOwned: Hashable + ExchangeData,
     V: ExchangeData,
     R: ExchangeData + Monoid,
-    Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
-    Tr::Diff: Semigroup,
+    Tr: TraceReader+Clone+'static,
     R: Mul<Tr::Diff>,
     <R as Mul<Tr::Diff>>::Output: Semigroup,
     FF: Fn(&G::Timestamp) -> G::Timestamp + 'static,
@@ -131,13 +129,11 @@ pub fn half_join_internal_unsafe<G, V, R, Tr, FF, CF, DOut, ROut, Y, I, S>(
     mut output_func: S,
 ) -> Collection<G, DOut, ROut>
 where
-    G: Scope,
-    G::Timestamp: Lattice,
-    Tr::KeyOwned: Ord + Hashable + ExchangeData,
+    G: Scope<Timestamp = Tr::Time>,
+    Tr::KeyOwned: Hashable + ExchangeData,
     V: ExchangeData,
     R: ExchangeData + Monoid,
-    Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
-    Tr::Diff: Semigroup,
+    Tr: TraceReader+Clone+'static,
     FF: Fn(&G::Timestamp) -> G::Timestamp + 'static,
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
     DOut: Clone+'static,

--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -27,9 +27,8 @@ pub fn lookup_map<G, D, R, Tr, F, DOut, ROut, S>(
     supplied_key2: Tr::KeyOwned,
 ) -> Collection<G, DOut, ROut>
 where
-    G: Scope,
-    G::Timestamp: Lattice,
-    Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
+    G: Scope<Timestamp=Tr::Time>,
+    Tr: TraceReader+Clone+'static,
     Tr::KeyOwned: Hashable,
     Tr::Diff: Monoid+ExchangeData,
     F: FnMut(&D, &mut Tr::KeyOwned)+Clone+'static,

--- a/dogsdogsdogs/src/operators/propose.rs
+++ b/dogsdogsdogs/src/operators/propose.rs
@@ -21,9 +21,8 @@ pub fn propose<G, Tr, F, P>(
     key_selector: F,
 ) -> Collection<G, (P, Tr::ValOwned), Tr::Diff>
 where
-    G: Scope,
-    G::Timestamp: Lattice,
-    Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
+    G: Scope<Timestamp=Tr::Time>,
+    Tr: TraceReader+Clone+'static,
     Tr::KeyOwned: Hashable + Default,
     Tr::Diff: Monoid+Multiply<Output = Tr::Diff>+ExchangeData,
     F: Fn(&P)->Tr::KeyOwned+Clone+'static,
@@ -51,9 +50,8 @@ pub fn propose_distinct<G, Tr, F, P>(
     key_selector: F,
 ) -> Collection<G, (P, Tr::ValOwned), Tr::Diff>
 where
-    G: Scope,
-    G::Timestamp: Lattice,
-    Tr: TraceReader<Time=G::Timestamp>+Clone+'static,
+    G: Scope<Timestamp=Tr::Time>,
+    Tr: TraceReader+Clone+'static,
     Tr::KeyOwned: Hashable + Default,
     Tr::Diff: Monoid+Multiply<Output = Tr::Diff>+ExchangeData,
     F: Fn(&P)->Tr::KeyOwned+Clone+'static,

--- a/dogsdogsdogs/src/operators/validate.rs
+++ b/dogsdogsdogs/src/operators/validate.rs
@@ -19,9 +19,8 @@ pub fn validate<G, K, V, Tr, F, P>(
     key_selector: F,
 ) -> Collection<G, (P, V), Tr::Diff>
 where
-    G: Scope,
-    G::Timestamp: Lattice,
-    Tr: TraceReader<KeyOwned=(K,V), ValOwned=(), Time=G::Timestamp>+Clone+'static,
+    G: Scope<Timestamp=Tr::Time>,
+    Tr: TraceReader<KeyOwned=(K,V), ValOwned=()>+Clone+'static,
     K: Ord+Hash+Clone+Default,
     V: ExchangeData+Hash+Default,
     Tr::Diff: Monoid+Multiply<Output = Tr::Diff>+ExchangeData,

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -132,10 +132,10 @@ fn main() {
 fn dump_cursor<Tr>(round: u32, index: usize, trace: &mut Tr)
 where
     Tr: TraceReader,
-    Tr::KeyOwned: Debug + Clone,
-    Tr::ValOwned: Debug + Clone,
-    Tr::Time: Debug + Clone,
-    Tr::Diff: Debug + Clone,
+    Tr::KeyOwned: Debug,
+    Tr::ValOwned: Debug,
+    Tr::Time: Debug,
+    Tr::Diff: Debug,
 {
     let (mut cursor, storage) = trace.cursor();
     for ((k, v), diffs) in cursor.to_vec(&storage).iter() {

--- a/src/algorithms/graphs/bfs.rs
+++ b/src/algorithms/graphs/bfs.rs
@@ -26,10 +26,9 @@ use crate::operators::arrange::Arranged;
 /// Returns pairs (node, dist) indicating distance of each node from a root.
 pub fn bfs_arranged<G, N, Tr>(edges: &Arranged<G, Tr>, roots: &Collection<G, N>) -> Collection<G, (N, u32)>
 where
-    G: Scope,
-    G::Timestamp: Lattice+Ord,
+    G: Scope<Timestamp=Tr::Time>,
     N: ExchangeData+Hash,
-    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Time=G::Timestamp, Diff=isize>+Clone+'static,
+    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Diff=isize>+Clone+'static,
 {
     // initialize roots as reaching themselves at distance 0
     let nodes = roots.map(|x| (x, 0));

--- a/src/algorithms/graphs/bijkstra.rs
+++ b/src/algorithms/graphs/bijkstra.rs
@@ -42,10 +42,9 @@ pub fn bidijkstra_arranged<G, N, Tr>(
     goals: &Collection<G, (N,N)>
 ) -> Collection<G, ((N,N), u32)>
 where
-    G: Scope,
-    G::Timestamp: Lattice+Ord,
+    G: Scope<Timestamp=Tr::Time>,
     N: ExchangeData+Hash,
-    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Time=G::Timestamp, Diff=isize>+Clone+'static,
+    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Diff=isize>+Clone+'static,
 {
     forward
         .stream

--- a/src/algorithms/graphs/propagate.rs
+++ b/src/algorithms/graphs/propagate.rs
@@ -56,14 +56,13 @@ use crate::operators::arrange::arrangement::Arranged;
 /// of `logic should be a number in the interval [0,64],
 pub fn propagate_core<G, N, L, Tr, F, R>(edges: &Arranged<G,Tr>, nodes: &Collection<G,(N,L),R>, logic: F) -> Collection<G,(N,L),R>
 where
-    G: Scope,
-    G::Timestamp: Lattice+Ord,
+    G: Scope<Timestamp=Tr::Time>,
     N: ExchangeData+Hash,
     R: ExchangeData+Abelian,
     R: Multiply<R, Output=R>,
     R: From<i8>,
     L: ExchangeData,
-    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Time=G::Timestamp, Diff=R>+Clone+'static,
+    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Diff=R>+Clone+'static,
     F: Fn(&L)->u64+Clone+'static,
 {
     // Morally the code performs the following iterative computation. However, in the interest of a simplified

--- a/src/operators/arrange/upsert.rs
+++ b/src/operators/arrange/upsert.rs
@@ -108,7 +108,6 @@ use timely::progress::Timestamp;
 use timely::progress::Antichain;
 use timely::dataflow::operators::Capability;
 
-use crate::lattice::Lattice;
 use crate::operators::arrange::arrangement::Arranged;
 use crate::trace::Builder;
 use crate::trace::{self, Trace, TraceReader, Batch, Cursor};
@@ -131,11 +130,11 @@ pub fn arrange_from_upsert<G, Tr>(
     name: &str,
 ) -> Arranged<G, TraceAgent<Tr>>
 where
-    G: Scope,
-    G::Timestamp: Lattice+Ord+TotalOrder+ExchangeData,
+    G: Scope<Timestamp=Tr::Time>,
+    Tr: Trace+TraceReader<Diff=isize>+'static,
     Tr::KeyOwned: ExchangeData+Hashable+std::hash::Hash,
     Tr::ValOwned: ExchangeData,
-    Tr: Trace+TraceReader<Time=G::Timestamp,Diff=isize>+'static,
+    Tr::Time: TotalOrder+ExchangeData,
     Tr::Batch: Batch,
     Tr::Builder: Builder<Item = ((Tr::KeyOwned, Tr::ValOwned), Tr::Time, Tr::Diff)>,
 {

--- a/src/operators/arrange/writer.rs
+++ b/src/operators/arrange/writer.rs
@@ -8,7 +8,6 @@ use std::cell::RefCell;
 
 use timely::progress::{Antichain, Timestamp};
 
-use crate::lattice::Lattice;
 use crate::trace::{Trace, Batch, BatchReader};
 use crate::trace::wrappers::rc::TraceBox;
 
@@ -23,7 +22,6 @@ use super::TraceReplayInstruction;
 pub struct TraceWriter<Tr>
 where
     Tr: Trace,
-    Tr::Time: Lattice+Timestamp+Ord+Clone+std::fmt::Debug+'static,
     Tr::Batch: Batch,
 {
     /// Current upper limit.
@@ -37,7 +35,6 @@ where
 impl<Tr> TraceWriter<Tr>
 where
     Tr: Trace,
-    Tr::Time: Lattice+Timestamp+Ord+Clone+std::fmt::Debug+'static,
     Tr::Batch: Batch,
 {
     /// Creates a new `TraceWriter`.
@@ -107,7 +104,6 @@ where
 impl<Tr> Drop for TraceWriter<Tr>
 where
     Tr: Trace,
-    Tr::Time: Lattice+Timestamp+Ord+Clone+std::fmt::Debug+'static,
     Tr::Batch: Batch,
 {
     fn drop(&mut self) {

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -50,12 +50,13 @@ where G::Timestamp: TotalOrder+Lattice+Ord {
     }
 }
 
-impl<G: Scope, T1> CountTotal<G, T1::KeyOwned, T1::Diff> for Arranged<G, T1>
+impl<G, T1> CountTotal<G, T1::KeyOwned, T1::Diff> for Arranged<G, T1>
 where
-    G::Timestamp: TotalOrder+Lattice+Ord,
-    T1: for<'a> TraceReader<Val<'a>=&'a (), Time=G::Timestamp>+Clone+'static,
+    G: Scope<Timestamp=T1::Time>,
+    T1: for<'a> TraceReader<Val<'a>=&'a ()>+Clone+'static,
     T1::KeyOwned: ExchangeData,
-    T1::Diff: ExchangeData+Semigroup,
+    T1::Time: TotalOrder,
+    T1::Diff: ExchangeData,
 {
     fn count_total_core<R2: Semigroup + From<i8>>(&self) -> Collection<G, (T1::KeyOwned, T1::Diff), R2> {
 

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -92,12 +92,13 @@ where G::Timestamp: TotalOrder+Lattice+Ord {
     }
 }
 
-impl<G: Scope, K, T1> ThresholdTotal<G, K, T1::Diff> for Arranged<G, T1>
+impl<G, K, T1> ThresholdTotal<G, K, T1::Diff> for Arranged<G, T1>
 where
-    G::Timestamp: TotalOrder+Lattice+Ord,
-    T1: for<'a> TraceReader<Key<'a>=&'a K, Val<'a>=&'a (), Time=G::Timestamp>+Clone+'static,
+    G: Scope<Timestamp=T1::Time>,
+    T1: for<'a> TraceReader<Key<'a>=&'a K, Val<'a>=&'a ()>+Clone+'static,
     K: ExchangeData,
-    T1::Diff: ExchangeData+Semigroup,
+    T1::Time: TotalOrder,
+    T1::Diff: ExchangeData,
 {
     fn threshold_semigroup<R2, F>(&self, mut thresh: F) -> Collection<G, K, R2>
     where

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -5,6 +5,10 @@
 //! both because it allows navigation on multiple levels (key and val), but also because it
 //! supports efficient seeking (via the `seek_key` and `seek_val` methods).
 
+use timely::progress::Timestamp;
+use crate::difference::Semigroup;
+use crate::lattice::Lattice;
+
 pub mod cursor_list;
 
 pub use self::cursor_list::CursorList;
@@ -63,9 +67,9 @@ pub trait Cursor {
     /// Owned version of the above.
     type ValOwned: Ord + Clone;
     /// Timestamps associated with updates
-    type Time;
+    type Time: Timestamp + Lattice + Ord + Clone;
     /// Associated update.
-    type Diff: ?Sized;
+    type Diff: Semigroup + ?Sized;
 
     /// Storage required by the cursor.
     type Storage;
@@ -117,11 +121,7 @@ pub trait Cursor {
     fn rewind_vals(&mut self, storage: &Self::Storage);
 
     /// Rewinds the cursor and outputs its contents to a Vec
-    fn to_vec(&mut self, storage: &Self::Storage) -> Vec<((Self::KeyOwned, Self::ValOwned), Vec<(Self::Time, Self::Diff)>)>
-    where
-        Self::Time: Clone,
-        Self::Diff: Clone,
-    {
+    fn to_vec(&mut self, storage: &Self::Storage) -> Vec<((Self::KeyOwned, Self::ValOwned), Vec<(Self::Time, Self::Diff)>)> {
         let mut out = Vec::new();
         self.rewind_keys(storage);
         self.rewind_vals(storage);

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -108,9 +108,6 @@ impl<U: Update> Layout for Vector<U>
 where
     U::Key: 'static,
     U::Val: 'static,
-// where
-//     U::Key: ToOwned<Owned = U::Key> + Sized + Clone + 'static,
-//     U::Val: ToOwned<Owned = U::Val> + Sized + Clone + 'static,
 {
     type Target = U;
     type KeyContainer = Vec<U::Key>;

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -17,7 +17,8 @@ use timely::progress::{Antichain, frontier::AntichainRef};
 use timely::progress::Timestamp;
 
 use crate::trace::cursor::MyTrait;
-
+use crate::difference::Semigroup;
+use crate::lattice::Lattice;
 // use ::difference::Semigroup;
 pub use self::cursor::Cursor;
 pub use self::description::Description;
@@ -56,9 +57,9 @@ pub trait TraceReader {
     /// Owned version of the above.
     type ValOwned: Ord + Clone;
     /// Timestamps associated with updates
-    type Time;
+    type Time: Timestamp + Lattice + Ord + Clone;
     /// Associated update.
-    type Diff;
+    type Diff: Semigroup;
 
     /// The type of an immutable collection of updates.
     type Batch: for<'a> BatchReader<Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, ValOwned = Self::ValOwned, Time = Self::Time, Diff = Self::Diff>+Clone+'static;
@@ -172,10 +173,7 @@ pub trait TraceReader {
     ///
     ///
     #[inline]
-    fn read_upper(&mut self, target: &mut Antichain<Self::Time>)
-    where
-        Self::Time: Timestamp,
-    {
+    fn read_upper(&mut self, target: &mut Antichain<Self::Time>) {
         target.clear();
         target.insert(<Self::Time as timely::progress::Timestamp>::minimum());
         self.map_batches(|batch| {
@@ -189,10 +187,7 @@ pub trait TraceReader {
     /// contents of `upper` will advance `upper` to `batch.upper`.
     /// Taken across all batches, this should advance `upper` across
     /// empty batch regions.
-    fn advance_upper(&mut self, upper: &mut Antichain<Self::Time>)
-    where
-        Self::Time: Timestamp,
-    {
+    fn advance_upper(&mut self, upper: &mut Antichain<Self::Time>) {
         self.map_batches(|batch| {
             if batch.is_empty() && batch.lower() == upper {
                 upper.clone_from(batch.upper());
@@ -270,9 +265,9 @@ where
     /// Owned version of the above.
     type ValOwned: Ord + Clone;
     /// Timestamps associated with updates
-    type Time: Timestamp;
+    type Time: Timestamp + Lattice + Ord + Clone;
     /// Associated update.
-    type Diff;
+    type Diff: Semigroup;
 
     /// The type used to enumerate the batch's contents.
     type Cursor: for<'a> Cursor<Storage=Self, Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, ValOwned = Self::ValOwned, Time = Self::Time, Diff = Self::Diff>;

--- a/src/trace/wrappers/enter.rs
+++ b/src/trace/wrappers/enter.rs
@@ -2,7 +2,6 @@
 
 // use timely::progress::nested::product::Product;
 use timely::progress::timestamp::Refines;
-use timely::progress::Timestamp;
 use timely::progress::{Antichain, frontier::AntichainRef};
 
 use crate::lattice::Lattice;
@@ -10,19 +9,13 @@ use crate::trace::{TraceReader, BatchReader, Description};
 use crate::trace::cursor::Cursor;
 
 /// Wrapper to provide trace to nested scope.
-pub struct TraceEnter<Tr, TInner>
-where
-    Tr: TraceReader,
-{
+pub struct TraceEnter<Tr: TraceReader, TInner> {
     trace: Tr,
     stash1: Antichain<Tr::Time>,
     stash2: Antichain<TInner>,
 }
 
-impl<Tr,TInner> Clone for TraceEnter<Tr, TInner>
-where
-    Tr: TraceReader+Clone,
-{
+impl<Tr: TraceReader + Clone, TInner> Clone for TraceEnter<Tr, TInner> {
     fn clone(&self) -> Self {
         TraceEnter {
             trace: self.trace.clone(),
@@ -36,8 +29,6 @@ impl<Tr, TInner> TraceReader for TraceEnter<Tr, TInner>
 where
     Tr: TraceReader,
     Tr::Batch: Clone,
-    Tr::Time: Timestamp,
-    Tr::Diff: 'static,
     TInner: Refines<Tr::Time>+Lattice,
 {
     type Key<'a> = Tr::Key<'a>;
@@ -99,7 +90,6 @@ where
 impl<Tr, TInner> TraceEnter<Tr, TInner>
 where
     Tr: TraceReader,
-    Tr::Time: Timestamp,
     TInner: Refines<Tr::Time>+Lattice,
 {
     /// Makes a new trace wrapper
@@ -123,7 +113,6 @@ pub struct BatchEnter<B, TInner> {
 impl<B, TInner> BatchReader for BatchEnter<B, TInner>
 where
     B: BatchReader,
-    B::Time: Timestamp,
     TInner: Refines<B::Time>+Lattice,
 {
     type Key<'a> = B::Key<'a>;
@@ -145,7 +134,6 @@ where
 impl<B, TInner> BatchEnter<B, TInner>
 where
     B: BatchReader,
-    B::Time: Timestamp,
     TInner: Refines<B::Time>+Lattice,
 {
     /// Makes a new batch wrapper
@@ -179,7 +167,6 @@ impl<C, TInner> CursorEnter<C, TInner> {
 impl<C, TInner> Cursor for CursorEnter<C, TInner>
 where
     C: Cursor,
-    C::Time: Timestamp,
     TInner: Refines<C::Time>+Lattice,
 {
     type Key<'a> = C::Key<'a>;
@@ -233,7 +220,6 @@ impl<C, TInner> BatchCursorEnter<C, TInner> {
 
 impl<TInner, C: Cursor> Cursor for BatchCursorEnter<C, TInner>
 where
-    C::Time: Timestamp,
     TInner: Refines<C::Time>+Lattice,
 {
     type Key<'a> = C::Key<'a>;

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -1,7 +1,6 @@
 //! Wrappers to provide trace access to nested scopes.
 
 use timely::progress::timestamp::Refines;
-use timely::progress::Timestamp;
 use timely::progress::{Antichain, frontier::AntichainRef};
 
 use crate::lattice::Lattice;
@@ -16,10 +15,7 @@ use crate::trace::cursor::Cursor;
 /// and which will be applied to compaction frontiers as they are communicated
 /// back to the wrapped traces. A better explanation is pending, and until that
 /// happens use this construct at your own peril!
-pub struct TraceEnter<Tr, TInner, F, G>
-where
-    Tr: TraceReader,
-{
+pub struct TraceEnter<Tr: TraceReader, TInner, F, G> {
     trace: Tr,
     stash1: Antichain<Tr::Time>,
     stash2: Antichain<TInner>,
@@ -48,9 +44,7 @@ impl<Tr, TInner, F, G> TraceReader for TraceEnter<Tr, TInner, F, G>
 where
     Tr: TraceReader,
     Tr::Batch: Clone,
-    Tr::Time: Timestamp,
     TInner: Refines<Tr::Time>+Lattice,
-    Tr::Diff: 'static,
     F: 'static,
     F: FnMut(Tr::Key<'_>, Tr::Val<'_>, &Tr::Time)->TInner+Clone,
     G: FnMut(&TInner)->Tr::Time+Clone+'static,
@@ -115,7 +109,6 @@ where
 impl<Tr, TInner, F, G> TraceEnter<Tr, TInner, F, G>
 where
     Tr: TraceReader,
-    Tr::Time: Timestamp,
     TInner: Refines<Tr::Time>+Lattice,
 {
     /// Makes a new trace wrapper
@@ -142,7 +135,6 @@ pub struct BatchEnter<B, TInner, F> {
 impl<B, TInner, F> BatchReader for BatchEnter<B, TInner, F>
 where
     B: BatchReader,
-    B::Time: Timestamp,
     TInner: Refines<B::Time>+Lattice,
     F: FnMut(B::Key<'_>, <B::Cursor as Cursor>::Val<'_>, &B::Time)->TInner+Clone,
 {
@@ -165,7 +157,6 @@ where
 impl<B, TInner, F> BatchEnter<B, TInner, F>
 where
     B: BatchReader,
-    B::Time: Timestamp,
     TInner: Refines<B::Time>+Lattice,
 {
     /// Makes a new batch wrapper
@@ -202,7 +193,6 @@ impl<C, TInner, F> CursorEnter<C, TInner, F> {
 impl<C, TInner, F> Cursor for CursorEnter<C, TInner, F>
 where
     C: Cursor,
-    C::Time: Timestamp,
     TInner: Refines<C::Time>+Lattice,
     F: FnMut(C::Key<'_>, C::Val<'_>, &C::Time)->TInner,
 {
@@ -262,7 +252,6 @@ impl<C, TInner, F> BatchCursorEnter<C, TInner, F> {
 
 impl<TInner, C: Cursor, F> Cursor for BatchCursorEnter<C, TInner, F>
 where
-    C::Time: Timestamp,
     TInner: Refines<C::Time>+Lattice,
     F: FnMut(C::Key<'_>, C::Val<'_>, &C::Time)->TInner,
 {

--- a/src/trace/wrappers/filter.rs
+++ b/src/trace/wrappers/filter.rs
@@ -1,6 +1,5 @@
 //! Wrapper for filtered trace.
 
-use timely::progress::Timestamp;
 use timely::progress::frontier::AntichainRef;
 
 use crate::trace::{TraceReader, BatchReader, Description};
@@ -29,8 +28,6 @@ impl<Tr, F> TraceReader for TraceFilter<Tr, F>
 where
     Tr: TraceReader,
     Tr::Batch: Clone,
-    Tr::Time: Timestamp,
-    Tr::Diff: 'static,
     F: FnMut(Tr::Key<'_>, Tr::Val<'_>)->bool+Clone+'static,
 {
     type Key<'a> = Tr::Key<'a>;
@@ -64,7 +61,6 @@ where
 impl<Tr, F> TraceFilter<Tr, F>
 where
     Tr: TraceReader,
-    Tr::Time: Timestamp,
 {
     /// Makes a new trace wrapper
     pub fn make_from(trace: Tr, logic: F) -> Self {
@@ -86,7 +82,6 @@ pub struct BatchFilter<B, F> {
 impl<B, F> BatchReader for BatchFilter<B, F>
 where
     B: BatchReader,
-    B::Time: Timestamp,
     F: FnMut(B::Key<'_>, B::Val<'_>)->bool+Clone+'static
 {
     type Key<'a> = B::Key<'a>;
@@ -108,7 +103,6 @@ where
 impl<B, F> BatchFilter<B, F>
 where
     B: BatchReader,
-    B::Time: Timestamp,
 {
     /// Makes a new batch wrapper
     pub fn make_from(batch: B, logic: F) -> Self {
@@ -137,7 +131,6 @@ impl<C, F> CursorFilter<C, F> {
 impl<C, F> Cursor for CursorFilter<C, F>
 where
     C: Cursor,
-    C::Time: Timestamp,
     F: FnMut(C::Key<'_>, C::Val<'_>)->bool+'static
 {
     type Key<'a> = C::Key<'a>;
@@ -193,7 +186,6 @@ impl<C, F> BatchCursorFilter<C, F> {
 
 impl<C: Cursor, F> Cursor for BatchCursorFilter<C, F>
 where
-    C::Time: Timestamp,
     F: FnMut(C::Key<'_>, C::Val<'_>)->bool+'static,
 {
     type Key<'a> = C::Key<'a>;


### PR DESCRIPTION
This PR introduces constraints to the `Time` and `Diff` associated types for `TraceReader`, `BatchReader`, and `Cursor`. They look roughly like so:
```
    /// Timestamps associated with updates
    type Time: Timestamp + Lattice + Ord + Clone;
    /// Associated update.
    type Diff: Semigroup;
```
These constraints are .. pretty much the rule now, in use of differential dataflow. Users end up needing to write `where` clauses with much of this information, even though no one expects to use these things in the absence of these properties.