### PR TITLE
Remove unused `BatchContainer` methods

### DIFF
--- a/src/trace/implementations/huffman_container.rs
+++ b/src/trace/implementations/huffman_container.rs
@@ -84,11 +84,6 @@ where
             }
         }
     }
-    fn copy_slice(&mut self, slice: &[Vec<B>]) {
-        for item in slice {
-            self.copy_push(item);
-        }
-    }
     fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
         for index in start .. end {
             self.copy(other.index(index));

--- a/src/trace/implementations/huffman_container.rs
+++ b/src/trace/implementations/huffman_container.rs
@@ -103,8 +103,6 @@ where
             stats: Default::default(),
         }
     }
-    fn reserve(&mut self, _additional: usize) {
-    }
     fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
 
         if cont1.len() > 0 { cont1.print(); }

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -306,10 +306,6 @@ impl BatchContainer for OffsetList {
         Self::with_capacity(size)
     }
 
-    fn reserve(&mut self, _additional: usize) {
-        // Nop
-    }
-
     fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
         Self::with_capacity(cont1.len() + cont2.len())
     }
@@ -353,8 +349,6 @@ pub mod containers {
         fn copy_range(&mut self, other: &Self, start: usize, end: usize);
         /// Creates a new container with sufficient capacity.
         fn with_capacity(size: usize) -> Self;
-        /// Reserves additional capacity.
-        fn reserve(&mut self, additional: usize);
         /// Creates a new container with sufficient capacity.
         fn merge_capacity(cont1: &Self, cont2: &Self) -> Self;
 
@@ -441,9 +435,6 @@ pub mod containers {
         fn with_capacity(size: usize) -> Self {
             Vec::with_capacity(size)
         }
-        fn reserve(&mut self, additional: usize) {
-            self.reserve(additional);
-        }
         fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
             Vec::with_capacity(cont1.len() + cont2.len())
         }
@@ -485,8 +476,6 @@ pub mod containers {
         }
         fn with_capacity(size: usize) -> Self {
             Self::with_capacity(size)
-        }
-        fn reserve(&mut self, _additional: usize) {
         }
         fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
             let mut new = Self::default();
@@ -550,8 +539,6 @@ pub mod containers {
                 offsets,
                 inner: Vec::with_capacity(size),
             }
-        }
-        fn reserve(&mut self, _additional: usize) {
         }
         fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
             let mut offsets = Vec::with_capacity(cont1.inner.len() + cont2.inner.len() + 1);
@@ -682,8 +669,6 @@ pub mod containers {
                 offsets,
                 inner: Vec::with_capacity(size),
             }
-        }
-        fn reserve(&mut self, _additional: usize) {
         }
         fn merge_capacity(cont1: &Self, cont2: &Self) -> Self {
             let mut offsets = Vec::with_capacity(cont1.inner.len() + cont2.inner.len() + 1);

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -290,12 +290,6 @@ impl BatchContainer for OffsetList {
         self.push(item.0);
     }
 
-    fn copy_slice(&mut self, slice: &[Self::PushItem]) {
-        for index in slice {
-            self.push(*index);
-        }
-    }
-
     fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
         for offset in start..end {
             self.push(other.index(offset));
@@ -343,8 +337,6 @@ pub mod containers {
         fn copy_push(&mut self, item: &Self::PushItem);
         /// Inserts a borrowed item.
         fn copy(&mut self, item: Self::ReadItem<'_>);
-        /// Extends from a slice of items.
-        fn copy_slice(&mut self, slice: &[Self::PushItem]);
         /// Extends from a range of items in another`Self`.
         fn copy_range(&mut self, other: &Self, start: usize, end: usize);
         /// Creates a new container with sufficient capacity.
@@ -426,9 +418,6 @@ pub mod containers {
         fn copy(&mut self, item: &T) {
             self.push(item.clone());
         }
-        fn copy_slice(&mut self, slice: &[T]) {
-            self.extend_from_slice(slice);
-        }
         fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
             self.extend_from_slice(&other[start .. end]);
         }
@@ -460,12 +449,6 @@ pub mod containers {
         }
         fn copy(&mut self, item: &T) {
             self.copy(item);
-        }
-        fn copy_slice(&mut self, slice: &[Self::PushItem]) {
-            self.reserve_items(slice.iter());
-            for item in slice.iter() {
-                self.copy(item);
-            }
         }
         fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
             let slice = &other[start .. end];
@@ -521,11 +504,6 @@ pub mod containers {
                 self.inner.copy(x);
             }
             self.offsets.push(self.inner.len());
-        }
-        fn copy_slice(&mut self, slice: &[Vec<B>]) {
-            for item in slice {
-                self.copy(item);
-            }
         }
         fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
             for index in start .. end {
@@ -627,8 +605,6 @@ pub mod containers {
             }
         }
     }
-    
-    
 
     impl<B> BatchContainer for SliceContainer2<B>
     where
@@ -650,11 +626,6 @@ pub mod containers {
                 self.inner.copy(x);
             }
             self.offsets.push(self.inner.len());
-        }
-        fn copy_slice(&mut self, slice: &[Vec<B>]) {
-            for item in slice {
-                self.copy_push(item);
-            }
         }
         fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
             for index in start .. end {


### PR DESCRIPTION
This PR removes `BatchContainer::{reserve, copy_slice}`, which were unused. They could plausibly be re-introduced, but the majority of implementations were no-ops. The only non-trivial instance was `Vec<T>`'s implementation of `copy_slice`, but you could get the same `extend_from_slice` behavior from its `copy_range` implementation.