### PR TITLE
Canonicalize `PointStamp` representation

### DIFF
--- a/src/dynamic/mod.rs
+++ b/src/dynamic/mod.rs
@@ -52,9 +52,11 @@ where
                 data.swap(&mut vector);
                 let mut new_time = cap.time().clone();
                 new_time.inner.vector.truncate(level - 1);
+                new_time.inner.enforce();
                 let new_cap = cap.delayed(&new_time);
                 for (_data, time, _diff) in vector.iter_mut() {
                     time.inner.vector.truncate(level - 1);
+                    time.inner.enforce();
                 }
                 output.session(&new_cap).give_vec(&mut vector);
             });

--- a/src/dynamic/mod.rs
+++ b/src/dynamic/mod.rs
@@ -51,12 +51,14 @@ where
             input.for_each(|cap, data| {
                 data.swap(&mut vector);
                 let mut new_time = cap.time().clone();
-                new_time.inner.vector.truncate(level - 1);
-                new_time.inner.enforce();
+                let mut vec = std::mem::take(&mut new_time.inner).into_vec();
+                vec.truncate(level - 1);
+                new_time.inner = PointStamp::new(vec);
                 let new_cap = cap.delayed(&new_time);
                 for (_data, time, _diff) in vector.iter_mut() {
-                    time.inner.vector.truncate(level - 1);
-                    time.inner.enforce();
+                    let mut vec = std::mem::take(&mut time.inner).into_vec();
+                    vec.truncate(level - 1);
+                    time.inner = PointStamp::new(vec);
                 }
                 output.session(&new_cap).give_vec(&mut vector);
             });

--- a/src/dynamic/pointstamp.rs
+++ b/src/dynamic/pointstamp.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// A sequence of timestamps, partially ordered by the product order.
 ///
 /// Sequences of different lengths are compared as if extended indefinitely by `T::minimum()`.
-/// Sequences are not guaranteed to be "minimal", and may end with `T::minimum()` entries.
+/// Sequences are guaranteed to be "minimal", and may not end with `T::minimum()` entries.
 #[derive(
     Hash, Default, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize, Abomonation,
 )]
@@ -26,10 +26,20 @@ pub struct PointStamp<T> {
     pub vector: Vec<T>,
 }
 
-impl<T> PointStamp<T> {
+impl<T: Timestamp> PointStamp<T> {
     /// Create a new sequence.
+    ///
+    /// This method will modify `vector` to ensure it does not end with `T::minimum()`.
     pub fn new(vector: Vec<T>) -> Self {
-        PointStamp { vector }
+        let mut result = PointStamp { vector };
+        result.enforce();
+        result
+    }
+    /// Enforces that `self` not end with `T::minimum()` by popping elements until it is true.
+    pub fn enforce(&mut self) {
+        while self.vector.last() == Some(&T::minimum()) {
+            self.vector.pop();
+        }
     }
 }
 
@@ -109,7 +119,7 @@ impl<T: Timestamp> PathSummary<PointStamp<T>> for PointStampSummary<T::Summary> 
             vector.push(action.results_in(&T::minimum())?);
         }
 
-        Some(PointStamp { vector })
+        Some(PointStamp::new(vector))
     }
     fn followed_by(&self, other: &Self) -> Option<Self> {
         // The output `retain` will be the minimum of the two inputs.
@@ -166,7 +176,7 @@ impl<TS: PartialOrder> PartialOrder for PointStampSummary<TS> {
 use timely::progress::Timestamp;
 impl<T: Timestamp> Timestamp for PointStamp<T> {
     fn minimum() -> Self {
-        Self { vector: Vec::new() }
+        Self::new(Vec::new())
     }
     type Summary = PointStampSummary<T::Summary>;
 }
@@ -190,7 +200,7 @@ impl<T: Lattice + Timestamp + Clone> Lattice for PointStamp<T> {
         for time in &other.vector[min_len..] {
             vector.push(time.clone());
         }
-        Self { vector }
+        Self::new(vector)
     }
     fn meet(&self, other: &Self) -> Self {
         let min_len = ::std::cmp::min(self.vector.len(), other.vector.len());
@@ -200,7 +210,7 @@ impl<T: Lattice + Timestamp + Clone> Lattice for PointStamp<T> {
             vector.push(self.vector[index].meet(&other.vector[index]));
         }
         // Remaining coordinates are `T::minimum()` in one input, and so in the output.
-        Self { vector }
+        Self::new(vector)
     }
 }
 

--- a/src/dynamic/pointstamp.rs
+++ b/src/dynamic/pointstamp.rs
@@ -23,23 +23,26 @@ use serde::{Deserialize, Serialize};
 )]
 pub struct PointStamp<T> {
     /// A sequence of timestamps corresponding to timestamps in a sequence of nested scopes.
-    pub vector: Vec<T>,
+    vector: Vec<T>,
 }
 
 impl<T: Timestamp> PointStamp<T> {
     /// Create a new sequence.
     ///
     /// This method will modify `vector` to ensure it does not end with `T::minimum()`.
-    pub fn new(vector: Vec<T>) -> Self {
-        let mut result = PointStamp { vector };
-        result.enforce();
-        result
-    }
-    /// Enforces that `self` not end with `T::minimum()` by popping elements until it is true.
-    pub fn enforce(&mut self) {
-        while self.vector.last() == Some(&T::minimum()) {
-            self.vector.pop();
+    pub fn new(mut vector: Vec<T>) -> Self {
+        while vector.last() == Some(&T::minimum()) {
+            vector.pop();
         }
+        PointStamp { vector }
+    }
+    /// Returns the wrapped vector.
+    ///
+    /// This method is the support way to mutate the contents of `self`, by extracting 
+    /// the vector and then re-introducting it with `PointStamp::new` to re-establish 
+    /// the invariant that the vector not end with `T::minimum`.
+    pub fn into_vec(self) -> Vec<T> {
+        self.vector
     }
 }
 


### PR DESCRIPTION
`PointStamp` represents an infinite vector of `T` elements, extending a maintained `vector` with `T::minimum()`. This allows multiple representations of the same vector when the `vector` is allowed to end with `T::minimum()`, which was documented as acceptable. However, it does mean that e.g. the derived `Eq` implementation, among others, would report two logically identical pointstamps as different, and imo the position that there can be multiple unequal representations of the same state is untenable.

This PR removes that ability, short of direct manipulation by users, through an `enforce` method that is called by a constructor, and use of that constructor whenever we mint new `PointStamp`s. Demonstration uses that manipulate `vector` directly are followed by `enforce` calls.

We could go further and make the field private, and prevent direct manipulation and require clones (or at least `into_vec` and `from_vec` patterns). That might increase confidence even further.

cc: @antiguru 