### PR TITLE
Change parameters to exert_logic from iterator to slice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,43 @@
-name: test
-
-on: [push, pull_request]
+name: "Test Suite"
+on:
+  push:
+  pull_request:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os:
+          - ubuntu
+          - macos
+          - windows
+        toolchain:
+          - stable
+          - 1.72
+    name: cargo test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     steps:
-    - uses: actions/checkout@v3
-    - run: rustup update 1.70 --no-self-update && rustup default 1.70
-    - run: cargo build --workspace
-    - name: test mdBook
-      # rustdoc doesn't build dependencies, so it needs to run after `cargo build`,
-      # but its dependency search gets confused if there are multiple copies of any
-      # dependency in target/debug/deps, so it needs to run before `cargo test` et al.
-      # clutter target/debug/deps with multiple copies of things.
-      run: for file in $(find mdbook -name '*.md' | sort); do rustdoc --test $file  -L ./target/debug/deps; done
-    - run: cargo test --workspace
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - name: Cargo test
+        run: cargo test
+
+  # Check formatting with rustfmt
+  mdbook:
+    name: test mdBook
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Ensure rustfmt is installed and setup problem matcher
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+      - run: cargo build
+      - name: test mdBook
+        # rustdoc doesn't build dependencies, so it needs to run after `cargo build`,
+        # but its dependency search gets confused if there are multiple copies of any
+        # dependency in target/debug/deps, so it needs to run before `cargo test` et al.
+        # clutter target/debug/deps with multiple copies of things.
+        run: for file in $(find mdbook -name '*.md' | sort); do rustdoc --test $file  -L ./target/debug/deps; done

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,8 +135,8 @@ pub fn configure(config: &mut timely::WorkerConfig, options: &Config) {
             std::sync::Arc::new(move |batches| {
                 let mut non_empty = 0;
                 for (_index, count, length) in batches {
-                    if count > 1 { return Some(effort as usize); }
-                    if length > 0 { non_empty += 1; }
+                    if *count > 1 { return Some(effort as usize); }
+                    if *length > 0 { non_empty += 1; }
                     if non_empty > 1 { return Some(effort as usize); }
                 }
                 None

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -27,7 +27,7 @@ pub use self::cursor::Cursor;
 pub use self::description::Description;
 
 /// A type used to express how much effort a trace should exert even in the absence of updates.
-pub type ExertionLogic = std::sync::Arc<dyn for<'a> Fn(Box<dyn Iterator<Item=(usize, usize, usize)>+'a>)->Option<usize>+Send+Sync>;
+pub type ExertionLogic = std::sync::Arc<dyn for<'a> Fn(&'a [(usize, usize, usize)])->Option<usize>+Send+Sync>;
 
 //     The traces and batch and cursors want the flexibility to appear as if they manage certain types of keys and
 //     values and such, while perhaps using other representations, I'm thinking mostly of wrappers around the keys


### PR DESCRIPTION
This avoid the intermediate allocation for every invocation of exert_logic to create a boxed iterator. Instead, pass a slice that contains the same information previously revealed by the iterator. At the same time, wrap the logic in an option to only invoke it if it is set.

This is the source of around 80% of all allocations in mostly idle Materialize clusters. The lower two large blocks are related to this in the following image.

![image](https://github.com/TimelyDataflow/differential-dataflow/assets/582946/7b47c705-c8ee-4719-8ac8-cc4c75985c7f)
