### PR TITLE
DNM: A merge batcher that gracefully handles non-ready data

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -51,7 +51,7 @@ fn main() {
 
         // Load up graph data. Round-robin among workers.
         for _ in 0 .. (edges / peers) + if index < (edges % peers) { 1 } else { 0 } {
-            input.update((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1)
+            input.update_at((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1_000_000, 1)
         }
 
         input.advance_to(1);

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,3 +1,4 @@
+use std::time::Instant;
 use rand::{Rng, SeedableRng, StdRng};
 
 use differential_dataflow::input::Input;
@@ -52,6 +53,7 @@ fn main() {
         // Load up graph data. Round-robin among workers.
         for _ in 0 .. (edges / peers) + if index < (edges % peers) { 1 } else { 0 } {
             input.update_at((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1_000_000, 1)
+            // input.update((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1)
         }
 
         input.advance_to(1);
@@ -67,7 +69,8 @@ fn main() {
             if index == 0 {
 
                 let mut next = batch;
-                for round in 1 .. {
+                let start_time = Instant::now();
+                for round in 1 .. 1_000_100 {
 
                     input.advance_to(round);
                     input.update((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), 1);
@@ -83,6 +86,7 @@ fn main() {
                         next += batch;
                     }
                 }
+                println!("rounds finished after {:?}", start_time.elapsed());
             }
         }
     }).unwrap();


### PR DESCRIPTION
This PR shows how to implement a merge batcher that is smart about reconsidering data that's in advance of the current frontier. It does the following things:
1. It extracts ready data from chains instead of merging all chains and then extracting data from the last remaining chain.
2. It separates canonicalization from the extraction operation, so it can be reused for inserts and extracts.
3. It memorizes a frontier per block, which allows for efficient frontier testing: If the extraction (upper) frontier is not less or equal to the block frontier, do not touch the block.

This should have the potential to reduce the amount of work for outstanding data from $O(n)$ where $n$ is the number of records in the merge batcher to $O(n/1024)$ by considering only the block itself, but not the data it contains.

I am sorry for the formatting noise which originates from copying this code from DD to Mz and back again :/