### PR TITLE
Name `Handle`'s container type

### DIFF
--- a/src/operators/iterate.rs
+++ b/src/operators/iterate.rs
@@ -154,7 +154,7 @@ impl<G: Scope, D: Ord+Data+Debug, R: Semigroup> Iterate<G, D, R> for G {
 pub struct Variable<G: Scope, D: Data, R: Abelian>
 where G::Timestamp: Lattice {
     collection: Collection<G, D, R>,
-    feedback: Handle<G, (D, G::Timestamp, R)>,
+    feedback: Handle<G, Vec<(D, G::Timestamp, R)>>,
     source: Option<Collection<G, D, R>>,
     step: <G::Timestamp as Timestamp>::Summary,
 }
@@ -225,7 +225,7 @@ impl<G: Scope, D: Data, R: Abelian> Deref for Variable<G, D, R> where G::Timesta
 pub struct SemigroupVariable<G: Scope, D: Data, R: Semigroup>
 where G::Timestamp: Lattice {
     collection: Collection<G, D, R>,
-    feedback: Handle<G, (D, G::Timestamp, R)>,
+    feedback: Handle<G, Vec<(D, G::Timestamp, R)>>,
     step: <G::Timestamp as Timestamp>::Summary,
 }
 


### PR DESCRIPTION
With TD updates, `Handle` now wants to know its container type rather than the elements that would be in a `Vec<_>` container. For the moment, continue to only handle these containers, but name them as now required.