### PR TITLE
Prevent `enter_at` from using `enter_at`

### DIFF
--- a/examples/accumulate.rs
+++ b/examples/accumulate.rs
@@ -16,7 +16,14 @@ fn main() {
 
         let mut input = worker.dataflow::<(), _, _>(|scope| {
             let (input, data) = scope.new_collection::<_, isize>();
-            data.consolidate();
+
+            use timely::dataflow::Scope;
+            scope.iterative::<u32,_,_>(|inner| {
+                data.enter_at(inner, |_| 0)
+                    .consolidate()
+                    .leave()
+            });
+
             input
         });
 

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -322,20 +322,16 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     ///     data.assert_eq(&result);
     /// });
     /// ```
-    pub fn enter_at<'a, T, F>(&self, child: &Iterative<'a, G, T>, initial: F) -> Collection<Iterative<'a, G, T>, D, R>
+    pub fn enter_at<'a, T, F>(&self, child: &Iterative<'a, G, T>, mut initial: F) -> Collection<Iterative<'a, G, T>, D, R>
     where
         T: Timestamp+Hash,
         F: FnMut(&D) -> T + Clone + 'static,
         G::Timestamp: Hash,
     {
-
-        let mut initial1 = initial.clone();
-        let mut initial2 = initial.clone();
-
         self.inner
-            .enter_at(child, move |x| initial1(&x.0))
+            .enter(child)
             .map(move |(data, time, diff)| {
-                let new_time = Product::new(time, initial2(&data));
+                let new_time = Product::new(time, initial(&data));
                 (data, new_time, diff)
             })
             .as_collection()


### PR DESCRIPTION
`Collection::enter_at` used timely's `enter_at` trait and method, but .. it is bad. Its implementation is roughly `enter().delay()`, where `delay()` does us the favor of queueing all input data until the delayed-to timestamp has passed. In a nested timestamp context, this means until the outer timestamp has fully passed, because it is not until then that we might not see `(time, 0)` in the loop.

So that means that users of `enter_at` introduce a stalling operator that prevents updates from passing through linear operators (`map`, `filter`) and from landing in a consolidating merge batcher where they will be compactly maintained.

The PR just deletes the use of `enter_at`, replacing it with `enter`. This seems harmless, as the `(_, time, _)` field of the triple is still updated, and it is only the introduced capability that is not delayed, but .. nothing good will happen until the outer timestamp clears anyhow, and the update's `time` needs to be consulted by the receiving operator in any case.

The PR also updates the `accumulate.rs` example to use a nested scope and `enter_at`, which without the fix grows without bound, and with the fix stays at about 2MB or so.