### PR TITLE
Merge batcher generic over containers

### DIFF
--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -464,7 +464,7 @@ where
 
             input.for_each(|cap, data| {
                 capabilities.insert(cap.retain());
-                batcher.push_batch(data);
+                batcher.push_container(data);
             });
 
             // The frontier may have advanced by multiple elements, which is an issue because

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -284,7 +284,7 @@ where
         F: Fn(T2::Val<'_>) -> V + 'static,
         T2::Diff: Abelian,
         T2::Batch: Batch,
-        T2::Builder: Builder<Input = ((T1::KeyOwned, V), T2::Time, T2::Diff)>,
+        T2::Builder: Builder<Input = Vec<((T1::KeyOwned, V), T2::Time, T2::Diff)>>,
         L: FnMut(T1::Key<'_>, &[(T1::Val<'_>, T1::Diff)], &mut Vec<(V, T2::Diff)>)+'static,
     {
         self.reduce_core::<_,V,F,T2>(name, from, move |key, input, output, change| {
@@ -303,7 +303,7 @@ where
         V: Data,
         F: Fn(T2::Val<'_>) -> V + 'static,
         T2::Batch: Batch,
-        T2::Builder: Builder<Input = ((T1::KeyOwned,V), T2::Time, T2::Diff)>,
+        T2::Builder: Builder<Input = Vec<((T1::KeyOwned,V), T2::Time, T2::Diff)>>,
         L: FnMut(T1::Key<'_>, &[(T1::Val<'_>, T1::Diff)], &mut Vec<(V, T2::Diff)>, &mut Vec<(V, T2::Diff)>)+'static,
     {
         use crate::operators::reduce::reduce_trace;

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -284,7 +284,7 @@ where
         F: Fn(T2::Val<'_>) -> V + 'static,
         T2::Diff: Abelian,
         T2::Batch: Batch,
-        T2::Builder: Builder<Input = Vec<((T1::KeyOwned, V), T2::Time, T2::Diff)>>,
+        T2::Builder: Builder<Input = ((T1::KeyOwned, V), T2::Time, T2::Diff)>,
         L: FnMut(T1::Key<'_>, &[(T1::Val<'_>, T1::Diff)], &mut Vec<(V, T2::Diff)>)+'static,
     {
         self.reduce_core::<_,V,F,T2>(name, from, move |key, input, output, change| {
@@ -303,7 +303,7 @@ where
         V: Data,
         F: Fn(T2::Val<'_>) -> V + 'static,
         T2::Batch: Batch,
-        T2::Builder: Builder<Input = Vec<((T1::KeyOwned,V), T2::Time, T2::Diff)>>,
+        T2::Builder: Builder<Input = ((T1::KeyOwned,V), T2::Time, T2::Diff)>,
         L: FnMut(T1::Key<'_>, &[(T1::Val<'_>, T1::Diff)], &mut Vec<(V, T2::Diff)>, &mut Vec<(V, T2::Diff)>)+'static,
     {
         use crate::operators::reduce::reduce_trace;

--- a/src/operators/arrange/upsert.rs
+++ b/src/operators/arrange/upsert.rs
@@ -138,7 +138,7 @@ where
     F: Fn(Tr::Val<'_>) -> V + 'static,
     Tr::Time: TotalOrder+ExchangeData,
     Tr::Batch: Batch,
-    Tr::Builder: Builder<Input = ((Tr::KeyOwned, V), Tr::Time, Tr::Diff)>,
+    Tr::Builder: Builder<Input = Vec<((Tr::KeyOwned, V), Tr::Time, Tr::Diff)>>,
 {
     let mut reader: Option<TraceAgent<Tr>> = None;
 
@@ -241,7 +241,6 @@ where
                                 // Prepare a cursor to the existing arrangement, and a batch builder for
                                 // new stuff that we add.
                                 let (mut trace_cursor, trace_storage) = reader_local.cursor();
-                                let mut builder = Tr::Builder::new();
                                 for (key, mut list) in to_process.drain(..) {
 
                                     use trace::cursor::MyTrait;
@@ -282,11 +281,10 @@ where
                                     }
                                     // Must insert updates in (key, val, time) order.
                                     updates.sort();
-                                    for update in updates.drain(..) {
-                                        builder.push(update);
-                                    }
                                 }
-                                let batch = builder.done(prev_frontier.clone(), upper.clone(), Antichain::from_elem(G::Timestamp::minimum()));
+                                let mut batches = vec![std::mem::take(&mut updates)];
+                                let batch = Tr::Builder::from_batches(&mut batches, prev_frontier.borrow(), upper.borrow(), Antichain::from_elem(G::Timestamp::minimum()).borrow());
+                                updates = batches.into_iter().next().unwrap_or_default();
                                 prev_frontier.clone_from(&upper);
 
                                 // Communicate `batch` to the arrangement and the stream.

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -252,7 +252,7 @@ pub trait ReduceCore<G: Scope, K: ToOwned + ?Sized, V: Data, R: Semigroup> where
             F: Fn(T2::Val<'_>) -> V + 'static,
             T2::Diff: Abelian,
             T2::Batch: Batch,
-            T2::Builder: Builder<Input = Vec<((K::Owned, V), T2::Time, T2::Diff)>>,
+            T2::Builder: Builder<Input = ((K::Owned, V), T2::Time, T2::Diff)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(V, T2::Diff)>)+'static,
         {
             self.reduce_core::<_,_,T2>(name, from, move |key, input, output, change| {
@@ -274,7 +274,7 @@ pub trait ReduceCore<G: Scope, K: ToOwned + ?Sized, V: Data, R: Semigroup> where
             T2: for<'a> Trace<Key<'a>=&'a K, Time=G::Timestamp>+'static,
             F: Fn(T2::Val<'_>) -> V + 'static,
             T2::Batch: Batch,
-            T2::Builder: Builder<Input = Vec<((K::Owned, V), T2::Time, T2::Diff)>>,
+            T2::Builder: Builder<Input = ((K::Owned, V), T2::Time, T2::Diff)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(V,T2::Diff)>, &mut Vec<(V, T2::Diff)>)+'static,
             ;
 }
@@ -293,7 +293,7 @@ where
             F: Fn(T2::Val<'_>) -> V + 'static,
             T2: for<'a> Trace<Key<'a>=&'a K, Time=G::Timestamp>+'static,
             T2::Batch: Batch,
-            T2::Builder: Builder<Input = Vec<((K, V), T2::Time, T2::Diff)>>,
+            T2::Builder: Builder<Input = ((K, V), T2::Time, T2::Diff)>,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(V,T2::Diff)>, &mut Vec<(V, T2::Diff)>)+'static,
     {
         self.arrange_by_key_named(&format!("Arrange: {}", name))
@@ -312,7 +312,7 @@ where
     V: Data,
     F: Fn(T2::Val<'_>) -> V + 'static,
     T2::Batch: Batch,
-    T2::Builder: Builder<Input = Vec<((T1::KeyOwned, V), T2::Time, T2::Diff)>>,
+    T2::Builder: Builder<Input = ((T1::KeyOwned, V), T2::Time, T2::Diff)>,
     L: FnMut(T1::Key<'_>, &[(T1::Val<'_>, T1::Diff)], &mut Vec<(V,T2::Diff)>, &mut Vec<(V, T2::Diff)>)+'static,
 {
     let mut result_trace = None;
@@ -529,20 +529,9 @@ where
                             //       (ii) that the buffers are time-ordered, and (iii) that the builders accept
                             //       arbitrarily ordered times.
                             for index in 0 .. buffers.len() {
-                                // TODO: This doesn't reuse allocations for `update`.
-                                let mut update = Vec::with_capacity(1024);
                                 buffers[index].1.sort_by(|x,y| x.0.cmp(&y.0));
                                 for (val, time, diff) in buffers[index].1.drain(..) {
-                                    update.push(((key.into_owned(), val), time, diff));
-                                    if update.len() == update.capacity() {
-                                        let mut chain = vec![update];
-                                        builders[index].push_batches(&mut chain);
-                                        update = chain.pop().unwrap_or_else(|| Vec::with_capacity(1024));
-                                        update.clear();
-                                    }
-                                }
-                                if !update.is_empty() {
-                                    builders[index].push_batches(&mut vec![update]);
+                                    builders[index].push(((key.into_owned(), val), time, diff));
                                 }
                             }
                         }

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -1,169 +1,220 @@
 //! A general purpose `Batcher` implementation based on radix sort.
 
 use std::collections::VecDeque;
+use std::marker::PhantomData;
 
 use timely::communication::message::RefOrMut;
+use timely::{Container, PartialOrder};
 use timely::logging::WorkerIdentifier;
 use timely::logging_core::Logger;
 use timely::progress::{frontier::Antichain, Timestamp};
+use timely::progress::frontier::AntichainRef;
 
+use crate::consolidation::consolidate_updates;
 use crate::difference::Semigroup;
 use crate::logging::{BatcherEvent, DifferentialEvent};
 use crate::trace::{Batcher, Builder};
 
 /// Creates batches from unordered tuples.
-pub struct MergeBatcher<K, V, T, D> {
-    sorter: MergeSorter<(K, V), T, D>,
+pub struct MergeBatcher<M, T>
+where
+    M: Merger,
+{
+    /// each power-of-two length list of allocations. Do not push/pop directly but use the corresponding functions.
+    queue: Vec<Vec<M::Batch>>,
+    /// Stash of empty batches
+    stash: Vec<M::Batch>,
+    /// Thing to accept data, merge chains, and talk to the builder.
+    merger: M,
+    /// Logger for size accounting.
+    logger: Option<Logger<DifferentialEvent, WorkerIdentifier>>,
+    /// Timely operator ID.
+    operator_id: usize,
+    /// Current lower frontier, we sealed up to here.
     lower: Antichain<T>,
+    /// The lower-bound frontier of the data, after the last call to seal.
     frontier: Antichain<T>,
 }
 
-impl<K, V, T, D> Batcher for MergeBatcher<K, V, T, D>
+impl<M, T> Batcher for MergeBatcher<M, T>
 where
-    K: Ord + Clone,
-    V: Ord + Clone,
+    M: Merger<Time=T>,
     T: Timestamp,
-    D: Semigroup,
 {
-    type Input = Vec<((K,V),T,D)>;
-    type Output = ((K,V),T,D);
+    type Input = M::Input;
+    type Output = M::Batch;
     type Time = T;
 
     fn new(logger: Option<Logger<DifferentialEvent, WorkerIdentifier>>, operator_id: usize) -> Self {
-        MergeBatcher {
-            sorter: MergeSorter::new(logger, operator_id),
+        Self {
+            logger,
+            operator_id,
+            merger: M::default(),
+            queue: Vec::new(),
+            stash: Vec::new(),
             frontier: Antichain::new(),
             lower: Antichain::from_elem(T::minimum()),
         }
     }
 
-    #[inline(never)]
-    fn push_batch(&mut self, batch: RefOrMut<Self::Input>) {
-        // `batch` is either a shared reference or an owned allocations.
-        match batch {
-            RefOrMut::Ref(reference) => {
-                // This is a moment at which we could capture the allocations backing
-                // `batch` into a different form of region, rather than just  cloning.
-                let mut owned: Vec<_> = self.sorter.empty();
-                owned.clone_from(reference);
-                self.sorter.push(&mut owned);
-            },
-            RefOrMut::Mut(reference) => {
-                self.sorter.push(reference);
-            }
-        }
+    fn push_batch(&mut self, batch: RefOrMut<M::Input>) {
+        let batch = self.merger.accept(batch, &mut self.stash);
+        self.insert_chain(batch);
     }
 
     // Sealing a batch means finding those updates with times not greater or equal to any time
     // in `upper`. All updates must have time greater or equal to the previously used `upper`,
     // which we call `lower`, by assumption that after sealing a batcher we receive no more
     // updates with times not greater or equal to `upper`.
-    #[inline(never)]
     fn seal<B: Builder<Input=Self::Output, Time=Self::Time>>(&mut self, upper: Antichain<T>) -> B::Output {
+        // Finish
+        let batch = self.merger.finish(&mut self.stash);
+        if !batch.is_empty() {
+            self.queue_push(batch);
+        }
 
-        let mut merged = Vec::new();
-        self.sorter.finish_into(&mut merged);
+        // Merge all remaining chains into a single chain.
+        while self.queue.len() > 1 {
+            let list1 = self.queue_pop().unwrap();
+            let list2 = self.queue_pop().unwrap();
+            let merged = self.merge_by(list1, list2);
+            self.queue_push(merged);
+        }
+        let merged = self.queue_pop().unwrap_or_default();
 
-        // Determine the number of distinct keys, values, and updates,
-        // and form a builder pre-sized for these numbers.
-        let mut builder = {
-            let mut keys = 0;
-            let mut vals = 0;
-            let mut upds = 0;
-            let mut prev_keyval = None;
-            for buffer in merged.iter() {
-                for ((key, val), time, _) in buffer.iter() {
-                    if !upper.less_equal(time) {
-                        if let Some((p_key, p_val)) = prev_keyval {
-                            if p_key != key {
-                                keys += 1;
-                                vals += 1;
-                            }
-                            else if p_val != val {
-                                vals += 1;
-                            }
-                            upds += 1;
-                        } else {
-                            keys += 1;
-                            vals += 1;
-                            upds += 1;
-                        }
-                        prev_keyval = Some((key, val));
-                    }
-                }
-            }
-            B::with_capacity(keys, vals, upds)
-        };
-
+        // Extract readied data.
         let mut kept = Vec::new();
-        let mut keep = Vec::new();
-
+        let mut readied = Vec::new();
         self.frontier.clear();
 
-        // TODO: Re-use buffer, rather than dropping.
-        for mut buffer in merged.drain(..) {
-            for ((key, val), time, diff) in buffer.drain(..) {
-                if upper.less_equal(&time) {
-                    self.frontier.insert(time.clone());
-                    if keep.len() == keep.capacity() && !keep.is_empty() {
-                        kept.push(keep);
-                        keep = self.sorter.empty();
-                    }
-                    keep.push(((key, val), time, diff));
-                }
-                else {
-                    builder.push(((key, val), time, diff));
-                }
-            }
-            // Recycling buffer.
-            self.sorter.push(&mut buffer);
-        }
+        self.merger.extract(merged, upper.borrow(), &mut self.frontier, &mut readied, &mut kept, &mut self.stash);
 
-        // Finish the kept data.
-        if !keep.is_empty() {
-            kept.push(keep);
-        }
         if !kept.is_empty() {
-            self.sorter.push_list(kept);
+            self.queue_push(kept);
         }
 
-        // Drain buffers (fast reclaimation).
-        // TODO : This isn't obviously the best policy, but "safe" wrt footprint.
-        //        In particular, if we are reading serialized input data, we may
-        //        prefer to keep these buffers around to re-fill, if possible.
-        let mut buffer = Vec::new();
-        self.sorter.push(&mut buffer);
-        // We recycle buffers with allocations (capacity, and not zero-sized).
-        while buffer.capacity() > 0 && std::mem::size_of::<((K,V),T,D)>() > 0 {
-            buffer = Vec::new();
-            self.sorter.push(&mut buffer);
-        }
+        self.stash.clear();
 
-        let seal = builder.done(self.lower.clone(), upper.clone(), Antichain::from_elem(T::minimum()));
+        let seal = B::from_batches(&mut readied, self.lower.borrow(), upper.borrow(), Antichain::from_elem(T::minimum()).borrow());
         self.lower = upper;
         seal
     }
 
     /// The frontier of elements remaining after the most recent call to `self.seal`.
-    fn frontier(&mut self) -> timely::progress::frontier::AntichainRef<T> {
+    #[inline]
+    fn frontier(&mut self) -> AntichainRef<T> {
         self.frontier.borrow()
     }
 }
+impl<M, T> MergeBatcher<M, T>
+where
+    M: Merger
+{
+    fn insert_chain(&mut self, chain: Vec<<M as Merger>::Batch>) {
+        if !chain.is_empty() {
+            self.queue_push(chain);
+            while self.queue.len() > 1 && (self.queue[self.queue.len() - 1].len() >= self.queue[self.queue.len() - 2].len() / 2) {
+                let list1 = self.queue_pop().unwrap();
+                let list2 = self.queue_pop().unwrap();
+                let merged = self.merge_by(list1, list2);
+                self.queue_push(merged);
+            }
+        }
+    }
 
-struct MergeSorter<D, T, R> {
-    /// each power-of-two length list of allocations. Do not push/pop directly but use the corresponding functions.
-    queue: Vec<Vec<Vec<(D, T, R)>>>,
-    stash: Vec<Vec<(D, T, R)>>,
-    logger: Option<Logger<DifferentialEvent, WorkerIdentifier>>,
-    operator_id: usize,
+    // merges two sorted input lists into one sorted output list.
+    fn merge_by(&mut self, list1: Vec<M::Batch>, list2: Vec<M::Batch>) -> Vec<M::Batch> {
+        self.account(list1.iter().chain(list2.iter()).map(M::account), -1);
+
+        // TODO: `list1` and `list2` get dropped; would be better to reuse?
+        let mut output = Vec::with_capacity(list1.len() + list2.len());
+        self.merger.merge(list1, list2, &mut output, &mut self.stash);
+
+        output
+    }
+
+    /// Pop a batch from `self.queue` and account size changes.
+    #[inline]
+    fn queue_pop(&mut self) -> Option<Vec<M::Batch>> {
+        let batch = self.queue.pop();
+        self.account(batch.iter().flatten().map(M::account), -1);
+        batch
+    }
+
+    /// Push a batch to `self.queue` and account size changes.
+    #[inline]
+    fn queue_push(&mut self, batch: Vec<M::Batch>) {
+        self.account(batch.iter().map(M::account), 1);
+        self.queue.push(batch);
+    }
+
+    /// Account size changes. Only performs work if a logger exists.
+    ///
+    /// Calculate the size based on the [`TimelyStack`]s passed along, with each attribute
+    /// multiplied by `diff`. Usually, one wants to pass 1 or -1 as the diff.
+    #[inline]
+    fn account<I: IntoIterator<Item=(usize, usize, usize, usize)>>(&self, items: I, diff: isize) {
+        if let Some(logger) = &self.logger {
+            let (mut records, mut size, mut capacity, mut allocations) = (0isize, 0isize, 0isize, 0isize);
+            for (records_, size_, capacity_, allocations_) in items {
+                records = records.saturating_add_unsigned(records_);
+                size = size.saturating_add_unsigned(size_);
+                capacity = capacity.saturating_add_unsigned(capacity_);
+                allocations = allocations.saturating_add_unsigned(allocations_);
+            }
+            logger.log(BatcherEvent {
+                operator: self.operator_id,
+                records_diff: records * diff,
+                size_diff: size * diff,
+                capacity_diff: capacity * diff,
+                allocations_diff: allocations * diff,
+            })
+        }
+    }
 }
 
-impl<D: Ord, T: Ord, R: Semigroup> MergeSorter<D, T, R> {
+impl<M: Merger, T> Drop for MergeBatcher<M, T> {
+    fn drop(&mut self) {
+        while self.queue_pop().is_some() { }
+    }
+}
 
+/// A trait to describe interesting moments in a merge batcher.
+pub trait Merger: Default {
+    /// The type of update containers received from inputs.
+    type Input;
+    /// The internal representation of batches of data.
+    type Batch: Container;
+    /// The type of time in frontiers to extract updates.
+    type Time;
+    /// Accept a fresh batch of input data.
+    fn accept(&mut self, batch: RefOrMut<Self::Input>, stash: &mut Vec<Self::Batch>) -> Vec<Self::Batch>;
+    /// Finish processing any stashed data.
+    fn finish(&mut self, stash: &mut Vec<Self::Batch>) -> Vec<Self::Batch>;
+    /// Merge chains into an output chain.
+    fn merge(&mut self, list1: Vec<Self::Batch>, list2: Vec<Self::Batch>, output: &mut Vec<Self::Batch>, stash: &mut Vec<Self::Batch>);
+    /// Extract ready updates based on the `upper` frontier.
+    fn extract(&mut self, merged: Vec<Self::Batch>, upper: AntichainRef<Self::Time>, frontier: &mut Antichain<Self::Time>, readied: &mut Vec<Self::Batch>, keep: &mut Vec<Self::Batch>, stash: &mut Vec<Self::Batch>);
+
+    /// Account size and allocation changes. Returns a tuple of (records, size, capacity, allocations).
+    fn account(batch: &Self::Batch) -> (usize, usize, usize, usize);
+}
+
+/// A merger that knows how to accept and maintain chains of vectors.
+pub struct VecMerger<T> {
+    _marker: PhantomData<T>,
+}
+
+impl<T> Default for VecMerger<T> {
+    fn default() -> Self {
+        Self {_marker: PhantomData}
+    }
+}
+
+impl<T> VecMerger<T> {
     const BUFFER_SIZE_BYTES: usize = 1 << 13;
-
-    fn buffer_size() -> usize {
-        let size = ::std::mem::size_of::<(D, T, R)>();
+    fn preferred_buffer_size(&self) -> usize {
+        let size = ::std::mem::size_of::<T>();
         if size == 0 {
             Self::BUFFER_SIZE_BYTES
         } else if size <= Self::BUFFER_SIZE_BYTES {
@@ -173,87 +224,64 @@ impl<D: Ord, T: Ord, R: Semigroup> MergeSorter<D, T, R> {
         }
     }
 
+    /// Helper to get pre-sized vector from the stash.
     #[inline]
-    fn new(logger: Option<Logger<DifferentialEvent, WorkerIdentifier>>, operator_id: usize) -> Self {
-        Self {
-            logger,
-            operator_id,
-            queue: Vec::new(),
-            stash: Vec::new(),
-        }
+    fn empty(&self, stash: &mut Vec<Vec<T>>) -> Vec<T> {
+        stash.pop().unwrap_or_else(|| Vec::with_capacity(self.preferred_buffer_size()))
     }
 
+    /// Helper to return a batch to the stash.
     #[inline]
-    pub fn empty(&mut self) -> Vec<(D, T, R)> {
-        self.stash.pop().unwrap_or_else(|| Vec::with_capacity(Self::buffer_size()))
-    }
-
-    #[inline]
-    pub fn push(&mut self, batch: &mut Vec<(D, T, R)>) {
-        // TODO: Reason about possible unbounded stash growth. How to / should we return them?
-        // TODO: Reason about mis-sized vectors, from deserialized data; should probably drop.
-        let mut batch = if self.stash.len() > 2 {
-            ::std::mem::replace(batch, self.stash.pop().unwrap())
+    fn recycle(&self, mut batch: Vec<T>, stash: &mut Vec<Vec<T>>) {
+        // TODO: Should we limit the size of `stash`?
+        if batch.capacity() == self.preferred_buffer_size() /*&& stash.len() < 2*/ {
+            batch.clear();
+            stash.push(batch);
         }
-        else {
-            ::std::mem::take(batch)
-        };
+    }
+}
 
-        if !batch.is_empty() {
-            crate::consolidation::consolidate_updates(&mut batch);
-            self.account([batch.len()], 1);
-            self.queue_push(vec![batch]);
-            while self.queue.len() > 1 && (self.queue[self.queue.len()-1].len() >= self.queue[self.queue.len()-2].len() / 2) {
-                let list1 = self.queue_pop().unwrap();
-                let list2 = self.queue_pop().unwrap();
-                let merged = self.merge_by(list1, list2);
-                self.queue_push(merged);
+impl<D: Ord+Clone+'static, T: Ord + PartialOrder + Clone+'static,R: Semigroup+'static> Merger for VecMerger<(D,T,R)> {
+    type Time = T;
+    type Input = Vec<(D,T,R)>;
+    type Batch = Vec<(D,T,R)>;
+
+    fn accept(&mut self, batch: RefOrMut<Vec<(D,T,R)>>, stash: &mut Vec<Self::Batch>) -> Vec<Vec<(D, T, R)>> {
+        // `batch` is either a shared reference or an owned allocations.
+        let mut owned = match batch {
+            RefOrMut::Ref(vec) => {
+                let mut owned = self.empty(stash);
+                owned.clone_from(vec);
+                owned
             }
+            RefOrMut::Mut(vec) => std::mem::take(vec)
+        };
+        consolidate_updates(&mut owned);
+        if owned.capacity() == self.preferred_buffer_size() {
+            vec![owned]
+        } else {
+            let mut chain = Vec::with_capacity((owned.len() + self.preferred_buffer_size() - 1) / self.preferred_buffer_size());
+            let mut iter = owned.drain(..).peekable();
+            while iter.peek().is_some() {
+                let mut batch = self.empty(stash);
+                batch.extend((&mut iter).take(self.preferred_buffer_size()));
+                chain.push(batch);
+            }
+            chain
         }
     }
 
-    // This is awkward, because it isn't a power-of-two length any more, and we don't want
-    // to break it down to be so.
-    pub fn push_list(&mut self, list: Vec<Vec<(D, T, R)>>) {
-        while self.queue.len() > 1 && self.queue[self.queue.len()-1].len() < list.len() {
-            let list1 = self.queue_pop().unwrap();
-            let list2 = self.queue_pop().unwrap();
-            let merged = self.merge_by(list1, list2);
-            self.queue_push(merged);
-        }
-        self.queue_push(list);
+    fn finish(&mut self, _stash: &mut Vec<Vec<(D, T, R)>>) -> Vec<Vec<(D, T, R)>> {
+        vec![]
     }
 
-    #[inline(never)]
-    pub fn finish_into(&mut self, target: &mut Vec<Vec<(D, T, R)>>) {
-        while self.queue.len() > 1 {
-            let list1 = self.queue_pop().unwrap();
-            let list2 = self.queue_pop().unwrap();
-            let merged = self.merge_by(list1, list2);
-            self.queue_push(merged);
-        }
-
-        if let Some(mut last) = self.queue_pop() {
-            ::std::mem::swap(&mut last, target);
-        }
-    }
-
-    // merges two sorted input lists into one sorted output list.
-    #[inline(never)]
-    fn merge_by(&mut self, list1: Vec<Vec<(D, T, R)>>, list2: Vec<Vec<(D, T, R)>>) -> Vec<Vec<(D, T, R)>> {
-        self.account(list1.iter().chain(list2.iter()).map(Vec::len), -1);
-
-        use std::cmp::Ordering;
-
-        // TODO: `list1` and `list2` get dropped; would be better to reuse?
-        let mut output = Vec::with_capacity(list1.len() + list2.len());
-        let mut result = self.empty();
-
+    fn merge(&mut self, list1: Vec<Vec<(D, T, R)>>, list2: Vec<Vec<(D, T, R)>>, output: &mut Vec<Vec<(D, T, R)>>, stash: &mut Vec<Vec<(D, T, R)>>) {
         let mut list1 = list1.into_iter();
         let mut list2 = list2.into_iter();
-
         let mut head1 = VecDeque::from(list1.next().unwrap_or_default());
         let mut head2 = VecDeque::from(list2.next().unwrap_or_default());
+
+        let mut result = self.empty(stash);
 
         // while we have valid data in each input, merge.
         while !head1.is_empty() && !head2.is_empty() {
@@ -265,6 +293,7 @@ impl<D: Ord, T: Ord, R: Semigroup> MergeSorter<D, T, R> {
                     let y = head2.front().unwrap();
                     (&x.0, &x.1).cmp(&(&y.0, &y.1))
                 };
+                use std::cmp::Ordering;
                 match cmp {
                     Ordering::Less    => result.push(head1.pop_front().unwrap()),
                     Ordering::Greater => result.push(head2.pop_front().unwrap()),
@@ -281,81 +310,74 @@ impl<D: Ord, T: Ord, R: Semigroup> MergeSorter<D, T, R> {
 
             if result.capacity() == result.len() {
                 output.push(result);
-                result = self.empty();
+                result = self.empty(stash);
             }
 
             if head1.is_empty() {
                 let done1 = Vec::from(head1);
-                if done1.capacity() == Self::buffer_size() { self.stash.push(done1); }
+                self.recycle(done1, stash);
                 head1 = VecDeque::from(list1.next().unwrap_or_default());
             }
             if head2.is_empty() {
                 let done2 = Vec::from(head2);
-                if done2.capacity() == Self::buffer_size() { self.stash.push(done2); }
+                self.recycle(done2, stash);
                 head2 = VecDeque::from(list2.next().unwrap_or_default());
             }
         }
 
         if !result.is_empty() { output.push(result); }
-        else if result.capacity() > 0 { self.stash.push(result); }
+        else { self.recycle(result, stash); }
 
         if !head1.is_empty() {
-            let mut result = self.empty();
+            let mut result = self.empty(stash);
             for item1 in head1 { result.push(item1); }
             output.push(result);
         }
         output.extend(list1);
 
         if !head2.is_empty() {
-            let mut result = self.empty();
+            let mut result = self.empty(stash);
             for item2 in head2 { result.push(item2); }
             output.push(result);
         }
         output.extend(list2);
-
-        output
-    }
-}
-
-impl<D, T, R> MergeSorter<D, T, R> {
-    /// Pop a batch from `self.queue` and account size changes.
-    #[inline]
-    fn queue_pop(&mut self) -> Option<Vec<Vec<(D, T, R)>>> {
-        let batch = self.queue.pop();
-        self.account(batch.iter().flatten().map(Vec::len), -1);
-        batch
     }
 
-    /// Push a batch to `self.queue` and account size changes.
-    #[inline]
-    fn queue_push(&mut self, batch: Vec<Vec<(D, T, R)>>) {
-        self.account(batch.iter().map(Vec::len), 1);
-        self.queue.push(batch);
-    }
+    fn extract(&mut self, merged: Vec<Vec<(D, T, R)>>, upper: AntichainRef<Self::Time>, frontier: &mut Antichain<Self::Time>, readied: &mut Vec<Vec<(D, T, R)>>, kept: &mut Vec<Vec<(D, T, R)>>, stash: &mut Vec<Vec<(D, T, R)>>) {
+        let mut keep = self.empty(stash);
+        let mut ready = self.empty(stash);
 
-    /// Account size changes. Only performs work if a logger exists.
-    ///
-    /// Calculate the size based on the [`TimelyStack`]s passed along, with each attribute
-    /// multiplied by `diff`. Usually, one wants to pass 1 or -1 as the diff.
-    fn account<I: IntoIterator<Item=usize>>(&self, items: I, diff: isize) {
-        if let Some(logger) = &self.logger {
-            let mut records= 0isize;
-            for len in items {
-                records = records.saturating_add_unsigned(len);
+        for mut buffer in merged {
+            for (data, time, diff) in buffer.drain(..) {
+                if upper.less_equal(&time) {
+                    frontier.insert(time.clone());
+                    if keep.len() == keep.capacity() && !keep.is_empty() {
+                        kept.push(keep);
+                        keep = self.empty(stash);
+                    }
+                    keep.push((data, time, diff));
+                }
+                else {
+                    if ready.len() == ready.capacity() && !ready.is_empty() {
+                        readied.push(ready);
+                        ready = self.empty(stash);
+                    }
+                    ready.push((data, time, diff));
+                }
             }
-            logger.log(BatcherEvent {
-                operator: self.operator_id,
-                records_diff: records * diff,
-                size_diff: 0,
-                capacity_diff: 0,
-                allocations_diff: 0,
-            })
+            // Recycling buffer.
+            self.recycle(buffer, stash);
+        }
+        // Finish the kept data.
+        if !keep.is_empty() {
+            kept.push(keep);
+        }
+        if !ready.is_empty() {
+            readied.push(ready);
         }
     }
-}
 
-impl<D, T, R> Drop for MergeSorter<D, T, R> {
-    fn drop(&mut self) {
-        while self.queue_pop().is_some() { }
+    fn account(batch: &Self::Batch) -> (usize, usize, usize, usize) {
+        (batch.len(), 0, 0, 0)
     }
 }

--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -239,7 +239,7 @@ impl<T> Default for VecMerger<T> {
 }
 
 impl<T> VecMerger<T> {
-    const BUFFER_SIZE_BYTES: usize = 1 << 13;
+    const BUFFER_SIZE_BYTES: usize = 8 << 10;
     fn chunk_capacity(&self) -> usize {
         let size = ::std::mem::size_of::<T>();
         if size == 0 {
@@ -300,7 +300,7 @@ where
         let form_chain = |this: &mut Self, final_chain: &mut Vec<Self::Chunk>, stash: &mut _| {
             if this.pending.len() == this.pending.capacity() {
                 consolidate_updates(&mut this.pending);
-                if this.pending.len() > this.pending.capacity() / 2 {
+                if this.pending.len() >= this.chunk_capacity() {
                     let mut chain = Vec::default();
                     while this.pending.len() > this.chunk_capacity() {
                         let mut chunk = this.empty(stash);

--- a/src/trace/implementations/merge_batcher_col.rs
+++ b/src/trace/implementations/merge_batcher_col.rs
@@ -4,18 +4,14 @@ use std::cmp::Ordering;
 use timely::{Container, Data, PartialOrder};
 use timely::communication::message::RefOrMut;
 use timely::container::columnation::{Columnation, TimelyStack};
-use timely::logging::WorkerIdentifier;
-use timely::logging_core::Logger;
-use timely::progress::{frontier::Antichain, Timestamp};
-use timely::progress::frontier::AntichainRef;
+use timely::progress::frontier::{Antichain, AntichainRef};
 use crate::consolidation::consolidate_updates;
 
 use crate::difference::Semigroup;
-use crate::logging::{BatcherEvent, DifferentialEvent};
-use crate::trace::{Batcher, Builder};
+use crate::trace::Builder;
 use crate::trace::implementations::merge_batcher::Merger;
 
-/// TODO
+/// A merger for timely stacks
 pub struct ColumnationMerger<T> {
     pending: Vec<T>,
 }
@@ -61,15 +57,17 @@ impl<T: Columnation> ColumnationMerger<T> {
     }
 }
 
-impl<D, T,R> Merger for ColumnationMerger<(D, T, R)>
+impl<K, V, T,R> Merger for ColumnationMerger<((K,V), T, R)>
 where
-    D: Columnation + Ord + Data,
+    K: Columnation + Ord + Data,
+    V: Columnation + Ord + Data,
     T: Columnation + Ord + PartialOrder + Data,
     R: Columnation + Semigroup + 'static,
 {
     type Time = T;
-    type Input = Vec<(D,T,R)>;
-    type Batch = TimelyStack<(D,T,R)>;
+    type Input = Vec<((K,V),T,R)>;
+    type Batch = TimelyStack<((K,V),T,R)>;
+    type Output = ((K,V),T,R);
 
     fn accept(&mut self, batch: RefOrMut<Self::Input>, stash: &mut Vec<Self::Batch>) -> Vec<Self::Batch> {
         // `batch` is either a shared reference or an owned allocations.
@@ -217,84 +215,13 @@ where
         }
     }
 
-    fn account(batch: &Self::Batch) -> (usize, usize, usize, usize) {
-        let (mut size, mut capacity, mut allocations) = (0, 0, 0);
-        let cb = |siz, cap| {
-            size += siz;
-            capacity += cap;
-            allocations += 1;
-        };
-        batch.heap_size(cb);
-        (batch.len(), size, capacity, allocations)
-    }
-}
-
-
-/// Creates batches from unordered tuples.
-pub struct ColumnatedMergeBatcher<K, V, T, D>
-where
-    K: Columnation + 'static,
-    V: Columnation + 'static,
-    T: Columnation + 'static,
-    D: Columnation + 'static,
-{
-    sorter: MergeSorterColumnation<(K, V), T, D>,
-    lower: Antichain<T>,
-    frontier: Antichain<T>,
-}
-
-impl<K, V, T, D> Batcher for ColumnatedMergeBatcher<K, V, T, D>
-where
-    K: Columnation + Ord + Clone + 'static,
-    V: Columnation + Ord + Clone + 'static,
-    T: Columnation + Timestamp + 'static,
-    D: Columnation + Semigroup + 'static,
-{
-    type Input = Vec<((K,V),T,D)>;
-    type Output = Vec<((K,V),T,D)>;
-    type Time = T;
-
-    fn new(logger: Option<Logger<DifferentialEvent, WorkerIdentifier>>, operator_id: usize) -> Self {
-        ColumnatedMergeBatcher {
-            sorter: MergeSorterColumnation::new(logger, operator_id),
-            frontier: Antichain::new(),
-            lower: Antichain::from_elem(<T as Timestamp>::minimum()),
-        }
-    }
-
-    #[inline]
-    fn push_batch(&mut self, batch: RefOrMut<Self::Input>) {
-        // `batch` is either a shared reference or an owned allocations.
-        match batch {
-            RefOrMut::Ref(reference) => {
-                // This is a moment at which we could capture the allocations backing
-                // `batch` into a different form of region, rather than just  cloning.
-                self.sorter.push(&mut reference.clone());
-            },
-            RefOrMut::Mut(reference) => {
-                self.sorter.push(reference);
-            }
-        }
-    }
-
-    // Sealing a batch means finding those updates with times not greater or equal to any time
-    // in `upper`. All updates must have time greater or equal to the previously used `upper`,
-    // which we call `lower`, by assumption that after sealing a batcher we receive no more
-    // updates with times not greater or equal to `upper`.
-    #[inline]
-    fn seal<B: Builder<Input=Self::Output, Time=Self::Time>>(&mut self, upper: Antichain<T>) -> B::Output {
-
-        let mut merged = Default::default();
-        self.sorter.finish_into(&mut merged);
-
-        // Determine the number of distinct keys, values, and updates,
-        // and form a builder pre-sized for these numbers.
+    fn seal<B: Builder<Input=Self::Output, Time=Self::Time>>(chain: &mut Vec<Self::Batch>, lower: AntichainRef<Self::Time>, upper: AntichainRef<Self::Time>, since: AntichainRef<Self::Time>) -> B::Output {
         let mut builder = {
             let mut keys = 0;
             let mut vals = 0;
             let mut upds = 0;
             let mut prev_keyval = None;
-            for buffer in merged.iter() {
+            for buffer in chain.iter() {
                 for ((key, val), time, _) in buffer.iter() {
                     if !upper.less_equal(time) {
                         if let Some((p_key, p_val)) = prev_keyval {
@@ -318,71 +245,25 @@ where
             B::with_capacity(keys, vals, upds)
         };
 
-        let mut kept = Vec::new();
-        let mut keep = TimelyStack::default();
-        let mut readied = Vec::new();
-        let mut ready = Vec::default();
-
-        self.frontier.clear();
-
-        for buffer in merged.drain(..) {
-            for datum @ ((_key, _val), time, _diff) in &buffer[..] {
-                if upper.less_equal(time) {
-                    self.frontier.insert(time.clone());
-                    if keep.is_empty() {
-                        if keep.capacity() != MergeSorterColumnation::<(K, V), T, D>::buffer_size() {
-                            keep = self.sorter.empty();
-                        }
-                    } else if keep.len() == keep.capacity() {
-                        kept.push(keep);
-                        keep = self.sorter.empty();
-                    }
-                    keep.copy(datum);
-                }
-                else {
-                    if ready.is_empty() {
-                        if ready.capacity() != MergeSorterColumnation::<(K, V), T, D>::buffer_size() {
-                            ready = Vec::with_capacity(MergeSorterColumnation::<(K, V), T, D>::buffer_size());
-                        }
-                    } else if ready.len() == ready.capacity() {
-                        readied.push(ready);
-                        ready = Vec::with_capacity(MergeSorterColumnation::<(K, V), T, D>::buffer_size());
-                    }
-                    ready.push(datum.clone());
-                }
-            }
-            // Recycling buffer.
-            self.sorter.recycle(buffer);
+        for datum in chain.iter().map(|ts| ts.iter()).flatten() {
+            builder.copy(datum);
         }
 
-        // Finish the kept data.
-        if !keep.is_empty() {
-            kept.push(keep);
-        }
-        if !kept.is_empty() {
-            self.sorter.push_list(kept);
-        }
-
-        if !ready.is_empty() {
-            readied.push(ready);
-        }
-        if !readied.is_empty() {
-            builder.push_batches(&mut readied);
-        }
-
-        // Drain buffers (fast reclamation).
-        self.sorter.clear_stash();
-
-        let seal = builder.done(self.lower.clone(), upper.clone(), Antichain::from_elem(T::minimum()));
-        self.lower = upper;
-        seal
+        builder.done(lower.to_owned(), upper.to_owned(), since.to_owned())
     }
 
-    /// The frontier of elements remaining after the most recent call to `self.seal`.
-    fn frontier(&mut self) -> timely::progress::frontier::AntichainRef<T> {
-        self.frontier.borrow()
+    fn account(batch: &Self::Batch) -> (usize, usize, usize, usize) {
+        let (mut size, mut capacity, mut allocations) = (0, 0, 0);
+        let cb = |siz, cap| {
+            size += siz;
+            capacity += cap;
+            allocations += 1;
+        };
+        batch.heap_size(cb);
+        (batch.len(), size, capacity, allocations)
     }
 }
+
 
 struct TimelyStackQueue<T: Columnation> {
     list: TimelyStack<T>,
@@ -422,254 +303,5 @@ impl<T: Columnation> TimelyStackQueue<T> {
     /// Return an iterator over the remaining elements.
     fn iter(&self) -> impl Iterator<Item=&T> + Clone + ExactSizeIterator {
         self.list[self.head..].iter()
-    }
-}
-
-struct MergeSorterColumnation<D: Columnation + 'static, T: Columnation + 'static, R: Columnation + 'static> {
-    /// each power-of-two length list of allocations. Do not push/pop directly but use the corresponding functions.
-    queue: Vec<Vec<TimelyStack<(D, T, R)>>>,
-    stash: Vec<TimelyStack<(D, T, R)>>,
-    pending: Vec<(D, T, R)>,
-    logger: Option<Logger<DifferentialEvent, WorkerIdentifier>>,
-    operator_id: usize,
-}
-
-impl<D: Ord+Columnation+'static, T: Ord+Columnation+'static, R: Semigroup+Columnation+'static> MergeSorterColumnation<D, T, R> {
-
-    const BUFFER_SIZE_BYTES: usize = 64 << 10;
-
-    /// Buffer size (number of elements) to use for new/empty buffers.
-    const fn buffer_size() -> usize {
-        let size = std::mem::size_of::<(D, T, R)>();
-        if size == 0 {
-            Self::BUFFER_SIZE_BYTES
-        } else if size <= Self::BUFFER_SIZE_BYTES {
-            Self::BUFFER_SIZE_BYTES / size
-        } else {
-            1
-        }
-    }
-
-    /// Buffer size for pending updates, currently 2 * [`Self::buffer_size`].
-    const fn pending_buffer_size() -> usize {
-        Self::buffer_size() * 2
-    }
-
-    fn new(logger: Option<Logger<DifferentialEvent, WorkerIdentifier>>, operator_id: usize) -> Self {
-        Self {
-            logger,
-            operator_id,
-            queue: Vec::new(),
-            stash: Vec::new(),
-            pending: Vec::new(),
-        }
-    }
-
-    fn empty(&mut self) -> TimelyStack<(D, T, R)> {
-        self.stash.pop().unwrap_or_else(|| TimelyStack::with_capacity(Self::buffer_size()))
-    }
-
-    /// Remove all elements from the stash.
-    fn clear_stash(&mut self) {
-        self.stash.clear();
-    }
-
-    /// Insert an empty buffer into the stash. Panics if the buffer is not empty.
-    fn recycle(&mut self, mut buffer: TimelyStack<(D, T, R)>) {
-        if buffer.capacity() == Self::buffer_size() && self.stash.len() < 2 {
-            buffer.clear();
-            self.stash.push(buffer);
-        }
-    }
-
-    fn push(&mut self, batch: &mut Vec<(D, T, R)>) {
-        // Ensure `self.pending` has a capacity of `Self::pending_buffer_size`.
-        if self.pending.capacity() < Self::pending_buffer_size() {
-            self.pending.reserve(Self::pending_buffer_size() - self.pending.capacity());
-        }
-
-        while !batch.is_empty() {
-            self.pending.extend(batch.drain(..std::cmp::min(batch.len(), self.pending.capacity() - self.pending.len())));
-            if self.pending.len() == self.pending.capacity() {
-                crate::consolidation::consolidate_updates(&mut self.pending);
-                if self.pending.len() > self.pending.capacity() / 2 {
-                    // Flush if `self.pending` is more than half full after consolidation.
-                    self.flush_pending();
-                }
-            }
-        }
-    }
-
-    /// Move all elements in `pending` into `queue`. The data in `pending` must be compacted and
-    /// sorted. After this function returns, `self.pending` is empty.
-    fn flush_pending(&mut self) {
-        if !self.pending.is_empty() {
-            let mut stack = self.empty();
-            stack.reserve_items(self.pending.iter());
-            for tuple in self.pending.drain(..) {
-                stack.copy(&tuple);
-            }
-            self.queue_push(vec![stack]);
-            while self.queue.len() > 1 && (self.queue[self.queue.len()-1].len() >= self.queue[self.queue.len()-2].len() / 2) {
-                let list1 = self.queue_pop().unwrap();
-                let list2 = self.queue_pop().unwrap();
-                let merged = self.merge_by(list1, list2);
-                self.queue_push(merged);
-            }
-        }
-    }
-
-    // This is awkward, because it isn't a power-of-two length any more, and we don't want
-    // to break it down to be so.
-    fn push_list(&mut self, list: Vec<TimelyStack<(D, T, R)>>) {
-        while self.queue.len() > 1 && self.queue[self.queue.len()-1].len() < list.len() {
-            let list1 = self.queue_pop().unwrap();
-            let list2 = self.queue_pop().unwrap();
-            let merged = self.merge_by(list1, list2);
-            self.queue_push(merged);
-        }
-        self.queue_push(list);
-    }
-
-    fn finish_into(&mut self, target: &mut Vec<TimelyStack<(D, T, R)>>) {
-        crate::consolidation::consolidate_updates(&mut self.pending);
-        self.flush_pending();
-        while self.queue.len() > 1 {
-            let list1 = self.queue_pop().unwrap();
-            let list2 = self.queue_pop().unwrap();
-            let merged = self.merge_by(list1, list2);
-            self.queue_push(merged);
-        }
-
-        if let Some(mut last) = self.queue_pop() {
-            std::mem::swap(&mut last, target);
-        }
-    }
-
-    // merges two sorted input lists into one sorted output list.
-    fn merge_by(&mut self, list1: Vec<TimelyStack<(D, T, R)>>, list2: Vec<TimelyStack<(D, T, R)>>) -> Vec<TimelyStack<(D, T, R)>> {
-
-        // TODO: `list1` and `list2` get dropped; would be better to reuse?
-        let mut output = Vec::with_capacity(list1.len() + list2.len());
-        let mut result = self.empty();
-
-        let mut list1 = list1.into_iter();
-        let mut list2 = list2.into_iter();
-
-        let mut head1 = TimelyStackQueue::from(list1.next().unwrap_or_default());
-        let mut head2 = TimelyStackQueue::from(list2.next().unwrap_or_default());
-
-        // while we have valid data in each input, merge.
-        while !head1.is_empty() && !head2.is_empty() {
-
-            while (result.capacity() - result.len()) > 0 && !head1.is_empty() && !head2.is_empty() {
-
-                let cmp = {
-                    let x = head1.peek();
-                    let y = head2.peek();
-                    (&x.0, &x.1).cmp(&(&y.0, &y.1))
-                };
-                match cmp {
-                    Ordering::Less    => { result.copy(head1.pop()); }
-                    Ordering::Greater => { result.copy(head2.pop()); }
-                    Ordering::Equal   => {
-                        let (data1, time1, diff1) = head1.pop();
-                        let (_data2, _time2, diff2) = head2.pop();
-                        let mut diff1 = diff1.clone();
-                        diff1.plus_equals(diff2);
-                        if !diff1.is_zero() {
-                            result.copy_destructured(data1, time1, &diff1);
-                        }
-                    }
-                }
-            }
-
-            if result.capacity() == result.len() {
-                output.push(result);
-                result = self.empty();
-            }
-
-            if head1.is_empty() {
-                self.recycle(head1.done());
-                head1 = TimelyStackQueue::from(list1.next().unwrap_or_default());
-            }
-            if head2.is_empty() {
-                self.recycle(head2.done());
-                head2 = TimelyStackQueue::from(list2.next().unwrap_or_default());
-            }
-        }
-
-        if result.len() > 0 {
-            output.push(result);
-        } else {
-            self.recycle(result);
-        }
-
-        if !head1.is_empty() {
-            let mut result = self.empty();
-            result.reserve_items(head1.iter());
-            for item in head1.iter() { result.copy(item); }
-            output.push(result);
-        }
-        output.extend(list1);
-
-        if !head2.is_empty() {
-            let mut result = self.empty();
-            result.reserve_items(head2.iter());
-            for item in head2.iter() { result.copy(item); }
-            output.push(result);
-        }
-        output.extend(list2);
-
-        output
-    }
-}
-
-impl<D: Columnation + 'static, T: Columnation + 'static, R: Columnation + 'static> MergeSorterColumnation<D, T, R> {
-    /// Pop a batch from `self.queue` and account size changes.
-    #[inline]
-    fn queue_pop(&mut self) -> Option<Vec<TimelyStack<(D, T, R)>>> {
-        let batch = self.queue.pop();
-        self.account(batch.iter().flatten(), -1);
-        batch
-    }
-
-    /// Push a batch to `self.queue` and account size changes.
-    #[inline]
-    fn queue_push(&mut self, batch: Vec<TimelyStack<(D, T, R)>>) {
-        self.account(&batch, 1);
-        self.queue.push(batch);
-    }
-
-    /// Account size changes. Only performs work if a logger exists.
-    ///
-    /// Calculate the size based on the [`TimelyStack`]s passed along, with each attribute
-    /// multiplied by `diff`. Usually, one wants to pass 1 or -1 as the diff.
-    fn account<'a, I: IntoIterator<Item=&'a TimelyStack<(D, T, R)>>>(&self, items: I, diff: isize) {
-        if let Some(logger) = &self.logger {
-            let (mut records, mut siz, mut capacity, mut allocations) = (0isize, 0isize, 0isize, 0isize);
-            for stack in items {
-                records = records.saturating_add_unsigned(stack.len());
-                stack.heap_size(|s, c| {
-                    siz = siz.saturating_add_unsigned(s);
-                    capacity = capacity.saturating_add_unsigned(c);
-                    allocations += isize::from(c > 0);
-                });
-            }
-            logger.log(BatcherEvent {
-                operator: self.operator_id,
-                records_diff: records * diff,
-                size_diff: siz * diff,
-                capacity_diff: capacity * diff,
-                allocations_diff: allocations * diff,
-            })
-        }
-    }
-
-}
-
-impl<D: Columnation + 'static, T: Columnation + 'static, R: Columnation + 'static> Drop for MergeSorterColumnation<D, T, R> {
-    fn drop(&mut self) {
-        while self.queue_pop().is_some() { }
     }
 }

--- a/src/trace/implementations/merge_batcher_col.rs
+++ b/src/trace/implementations/merge_batcher_col.rs
@@ -23,7 +23,7 @@ impl<T> Default for ColumnationMerger<T> {
 }
 
 impl<T: Columnation> ColumnationMerger<T> {
-    const BUFFER_SIZE_BYTES: usize = 1 << 13;
+    const BUFFER_SIZE_BYTES: usize = 64 << 10;
     fn chunk_capacity(&self) -> usize {
         let size = ::std::mem::size_of::<T>();
         if size == 0 {
@@ -35,9 +35,9 @@ impl<T: Columnation> ColumnationMerger<T> {
         }
     }
 
-    /// Buffer size for pending updates, currently 4 * [`Self::chunk_capacity`].
+    /// Buffer size for pending updates, currently 2 * [`Self::chunk_capacity`].
     fn pending_capacity(&self) -> usize {
-        self.chunk_capacity() * 4
+        self.chunk_capacity() * 2
     }
 
     /// Helper to get pre-sized vector from the stash.
@@ -85,7 +85,7 @@ where
         let form_chain = |this: &mut Self, final_chain: &mut Vec<Self::Chunk>, stash: &mut _| {
             if this.pending.len() == this.pending.capacity() {
                 consolidate_updates(&mut this.pending);
-                if this.pending.len() > this.pending.capacity() / 2 {
+                if this.pending.len() >= this.chunk_capacity() {
                     let mut chain = Vec::default();
                     while this.pending.len() > this.chunk_capacity() {
                         let mut chunk = this.empty(stash);

--- a/src/trace/implementations/merge_batcher_col.rs
+++ b/src/trace/implementations/merge_batcher_col.rs
@@ -1,15 +1,234 @@
 //! A general purpose `Batcher` implementation based on radix sort for TimelyStack.
 
-use timely::Container;
+use std::cmp::Ordering;
+use timely::{Container, Data, PartialOrder};
 use timely::communication::message::RefOrMut;
 use timely::container::columnation::{Columnation, TimelyStack};
 use timely::logging::WorkerIdentifier;
 use timely::logging_core::Logger;
 use timely::progress::{frontier::Antichain, Timestamp};
+use timely::progress::frontier::AntichainRef;
+use crate::consolidation::consolidate_updates;
 
 use crate::difference::Semigroup;
 use crate::logging::{BatcherEvent, DifferentialEvent};
 use crate::trace::{Batcher, Builder};
+use crate::trace::implementations::merge_batcher::Merger;
+
+/// TODO
+pub struct ColumnationMerger<T> {
+    pending: Vec<T>,
+}
+
+impl<T> Default for ColumnationMerger<T> {
+    fn default() -> Self {
+        Self { pending: Vec::default() }
+    }
+}
+
+impl<T: Columnation> ColumnationMerger<T> {
+    const BUFFER_SIZE_BYTES: usize = 1 << 13;
+    fn preferred_buffer_size(&self) -> usize {
+        let size = ::std::mem::size_of::<T>();
+        if size == 0 {
+            Self::BUFFER_SIZE_BYTES
+        } else if size <= Self::BUFFER_SIZE_BYTES {
+            Self::BUFFER_SIZE_BYTES / size
+        } else {
+            1
+        }
+    }
+
+    /// Buffer size for pending updates, currently 4 * [`Self::buffer_size`].
+    fn pending_buffer_size(&self) -> usize {
+        self.preferred_buffer_size() * 1
+    }
+
+    /// Helper to get pre-sized vector from the stash.
+    #[inline]
+    fn empty(&self, stash: &mut Vec<TimelyStack<T>>) -> TimelyStack<T> {
+        stash.pop().unwrap_or_else(|| TimelyStack::with_capacity(self.preferred_buffer_size()))
+    }
+
+    /// Helper to return a batch to the stash.
+    #[inline]
+    fn recycle(&self, mut batch: TimelyStack<T>, stash: &mut Vec<TimelyStack<T>>) {
+        // TODO: Should we limit the size of `stash`?
+        if batch.capacity() == self.preferred_buffer_size() /*&& stash.len() < 2*/ {
+            batch.clear();
+            stash.push(batch);
+        }
+    }
+}
+
+impl<D, T,R> Merger for ColumnationMerger<(D, T, R)>
+where
+    D: Columnation + Ord + Data,
+    T: Columnation + Ord + PartialOrder + Data,
+    R: Columnation + Semigroup + 'static,
+{
+    type Time = T;
+    type Input = Vec<(D,T,R)>;
+    type Batch = TimelyStack<(D,T,R)>;
+
+    fn accept(&mut self, batch: RefOrMut<Self::Input>, stash: &mut Vec<Self::Batch>) -> Vec<Self::Batch> {
+        // `batch` is either a shared reference or an owned allocations.
+        let mut batch: Vec<_> = match batch {
+            RefOrMut::Ref(vec) => {
+                let mut owned = Vec::default();
+                owned.clone_from(vec);
+                owned
+            }
+            RefOrMut::Mut(vec) => std::mem::take(vec)
+        };
+        // Ensure `self.pending` has a capacity of `Self::pending_buffer_size`.
+        if self.pending.capacity() < self.pending_buffer_size() {
+            self.pending.reserve(self.pending_buffer_size() - self.pending.capacity());
+        }
+
+        let mut output = Vec::default();
+
+        while !batch.is_empty() {
+            self.pending.extend(batch.drain(..std::cmp::min(batch.len(), self.pending.capacity() - self.pending.len())));
+            if self.pending.len() == self.pending.capacity() {
+                consolidate_updates(&mut self.pending);
+                if self.pending.len() > self.pending.capacity() / 2 {
+                    // Flush if `self.pending` is more than half full after consolidation.
+                    let mut stack = self.empty(stash);
+                    stack.reserve_items(self.pending.iter());
+                    for tuple in self.pending.drain(..) {
+                        stack.copy(&tuple);
+                    }
+                    output.push(stack);
+                }
+            }
+        }
+
+        output
+    }
+
+    fn finish(&mut self, _stash: &mut Vec<Self::Batch>) -> Vec<Self::Batch> {
+        vec![]
+    }
+
+    fn merge(&mut self, list1: Vec<Self::Batch>, list2: Vec<Self::Batch>, output: &mut Vec<Self::Batch>, stash: &mut Vec<Self::Batch>) {
+        let mut list1 = list1.into_iter();
+        let mut list2 = list2.into_iter();
+
+        let mut head1 = TimelyStackQueue::from(list1.next().unwrap_or_default());
+        let mut head2 = TimelyStackQueue::from(list2.next().unwrap_or_default());
+
+        let mut result = self.empty(stash);
+
+        // while we have valid data in each input, merge.
+        while !head1.is_empty() && !head2.is_empty() {
+
+            while (result.capacity() - result.len()) > 0 && !head1.is_empty() && !head2.is_empty() {
+
+                let cmp = {
+                    let x = head1.peek();
+                    let y = head2.peek();
+                    (&x.0, &x.1).cmp(&(&y.0, &y.1))
+                };
+                match cmp {
+                    Ordering::Less    => { result.copy(head1.pop()); }
+                    Ordering::Greater => { result.copy(head2.pop()); }
+                    Ordering::Equal   => {
+                        let (data1, time1, diff1) = head1.pop();
+                        let (_data2, _time2, diff2) = head2.pop();
+                        let mut diff1 = diff1.clone();
+                        diff1.plus_equals(diff2);
+                        if !diff1.is_zero() {
+                            result.copy_destructured(data1, time1, &diff1);
+                        }
+                    }
+                }
+            }
+
+            if result.capacity() == result.len() {
+                output.push(result);
+                result = self.empty(stash);
+            }
+
+            if head1.is_empty() {
+                self.recycle(head1.done(), stash);
+                head1 = TimelyStackQueue::from(list1.next().unwrap_or_default());
+            }
+            if head2.is_empty() {
+                self.recycle(head2.done(), stash);
+                head2 = TimelyStackQueue::from(list2.next().unwrap_or_default());
+            }
+        }
+
+        if result.len() > 0 {
+            output.push(result);
+        } else {
+            self.recycle(result, stash);
+        }
+
+        if !head1.is_empty() {
+            let mut result = self.empty(stash);
+            result.reserve_items(head1.iter());
+            for item in head1.iter() { result.copy(item); }
+            output.push(result);
+        }
+        output.extend(list1);
+
+        if !head2.is_empty() {
+            let mut result = self.empty(stash);
+            result.reserve_items(head2.iter());
+            for item in head2.iter() { result.copy(item); }
+            output.push(result);
+        }
+        output.extend(list2);
+    }
+
+    fn extract(&mut self, merged: Vec<Self::Batch>, upper: AntichainRef<Self::Time>, frontier: &mut Antichain<Self::Time>, readied: &mut Vec<Self::Batch>, kept: &mut Vec<Self::Batch>, stash: &mut Vec<Self::Batch>) {
+        let mut keep = self.empty(stash);
+        let mut ready = self.empty(stash);
+
+        for buffer in merged {
+            for d @ (_data, time, _diff) in buffer.iter() {
+                if upper.less_equal(time) {
+                    frontier.insert(time.clone());
+                    if keep.len() == keep.capacity() && !keep.is_empty() {
+                        kept.push(keep);
+                        keep = self.empty(stash);
+                    }
+                    keep.copy(d);
+                }
+                else {
+                    if ready.len() == ready.capacity() && !ready.is_empty() {
+                        readied.push(ready);
+                        ready = self.empty(stash);
+                    }
+                    ready.copy(d);
+                }
+            }
+            // Recycling buffer.
+            self.recycle(buffer, stash);
+        }
+        // Finish the kept data.
+        if !keep.is_empty() {
+            kept.push(keep);
+        }
+        if !ready.is_empty() {
+            readied.push(ready);
+        }
+    }
+
+    fn account(batch: &Self::Batch) -> (usize, usize, usize, usize) {
+        let (mut size, mut capacity, mut allocations) = (0, 0, 0);
+        let cb = |siz, cap| {
+            size += siz;
+            capacity += cap;
+            allocations += 1;
+        };
+        batch.heap_size(cb);
+        (batch.len(), size, capacity, allocations)
+    }
+}
+
 
 /// Creates batches from unordered tuples.
 pub struct ColumnatedMergeBatcher<K, V, T, D>
@@ -32,7 +251,7 @@ where
     D: Columnation + Semigroup + 'static,
 {
     type Input = Vec<((K,V),T,D)>;
-    type Output = ((K,V),T,D);
+    type Output = Vec<((K,V),T,D)>;
     type Time = T;
 
     fn new(logger: Option<Logger<DifferentialEvent, WorkerIdentifier>>, operator_id: usize) -> Self {
@@ -101,6 +320,8 @@ where
 
         let mut kept = Vec::new();
         let mut keep = TimelyStack::default();
+        let mut readied = Vec::new();
+        let mut ready = Vec::default();
 
         self.frontier.clear();
 
@@ -119,7 +340,15 @@ where
                     keep.copy(datum);
                 }
                 else {
-                    builder.copy(datum);
+                    if ready.is_empty() {
+                        if ready.capacity() != MergeSorterColumnation::<(K, V), T, D>::buffer_size() {
+                            ready = Vec::with_capacity(MergeSorterColumnation::<(K, V), T, D>::buffer_size());
+                        }
+                    } else if ready.len() == ready.capacity() {
+                        readied.push(ready);
+                        ready = Vec::with_capacity(MergeSorterColumnation::<(K, V), T, D>::buffer_size());
+                    }
+                    ready.push(datum.clone());
                 }
             }
             // Recycling buffer.
@@ -132,6 +361,13 @@ where
         }
         if !kept.is_empty() {
             self.sorter.push_list(kept);
+        }
+
+        if !ready.is_empty() {
+            readied.push(ready);
+        }
+        if !readied.is_empty() {
+            builder.push_batches(&mut readied);
         }
 
         // Drain buffers (fast reclamation).
@@ -312,7 +548,6 @@ impl<D: Ord+Columnation+'static, T: Ord+Columnation+'static, R: Semigroup+Column
 
     // merges two sorted input lists into one sorted output list.
     fn merge_by(&mut self, list1: Vec<TimelyStack<(D, T, R)>>, list2: Vec<TimelyStack<(D, T, R)>>) -> Vec<TimelyStack<(D, T, R)>> {
-        use std::cmp::Ordering;
 
         // TODO: `list1` and `list2` get dropped; would be better to reuse?
         let mut output = Vec::with_capacity(list1.len() + list2.len());

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -42,9 +42,6 @@ pub mod spine_fueled;
 
 pub mod merge_batcher;
 pub mod merge_batcher_col;
-
-pub use self::merge_batcher::MergeBatcher as Batcher;
-
 pub mod ord_neu;
 pub mod rhh;
 pub mod huffman_container;

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 
 use crate::trace::implementations::spine_fueled::Spine;
 use crate::trace::implementations::merge_batcher::{MergeBatcher, VecMerger};
-use crate::trace::implementations::merge_batcher_col::ColumnatedMergeBatcher;
+use crate::trace::implementations::merge_batcher_col::ColumnationMerger;
 use crate::trace::rc_blanket_impls::RcBuilder;
 
 use super::{Update, Layout, Vector, TStack, Preferred};
@@ -32,8 +32,7 @@ pub type OrdValSpine<K, V, T, R> = Spine<
 /// A trace implementation backed by columnar storage.
 pub type ColValSpine<K, V, T, R> = Spine<
     Rc<OrdValBatch<TStack<((K,V),T,R)>>>,
-    // MergeBatcher<ColumnationMerger<((K,V),T,R)>, T>,
-    ColumnatedMergeBatcher<K,V,T,R>,
+    MergeBatcher<ColumnationMerger<((K,V),T,R)>, T>,
     RcBuilder<OrdValBuilder<TStack<((K,V),T,R)>>>,
 >;
 
@@ -49,16 +48,14 @@ pub type OrdKeySpine<K, T, R> = Spine<
 /// A trace implementation backed by columnar storage.
 pub type ColKeySpine<K, T, R> = Spine<
     Rc<OrdKeyBatch<TStack<((K,()),T,R)>>>,
-    // MergeBatcher<ColumnationMerger<((K,()),T,R)>, T>,
-    ColumnatedMergeBatcher<K,(),T,R>,
+    MergeBatcher<ColumnationMerger<((K,()),T,R)>, T>,
     RcBuilder<OrdKeyBuilder<TStack<((K,()),T,R)>>>,
 >;
 
 /// A trace implementation backed by columnar storage.
 pub type PreferredSpine<K, V, T, R> = Spine<
     Rc<OrdValBatch<Preferred<K,V,T,R>>>,
-    // MergeBatcher<ColumnationMerger<((<K as ToOwned>::Owned,<V as ToOwned>::Owned),T,R)>,T>,
-    ColumnatedMergeBatcher<<K as ToOwned>::Owned,<V as ToOwned>::Owned,T,R>,
+    MergeBatcher<ColumnationMerger<((<K as ToOwned>::Owned,<V as ToOwned>::Owned),T,R)>,T>,
     RcBuilder<OrdValBuilder<Preferred<K,V,T,R>>>,
 >;
 
@@ -541,7 +538,7 @@ mod val_batch {
 
     impl<L: Layout> Builder for OrdValBuilder<L> {
 
-        type Input = Vec<((<L::Target as Update>::Key, <L::Target as Update>::Val), <L::Target as Update>::Time, <L::Target as Update>::Diff)>;
+        type Input = ((<L::Target as Update>::Key, <L::Target as Update>::Val), <L::Target as Update>::Time, <L::Target as Update>::Diff);
         type Time = <L::Target as Update>::Time;
         type Output = OrdValBatch<L>;
 
@@ -560,60 +557,59 @@ mod val_batch {
             }
         }
 
-        fn from_batches(batches: &mut Vec<Self::Input>, lower: AntichainRef<Self::Time>, upper: AntichainRef<Self::Time>, since: AntichainRef<Self::Time>) -> Self::Output {
-            let mut keys = 0;
-            let mut vals = 0;
-            let mut upds = 0;
-            let mut prev_keyval = None;
-            for buffer in batches.iter() {
-                for ((key, val), time, _) in buffer.iter() {
-                    if !upper.less_equal(time) {
-                        if let Some((p_key, p_val)) = prev_keyval {
-                            if p_key != key {
-                                keys += 1;
-                                vals += 1;
-                            }
-                            else if p_val != val {
-                                vals += 1;
-                            }
-                            upds += 1;
-                        } else {
-                            keys += 1;
-                            vals += 1;
-                            upds += 1;
-                        }
-                        prev_keyval = Some((key, val));
-                    }
-                }
-            }
-            let mut new = Self::with_capacity(keys, vals, upds);
-            new.push_batches(batches);
-            new.done(lower.to_owned(), upper.to_owned(), since.to_owned())
-        }
+        #[inline]
+        fn push(&mut self, ((key, val), time, diff): Self::Input) {
 
-        fn push_batches(&mut self, batches: &mut Vec<Self::Input>) {
-            for ((key, val), time, diff) in batches.iter_mut().map(|batch| batch.drain(..)).flatten() {
-                // Perhaps this is a continuation of an already received key.
-                if self.result.keys.last().map(|k| k.equals(&key)).unwrap_or(false) {
-                    // Perhaps this is a continuation of an already received value.
-                    if self.result.vals.last().map(|v| v.equals(&val)).unwrap_or(false) {
-                        self.push_update(time, diff);
-                    } else {
-                        // New value; complete representation of prior value.
-                        self.result.vals_offs.push(self.result.updates.len());
-                        if self.singleton.take().is_some() { self.singletons += 1; }
-                        self.push_update(time, diff);
-                        self.result.vals.push(val);
-                    }
+            // Perhaps this is a continuation of an already received key.
+            if self.result.keys.last().map(|k| k.equals(&key)).unwrap_or(false) {
+                // Perhaps this is a continuation of an already received value.
+                if self.result.vals.last().map(|v| v.equals(&val)).unwrap_or(false) {
+                    self.push_update(time, diff);
                 } else {
-                    // New key; complete representation of prior key.
+                    // New value; complete representation of prior value.
                     self.result.vals_offs.push(self.result.updates.len());
                     if self.singleton.take().is_some() { self.singletons += 1; }
-                    self.result.keys_offs.push(self.result.vals.len());
                     self.push_update(time, diff);
                     self.result.vals.push(val);
-                    self.result.keys.push(key);
                 }
+            } else {
+                // New key; complete representation of prior key.
+                self.result.vals_offs.push(self.result.updates.len());
+                if self.singleton.take().is_some() { self.singletons += 1; }
+                self.result.keys_offs.push(self.result.vals.len());
+                self.push_update(time, diff);
+                self.result.vals.push(val);
+                self.result.keys.push(key);
+            }
+        }
+
+        #[inline]
+        fn copy(&mut self, ((key, val), time, diff): &Self::Input) {
+
+            // Perhaps this is a continuation of an already received key.
+            if self.result.keys.last().map(|k| k.equals(key)).unwrap_or(false) {
+                // Perhaps this is a continuation of an already received value.
+                if self.result.vals.last().map(|v| v.equals(val)).unwrap_or(false) {
+                    // TODO: here we could look for repetition, and not push the update in that case.
+                    // More logic (and state) would be required to correctly wrangle this.
+                    self.push_update(time.clone(), diff.clone());
+                } else {
+                    // New value; complete representation of prior value.
+                    self.result.vals_offs.push(self.result.updates.len());
+                    // Remove any pending singleton, and if it was set increment our count.
+                    if self.singleton.take().is_some() { self.singletons += 1; }
+                    self.push_update(time.clone(), diff.clone());
+                    self.result.vals.copy_push(val);
+                }
+            } else {
+                // New key; complete representation of prior key.
+                self.result.vals_offs.push(self.result.updates.len());
+                // Remove any pending singleton, and if it was set increment our count.
+                if self.singleton.take().is_some() { self.singletons += 1; }
+                self.result.keys_offs.push(self.result.vals.len());
+                self.push_update(time.clone(), diff.clone());
+                self.result.vals.copy_push(val);
+                self.result.keys.copy_push(key);
             }
         }
 
@@ -1006,7 +1002,7 @@ mod key_batch {
 
     impl<L: Layout> Builder for OrdKeyBuilder<L> {
 
-        type Input = Vec<((<L::Target as Update>::Key, ()), <L::Target as Update>::Time, <L::Target as Update>::Diff)>;
+        type Input = ((<L::Target as Update>::Key, ()), <L::Target as Update>::Time, <L::Target as Update>::Diff);
         type Time = <L::Target as Update>::Time;
         type Output = OrdKeyBatch<L>;
 
@@ -1023,45 +1019,35 @@ mod key_batch {
             }
         }
 
-        /// Build from batches
-        fn from_batches(batches: &mut Vec<Self::Input>, lower: AntichainRef<Self::Time>, upper: AntichainRef<Self::Time>, since: AntichainRef<Self::Time>) -> Self::Output {
-            let mut keys = 0;
-            let mut upds = 0;
-            let mut prev_key = None;
-            for buffer in batches.iter() {
-                for ((key, ()), time, _) in buffer.iter() {
-                    if !upper.less_equal(time) {
-                        if let Some(p_key) = prev_key {
-                            if p_key != key {
-                                keys += 1;
-                            }
-                            upds += 1;
-                        } else {
-                            keys += 1;
-                            upds += 1;
-                        }
-                        prev_key = Some(key);
-                    }
-                }
+        #[inline]
+        fn push(&mut self, ((key, ()), time, diff): Self::Input) {
+
+            // Perhaps this is a continuation of an already received key.
+            if self.result.keys.last().map(|k| k.equals(&key)).unwrap_or(false) {
+                self.push_update(time, diff);
+            } else {
+                // New key; complete representation of prior key.
+                self.result.keys_offs.push(self.result.updates.len());
+                // Remove any pending singleton, and if it was set increment our count.
+                if self.singleton.take().is_some() { self.singletons += 1; }
+                self.push_update(time, diff);
+                self.result.keys.push(key);
             }
-            let mut new = Self::with_capacity(keys, 0, upds);
-            new.push_batches(batches);
-            new.done(lower.to_owned(), upper.to_owned(), since.to_owned())
         }
 
-        fn push_batches(&mut self, batches: &mut Vec<Self::Input>) {
-            for ((key, ()), time, diff) in batches.iter_mut().map(|batch| batch.drain(..)).flatten() {
-                // Perhaps this is a continuation of an already received key.
-                if self.result.keys.last().map(|k| k.equals(&key)).unwrap_or(false) {
-                    self.push_update(time, diff);
-                } else {
-                    // New key; complete representation of prior key.
-                    self.result.keys_offs.push(self.result.updates.len());
-                    // Remove any pending singleton, and if it was set increment our count.
-                    if self.singleton.take().is_some() { self.singletons += 1; }
-                    self.push_update(time, diff);
-                    self.result.keys.push(key);
-                }
+        #[inline]
+        fn copy(&mut self, ((key, ()), time, diff): &Self::Input) {
+
+            // Perhaps this is a continuation of an already received key.
+            if self.result.keys.last().map(|k| k.equals(key)).unwrap_or(false) {
+                self.push_update(time.clone(), diff.clone());
+            } else {
+                // New key; complete representation of prior key.
+                self.result.keys_offs.push(self.result.updates.len());
+                // Remove any pending singleton, and if it was set increment our count.
+                if self.singleton.take().is_some() { self.singletons += 1; }
+                self.push_update(time.clone(), diff.clone());
+                self.result.keys.copy_push(key);
             }
         }
 

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -310,8 +310,8 @@ pub trait Batcher {
     type Time: Timestamp;
     /// Allocates a new empty batcher.
     fn new(logger: Option<Logger<DifferentialEvent, WorkerIdentifier>>, operator_id: usize) -> Self;
-    /// Adds an unordered batch of elements to the batcher.
-    fn push_batch(&mut self, batch: RefOrMut<Self::Input>);
+    /// Adds an unordered container of elements to the batcher.
+    fn push_container(&mut self, batch: RefOrMut<Self::Input>);
     /// Returns all updates not greater or equal to an element of `upper`.
     fn seal<B: Builder<Input=Self::Output, Time=Self::Time>>(&mut self, upper: Antichain<Self::Time>) -> B::Output;
     /// Returns the lower envelope of contained update times.

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -320,13 +320,16 @@ pub trait Batcher {
 
 /// Functionality for building batches from ordered update sequences.
 pub trait Builder: Sized {
-    /// Input item type.
+    /// Input type.
     type Input;
     /// Timestamp type.
     type Time: Timestamp;
     /// Output batch type.
     type Output;
-    
+
+    /// Build from batches
+    fn from_batches(batches: &mut Vec<Self::Input>, lower: AntichainRef<Self::Time>, upper: AntichainRef<Self::Time>, since: AntichainRef<Self::Time>) -> Self::Output;
+
     /// Allocates an empty builder.
     ///
     /// Ideally we deprecate this and insist all non-trivial building happens via `with_capacity()`.
@@ -335,17 +338,14 @@ pub trait Builder: Sized {
     /// Allocates an empty builder with capacity for the specified keys, values, and updates.
     ///
     /// They represent respectively the number of distinct `key`, `(key, val)`, and total updates.
+    // #[deprecated]
     fn with_capacity(keys: usize, vals: usize, upds: usize) -> Self;
-    /// Adds an element to the batch.
-    ///
-    /// The default implementation uses `self.copy` with references to the owned arguments.
-    /// One should override it if the builder can take advantage of owned arguments.
-    fn push(&mut self, element: Self::Input) {
-        self.copy(&element);
-    }
-    /// Adds an element to the batch.
-    fn copy(&mut self, element: &Self::Input);
+    /// Adds elements in sorted order to the batch.
+    /// TODO: Refine the `batches` parameter to allow allocation reuse.
+    // #[deprecated]
+    fn push_batches(&mut self, batches: &mut Vec<Self::Input>);
     /// Completes building and returns the batch.
+    // #[deprecated]
     fn done(self, lower: Antichain<Self::Time>, upper: Antichain<Self::Time>, since: Antichain<Self::Time>) -> Self::Output;
 }
 
@@ -453,9 +453,11 @@ pub mod rc_blanket_impls {
         type Input = B::Input;
         type Time = B::Time;
         type Output = Rc<B::Output>;
+        fn from_batches(batches: &mut Vec<Self::Input>, lower: AntichainRef<Self::Time>, upper: AntichainRef<Self::Time>, since: AntichainRef<Self::Time>) -> Self::Output {
+            Rc::new(B::from_batches(batches, lower, upper, since))
+        }
         fn with_capacity(keys: usize, vals: usize, upds: usize) -> Self { RcBuilder { builder: B::with_capacity(keys, vals, upds) } }
-        fn push(&mut self, element: Self::Input) { self.builder.push(element) }
-        fn copy(&mut self, element: &Self::Input) { self.builder.copy(element) }
+        fn push_batches(&mut self, batches: &mut Vec<Self::Input>) { self.builder.push_batches(batches) }
         fn done(self, lower: Antichain<Self::Time>, upper: Antichain<Self::Time>, since: Antichain<Self::Time>) -> Rc<B::Output> { Rc::new(self.builder.done(lower, upper, since)) }
     }
 
@@ -560,9 +562,14 @@ pub mod abomonated_blanket_impls {
         type Input = B::Input;
         type Time = B::Time;
         type Output = Abomonated<B::Output, Vec<u8>>;
+        fn from_batches(batches: &mut Vec<Self::Input>, lower: AntichainRef<Self::Time>, upper: AntichainRef<Self::Time>, since: AntichainRef<Self::Time>) -> Self::Output {
+            let batch = B::from_batches(batches, lower, upper, since);
+            let mut bytes = Vec::with_capacity(measure(&batch));
+            unsafe { abomonation::encode(&batch, &mut bytes).unwrap() };
+            unsafe { Abomonated::<B::Output,_>::new(bytes).unwrap() }
+        }
         fn with_capacity(keys: usize, vals: usize, upds: usize) -> Self { AbomonatedBuilder { builder: B::with_capacity(keys, vals, upds) } }
-        fn push(&mut self, element: Self::Input) { self.builder.push(element) }
-        fn copy(&mut self, element: &Self::Input) { self.builder.copy(element) }
+        fn push_batches(&mut self, batches: &mut Vec<Self::Input>) { self.builder.push_batches(batches) }
         fn done(self, lower: Antichain<Self::Time>, upper: Antichain<Self::Time>, since: Antichain<Self::Time>) -> Self::Output {
             let batch = self.builder.done(lower, upper, since);
             let mut bytes = Vec::with_capacity(measure(&batch));

--- a/tests/trace.rs
+++ b/tests/trace.rs
@@ -15,7 +15,7 @@ fn get_trace() -> ValSpine<u64, u64, usize, i64> {
         let mut batcher = <IntegerTrace as Trace>::Batcher::new(None, 0);
 
         use timely::communication::message::RefOrMut;
-        batcher.push_batch(RefOrMut::Mut(&mut vec![
+        batcher.push_container(RefOrMut::Mut(&mut vec![
             ((1, 2), 0, 1),
             ((2, 3), 1, 1),
             ((2, 3), 2, -1),


### PR DESCRIPTION
Merge batcher that's generic over input containers and internal chains, with specific implementations.

## Ideas

At the moment, a merge batcher receives a stream of vectors. It consolidates the input vectors, and inserts them into its queue structure. When sealing, it extracts ready data and presents it record-by-record to the builder. It inserts future updates into its queue.

This introduces several opportunities to introduce containers:
* The input the batcher: The stream of updates received from a timely operator. The batcher requires each batch to be consolidated, i.e., sorted and differences for same data accumulated. It can either take consolidated data, or consolidate it itself. We're missing an abstraction that allows the batcher to consolidate containers, and often containers are read-only, or we only get to look at the data.
  * We could sort by permuting a `Vec<usize>` and copying into a new container in sorted order.
  * Consolidating requires addition, which either requires storage or mutability, which is odd for read-only containers. Not sure what to do here.
* The internal queue structure. We need to traverse the elements in order, and compare on data and time, accumulating diffs as we go. This requires specific knowledge about items of a container, which motivates moving the bulk of the implementation behind a trait to avoid generic parameters.
* Ready data presented to the builder. We have an opportunity to present all data to the builder at once, which relieves it from incrementally building batches. It unlocks "looking ahead" in the input data.