### PR TITLE
Remove `ValOwned`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
     # "advent_of_code_2017",
     "dogsdogsdogs",
     "experiments",
-    "interactive",
+    #"interactive",
     "server",
     "server/dataflows/degr_dist",
     "server/dataflows/neighborhood",

--- a/dogsdogsdogs/examples/delta_query.rs
+++ b/dogsdogsdogs/examples/delta_query.rs
@@ -79,17 +79,17 @@ fn main() {
 
                 // Prior technology
                 //   dQ/dE1 := dE1(a,b), E2(b,c), E3(a,c)
-                let changes1 = propose(&changes, forward_key_neu.clone(), key2.clone());
+                let changes1 = propose(&changes, forward_key_neu.clone(), key2.clone(), |v| v.clone());
                 let changes1 = validate(&changes1, forward_self_neu.clone(), key1.clone());
                 let changes1 = changes1.map(|((a,b),c)| (a,b,c));
 
                 //   dQ/dE2 := dE2(b,c), E1(a,b), E3(a,c)
-                let changes2 = propose(&changes, reverse_key_alt.clone(), key1.clone());
+                let changes2 = propose(&changes, reverse_key_alt.clone(), key1.clone(), |v| v.clone());
                 let changes2 = validate(&changes2, reverse_self_neu.clone(), key2.clone());
                 let changes2 = changes2.map(|((b,c),a)| (a,b,c));
 
                 //   dQ/dE3 := dE3(a,c), E1(a,b), E2(b,c)
-                let changes3 = propose(&changes, forward_key_alt.clone(), key1.clone());
+                let changes3 = propose(&changes, forward_key_alt.clone(), key1.clone(), |v| v.clone());
                 let changes3 = validate(&changes3, reverse_self_alt.clone(), key2.clone());
                 let changes3 = changes3.map(|((a,c),b)| (a,b,c));
 

--- a/dogsdogsdogs/examples/delta_query.rs
+++ b/dogsdogsdogs/examples/delta_query.rs
@@ -79,17 +79,17 @@ fn main() {
 
                 // Prior technology
                 //   dQ/dE1 := dE1(a,b), E2(b,c), E3(a,c)
-                let changes1 = propose(&changes, forward_key_neu.clone(), key2.clone(), |v| v.clone());
+                let changes1 = propose(&changes, forward_key_neu.clone(), key2.clone(), Clone::clone);
                 let changes1 = validate(&changes1, forward_self_neu.clone(), key1.clone());
                 let changes1 = changes1.map(|((a,b),c)| (a,b,c));
 
                 //   dQ/dE2 := dE2(b,c), E1(a,b), E3(a,c)
-                let changes2 = propose(&changes, reverse_key_alt.clone(), key1.clone(), |v| v.clone());
+                let changes2 = propose(&changes, reverse_key_alt.clone(), key1.clone(), Clone::clone);
                 let changes2 = validate(&changes2, reverse_self_neu.clone(), key2.clone());
                 let changes2 = changes2.map(|((b,c),a)| (a,b,c));
 
                 //   dQ/dE3 := dE3(a,c), E1(a,b), E2(b,c)
-                let changes3 = propose(&changes, forward_key_alt.clone(), key1.clone(), |v| v.clone());
+                let changes3 = propose(&changes, forward_key_alt.clone(), key1.clone(), Clone::clone);
                 let changes3 = validate(&changes3, reverse_self_alt.clone(), key2.clone());
                 let changes3 = changes3.map(|((a,c),b)| (a,b,c));
 

--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -199,7 +199,7 @@ where
 
     fn propose(&mut self, prefixes: &Collection<G, P, R>) -> Collection<G, (P, V), R> {
         let propose = self.indices.propose_trace.import(&prefixes.scope());
-        operators::propose::propose(prefixes, propose, self.key_selector.clone())
+        operators::propose::propose(prefixes, propose, self.key_selector.clone(), |x| x.clone())
     }
 
     fn validate(&mut self, extensions: &Collection<G, (P, V), R>) -> Collection<G, (P, V), R> {

--- a/dogsdogsdogs/src/operators/count.rs
+++ b/dogsdogsdogs/src/operators/count.rs
@@ -19,7 +19,7 @@ pub fn count<G, Tr, R, F, P>(
 ) -> Collection<G, (P, usize, usize), R>
 where
     G: Scope<Timestamp=Tr::Time>,
-    Tr: TraceReader<ValOwned=(), Diff=isize>+Clone+'static,
+    Tr: TraceReader<Diff=isize>+Clone+'static,
     Tr::KeyOwned: Hashable + Default,
     R: Monoid+Multiply<Output = R>+ExchangeData,
     F: Fn(&P)->Tr::KeyOwned+Clone+'static,

--- a/dogsdogsdogs/src/operators/propose.rs
+++ b/dogsdogsdogs/src/operators/propose.rs
@@ -13,11 +13,11 @@ use differential_dataflow::trace::TraceReader;
 /// create a join if the `prefixes` collection is also arranged and responds to changes that
 /// `arrangement` undergoes. More complicated patterns are also appropriate, as in the case
 /// of delta queries.
-pub fn propose<G, Tr, F, P, V, I>(
+pub fn propose<G, Tr, F, P, V, VF>(
     prefixes: &Collection<G, P, Tr::Diff>,
     arrangement: Arranged<G, Tr>,
     key_selector: F,
-    into: I,
+    val_from: VF,
 ) -> Collection<G, (P, V), Tr::Diff>
 where
     G: Scope<Timestamp=Tr::Time>,
@@ -27,13 +27,13 @@ where
     F: Fn(&P)->Tr::KeyOwned+Clone+'static,
     P: ExchangeData,
     V: Clone + 'static,
-    I: Fn(Tr::Val<'_>) -> V + 'static,
+    VF: Fn(Tr::Val<'_>) -> V + 'static,
 {
     crate::operators::lookup_map(
         prefixes,
         arrangement,
         move |p: &P, k: &mut Tr::KeyOwned | { *k = key_selector(p); },
-        move |prefix, diff, value, sum| ((prefix.clone(), into(value)), diff.clone().multiply(sum)),
+        move |prefix, diff, value, sum| ((prefix.clone(), val_from(value)), diff.clone().multiply(sum)),
         Default::default(),
         Default::default(),
         Default::default(),
@@ -45,11 +45,11 @@ where
 /// Unlike `propose`, this method does not scale the multiplicity of matched
 /// prefixes by the number of matches in `arrangement`. This can be useful to
 /// avoid the need to prepare an arrangement of distinct extensions.
-pub fn propose_distinct<G, Tr, F, P, V, I>(
+pub fn propose_distinct<G, Tr, F, P, V, VF>(
     prefixes: &Collection<G, P, Tr::Diff>,
     arrangement: Arranged<G, Tr>,
     key_selector: F,
-    into: I,
+    val_from: VF,
 ) -> Collection<G, (P, V), Tr::Diff>
 where
     G: Scope<Timestamp=Tr::Time>,
@@ -59,13 +59,13 @@ where
     F: Fn(&P)->Tr::KeyOwned+Clone+'static,
     P: ExchangeData,
     V: Clone + 'static,
-    I: Fn(Tr::Val<'_>) -> V + 'static,
+    VF: Fn(Tr::Val<'_>) -> V + 'static,
 {
     crate::operators::lookup_map(
         prefixes,
         arrangement,
         move |p: &P, k: &mut Tr::KeyOwned| { *k = key_selector(p); },
-        move |prefix, diff, value, _sum| ((prefix.clone(), into(value)), diff.clone()),
+        move |prefix, diff, value, _sum| ((prefix.clone(), val_from(value)), diff.clone()),
         Default::default(),
         Default::default(),
         Default::default(),

--- a/dogsdogsdogs/src/operators/propose.rs
+++ b/dogsdogsdogs/src/operators/propose.rs
@@ -4,7 +4,6 @@ use differential_dataflow::{ExchangeData, Collection, Hashable};
 use differential_dataflow::difference::{Monoid, Multiply};
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::TraceReader;
-use differential_dataflow::trace::cursor::MyTrait;
 
 /// Proposes extensions to a prefix stream.
 ///
@@ -14,11 +13,12 @@ use differential_dataflow::trace::cursor::MyTrait;
 /// create a join if the `prefixes` collection is also arranged and responds to changes that
 /// `arrangement` undergoes. More complicated patterns are also appropriate, as in the case
 /// of delta queries.
-pub fn propose<G, Tr, F, P>(
+pub fn propose<G, Tr, F, P, V, I>(
     prefixes: &Collection<G, P, Tr::Diff>,
     arrangement: Arranged<G, Tr>,
     key_selector: F,
-) -> Collection<G, (P, Tr::ValOwned), Tr::Diff>
+    into: I,
+) -> Collection<G, (P, V), Tr::Diff>
 where
     G: Scope<Timestamp=Tr::Time>,
     Tr: TraceReader+Clone+'static,
@@ -26,12 +26,14 @@ where
     Tr::Diff: Monoid+Multiply<Output = Tr::Diff>+ExchangeData,
     F: Fn(&P)->Tr::KeyOwned+Clone+'static,
     P: ExchangeData,
+    V: Clone + 'static,
+    I: Fn(Tr::Val<'_>) -> V + 'static,
 {
     crate::operators::lookup_map(
         prefixes,
         arrangement,
         move |p: &P, k: &mut Tr::KeyOwned | { *k = key_selector(p); },
-        |prefix, diff, value, sum| ((prefix.clone(), value.into_owned()), diff.clone().multiply(sum)),
+        move |prefix, diff, value, sum| ((prefix.clone(), into(value)), diff.clone().multiply(sum)),
         Default::default(),
         Default::default(),
         Default::default(),
@@ -43,11 +45,12 @@ where
 /// Unlike `propose`, this method does not scale the multiplicity of matched
 /// prefixes by the number of matches in `arrangement`. This can be useful to
 /// avoid the need to prepare an arrangement of distinct extensions.
-pub fn propose_distinct<G, Tr, F, P>(
+pub fn propose_distinct<G, Tr, F, P, V, I>(
     prefixes: &Collection<G, P, Tr::Diff>,
     arrangement: Arranged<G, Tr>,
     key_selector: F,
-) -> Collection<G, (P, Tr::ValOwned), Tr::Diff>
+    into: I,
+) -> Collection<G, (P, V), Tr::Diff>
 where
     G: Scope<Timestamp=Tr::Time>,
     Tr: TraceReader+Clone+'static,
@@ -55,12 +58,14 @@ where
     Tr::Diff: Monoid+Multiply<Output = Tr::Diff>+ExchangeData,
     F: Fn(&P)->Tr::KeyOwned+Clone+'static,
     P: ExchangeData,
+    V: Clone + 'static,
+    I: Fn(Tr::Val<'_>) -> V + 'static,
 {
     crate::operators::lookup_map(
         prefixes,
         arrangement,
         move |p: &P, k: &mut Tr::KeyOwned| { *k = key_selector(p); },
-        |prefix, diff, value, _sum| ((prefix.clone(), value.into_owned()), diff.clone()),
+        move |prefix, diff, value, _sum| ((prefix.clone(), into(value)), diff.clone()),
         Default::default(),
         Default::default(),
         Default::default(),

--- a/dogsdogsdogs/src/operators/validate.rs
+++ b/dogsdogsdogs/src/operators/validate.rs
@@ -19,7 +19,7 @@ pub fn validate<G, K, V, Tr, F, P>(
 ) -> Collection<G, (P, V), Tr::Diff>
 where
     G: Scope<Timestamp=Tr::Time>,
-    Tr: TraceReader<KeyOwned=(K,V), ValOwned=()>+Clone+'static,
+    Tr: TraceReader<KeyOwned=(K,V)>+Clone+'static,
     K: Ord+Hash+Clone+Default,
     V: ExchangeData+Hash+Default,
     Tr::Diff: Monoid+Multiply<Output = Tr::Diff>+ExchangeData,

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -31,7 +31,6 @@
 //! Final graph: {(2, 1): 1, (3, 2): 1, (3, 4): 1, (4, 3): 1}
 //! ```
 
-use std::fmt::Debug;
 use std::collections::BTreeMap;
 
 use timely::dataflow::operators::probe::Handle;
@@ -77,7 +76,6 @@ fn main() {
                 graph_trace.set_physical_compaction(AntichainRef::new(&[i]));
                 graph_trace.set_logical_compaction(AntichainRef::new(&[i]));
                 worker.step_while(|| probe.less_than(&i));
-                dump_cursor(i, worker.index(), &mut graph_trace);
             }
         } else {
             /* Only worker 0 feeds inputs to the dataflow. */
@@ -92,13 +90,12 @@ fn main() {
                 graph_trace.set_physical_compaction(AntichainRef::new(&[i]));
                 graph_trace.set_logical_compaction(AntichainRef::new(&[i]));
                 worker.step_while(|| probe.less_than(graph.time()));
-                dump_cursor(i, worker.index(), &mut graph_trace);
             }
         }
 
         /* Return trace content after the last round. */
         let (mut cursor, storage) = graph_trace.cursor();
-        cursor.to_vec(&storage)
+        cursor.to_vec(|v| v.clone(), &storage)
     })
     .unwrap().join();
 
@@ -127,18 +124,4 @@ fn main() {
     }
     expected_graph_content.insert((rounds, rounds+1), 1);
     assert_eq!(graph_content, expected_graph_content);
-}
-
-fn dump_cursor<Tr>(round: u32, index: usize, trace: &mut Tr)
-where
-    Tr: TraceReader,
-    Tr::KeyOwned: Debug,
-    Tr::ValOwned: Debug,
-    Tr::Time: Debug,
-    Tr::Diff: Debug,
-{
-    let (mut cursor, storage) = trace.cursor();
-    for ((k, v), diffs) in cursor.to_vec(&storage).iter() {
-        println!("round {}, w{} {:?}:{:?}: {:?}", round, index, *k, *v, diffs);
-    }
 }

--- a/examples/cursors.rs
+++ b/examples/cursors.rs
@@ -95,7 +95,7 @@ fn main() {
 
         /* Return trace content after the last round. */
         let (mut cursor, storage) = graph_trace.cursor();
-        cursor.to_vec(|v| v.clone(), &storage)
+        cursor.to_vec(Clone::clone, &storage)
     })
     .unwrap().join();
 

--- a/examples/monoid-bfs.rs
+++ b/examples/monoid-bfs.rs
@@ -145,7 +145,7 @@ where G::Timestamp: Lattice+Ord {
             .join_map(&edges, |_k,&(),d| *d)
             .concat(&roots)
             .map(|x| (x,()))
-            .reduce_core::<_,KeySpine<_,_,_>>("Reduce", |_key, input, output, updates| {
+            .reduce_core::<_,_,KeySpine<_,_,_>>("Reduce", |v| v.clone(), |_key, input, output, updates| {
                 if output.is_empty() || input[0].1 < output[0].1 {
                     updates.push(((), input[0].1));
                 }

--- a/examples/monoid-bfs.rs
+++ b/examples/monoid-bfs.rs
@@ -145,7 +145,7 @@ where G::Timestamp: Lattice+Ord {
             .join_map(&edges, |_k,&(),d| *d)
             .concat(&roots)
             .map(|x| (x,()))
-            .reduce_core::<_,_,KeySpine<_,_,_>>("Reduce", |v| v.clone(), |_key, input, output, updates| {
+            .reduce_core::<_,_,KeySpine<_,_,_>>("Reduce", Clone::clone, |_key, input, output, updates| {
                 if output.is_empty() || input[0].1 < output[0].1 {
                     updates.push(((), input[0].1));
                 }

--- a/examples/spines.rs
+++ b/examples/spines.rs
@@ -55,11 +55,11 @@ fn main() {
                     let data =
                     data.map(|x| (x.clone().into_bytes(), x.into_bytes()))
                         .arrange::<PreferredSpine<[u8],[u8],_,_>>()
-                        .reduce_abelian::<_, PreferredSpine<[u8],(),_,_>>("distinct", |_,_,output| output.push(((), 1)));
+                        .reduce_abelian::<_, _, _, PreferredSpine<[u8],(),_,_>>("distinct", |v| v.clone(), |_,_,output| output.push(((), 1)));
                     let keys =
                     keys.map(|x| (x.clone().into_bytes(), 7))
                         .arrange::<PreferredSpine<[u8],u8,_,_>>()
-                        .reduce_abelian::<_, PreferredSpine<[u8],(),_,_>>("distinct", |_,_,output| output.push(((), 1)));
+                        .reduce_abelian::<_, _, _, PreferredSpine<[u8],(),_,_>>("distinct", |v| v.clone(), |_,_,output| output.push(((), 1)));
 
                     keys.join_core(&data, |k,_v1,_v2| {
                         println!("{:?}", k.text);

--- a/src/algorithms/graphs/propagate.rs
+++ b/src/algorithms/graphs/propagate.rs
@@ -96,7 +96,7 @@ where
         let labels =
         proposals
             .concat(&nodes)
-            .reduce_abelian::<_,ValSpine<_,_,_,_>>("Propagate", |_, s, t| t.push((s[0].0.clone(), R::from(1_i8))));
+            .reduce_abelian::<_,_,ValSpine<_,_,_,_>>("Propagate", |v| v.clone(), |_, s, t| t.push((s[0].0.clone(), R::from(1_i8))));
 
         let propagate: Collection<_, (N, L), R> =
         labels

--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -46,7 +46,6 @@ where
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type ValOwned = Tr::ValOwned;
     type Time = Tr::Time;
     type Diff = Tr::Diff;
 

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -51,7 +51,7 @@ where
     /// As `consolidate` but with the ability to name the operator and specify the trace type.
     pub fn consolidate_named<Tr>(&self, name: &str) -> Self
     where
-        Tr: crate::trace::Trace<KeyOwned = D,ValOwned = (),Time=G::Timestamp,Diff=R>+'static,
+        Tr: crate::trace::Trace<KeyOwned = D,Time=G::Timestamp,Diff=R>+'static,
         Tr::Batch: crate::trace::Batch,
         Tr::Batcher: Batcher<Input=Vec<((D,()),G::Timestamp,R)>>,
     {

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -87,7 +87,7 @@ where
 {
     fn reduce_named<L, V2: Data, R2: Abelian>(&self, name: &str, logic: L) -> Collection<G, (K, V2), R2>
         where L: FnMut(&K, &[(&V, R)], &mut Vec<(V2, R2)>)+'static {
-        self.reduce_abelian::<_,ValSpine<_,_,_,_>>(name, logic)
+        self.reduce_abelian::<_,V2,_,ValSpine<_,_,_,_>>(name, |val| val.clone(), logic)
             .as_collection(|k,v| (k.clone(), v.clone()))
     }
 }
@@ -163,7 +163,7 @@ where
     T1: for<'a> TraceReader<Key<'a>=&'a K, KeyOwned=K, Val<'a>=&'a (), Diff=R1>+Clone+'static,
 {
     fn threshold_named<R2: Abelian, F: FnMut(&K,&R1)->R2+'static>(&self, name: &str, mut thresh: F) -> Collection<G, K, R2> {
-        self.reduce_abelian::<_,KeySpine<_,_,_>>(name, move |k,s,t| t.push(((), thresh(k, &s[0].1))))
+        self.reduce_abelian::<_,(),_,KeySpine<_,_,_>>(name, |_| (), move |k,s,t| t.push(((), thresh(k, &s[0].1))))
             .as_collection(|k,_| k.clone())
     }
 }
@@ -213,13 +213,13 @@ where
     T1: for<'a> TraceReader<Key<'a>=&'a K, KeyOwned=K, Val<'a>=&'a (), Diff=R>+Clone+'static,
 {
     fn count_core<R2: Abelian + From<i8>>(&self) -> Collection<G, (K, R), R2> {
-        self.reduce_abelian::<_,ValSpine<_,_,_,_>>("Count", |_k,s,t| t.push((s[0].1.clone(), R2::from(1i8))))
+        self.reduce_abelian::<_,R,_,ValSpine<_,_,_,_>>("Count", |r| r.clone(), |_k,s,t| t.push((s[0].1.clone(), R2::from(1i8))))
             .as_collection(|k,c| (k.clone(), c.clone()))
     }
 }
 
 /// Extension trait for the `reduce_core` differential dataflow method.
-pub trait ReduceCore<G: Scope, K: ToOwned + ?Sized, V: ToOwned + ?Sized, R: Semigroup> where G::Timestamp: Lattice+Ord {
+pub trait ReduceCore<G: Scope, K: ToOwned + ?Sized, V, R: Semigroup> where G::Timestamp: Lattice+Ord {
     /// Applies `reduce` to arranged data, and returns an arrangement of output data.
     ///
     /// This method is used by the more ergonomic `reduce`, `distinct`, and `count` methods, although
@@ -238,23 +238,25 @@ pub trait ReduceCore<G: Scope, K: ToOwned + ?Sized, V: ToOwned + ?Sized, R: Semi
     ///     let trace =
     ///     scope.new_collection_from(1 .. 10u32).1
     ///          .map(|x| (x, x))
-    ///          .reduce_abelian::<_,ValSpine<_,_,_,_>>(
+    ///          .reduce_abelian::<_,_,ValSpine<_,_,_,_>>(
     ///             "Example",
+    ///              |v| v.clone(), 
     ///              move |_key, src, dst| dst.push((*src[0].0, 1))
     ///          )
     ///          .trace;
     /// });
     /// ```
-    fn reduce_abelian<L, T2>(&self, name: &str, mut logic: L) -> Arranged<G, TraceAgent<T2>>
+    fn reduce_abelian<L, F, T2>(&self, name: &str, from: F, mut logic: L) -> Arranged<G, TraceAgent<T2>>
         where
             T2: for<'a> Trace<Key<'a>= &'a K, Time=G::Timestamp>+'static,
-            T2::ValOwned: Data,
+            V: Data,
+            F: Fn(T2::Val<'_>) -> V + 'static,
             T2::Diff: Abelian,
             T2::Batch: Batch,
-            T2::Builder: Builder<Input = ((K::Owned, T2::ValOwned), T2::Time, T2::Diff)>,
-            L: FnMut(&K, &[(&V, R)], &mut Vec<(<T2::Cursor as Cursor>::ValOwned, T2::Diff)>)+'static,
+            T2::Builder: Builder<Input = ((K::Owned, V), T2::Time, T2::Diff)>,
+            L: FnMut(&K, &[(&V, R)], &mut Vec<(V, T2::Diff)>)+'static,
         {
-            self.reduce_core::<_,T2>(name, move |key, input, output, change| {
+            self.reduce_core::<_,_,T2>(name, from, move |key, input, output, change| {
                 if !input.is_empty() {
                     logic(key, input, change);
                 }
@@ -268,13 +270,14 @@ pub trait ReduceCore<G: Scope, K: ToOwned + ?Sized, V: ToOwned + ?Sized, R: Semi
     /// Unlike `reduce_arranged`, this method may be called with an empty `input`,
     /// and it may not be safe to index into the first element.
     /// At least one of the two collections will be non-empty.
-    fn reduce_core<L, T2>(&self, name: &str, logic: L) -> Arranged<G, TraceAgent<T2>>
+    fn reduce_core<L, F, T2>(&self, name: &str, from: F, logic: L) -> Arranged<G, TraceAgent<T2>>
         where
             T2: for<'a> Trace<Key<'a>=&'a K, Time=G::Timestamp>+'static,
-            T2::ValOwned: Data,
+            V: Data,
+            F: Fn(T2::Val<'_>) -> V + 'static,
             T2::Batch: Batch,
-            T2::Builder: Builder<Input = ((K::Owned, T2::ValOwned), T2::Time, T2::Diff)>,
-            L: FnMut(&K, &[(&V, R)], &mut Vec<(<T2::Cursor as Cursor>::ValOwned,T2::Diff)>, &mut Vec<(<T2::Cursor as Cursor>::ValOwned, T2::Diff)>)+'static,
+            T2::Builder: Builder<Input = ((K::Owned, V), T2::Time, T2::Diff)>,
+            L: FnMut(&K, &[(&V, R)], &mut Vec<(V,T2::Diff)>, &mut Vec<(V, T2::Diff)>)+'static,
             ;
 }
 
@@ -283,35 +286,36 @@ where
     G: Scope,
     G::Timestamp: Lattice+Ord,
     K: ExchangeData+Hashable,
-    K: ToOwned<Owned = K>,
     V: ExchangeData,
     R: ExchangeData+Semigroup,
 {
-    fn reduce_core<L, T2>(&self, name: &str, logic: L) -> Arranged<G, TraceAgent<T2>>
+    fn reduce_core<L, F, T2>(&self, name: &str, from: F, logic: L) -> Arranged<G, TraceAgent<T2>>
         where
-            T2::ValOwned: Data,
+            V: Data,
+            F: Fn(T2::Val<'_>) -> V + 'static,
             T2: for<'a> Trace<Key<'a>=&'a K, Time=G::Timestamp>+'static,
             T2::Batch: Batch,
-            T2::Builder: Builder<Input = ((K::Owned, T2::ValOwned), T2::Time, T2::Diff)>,
-            L: FnMut(&K, &[(&V, R)], &mut Vec<(<T2::Cursor as Cursor>::ValOwned,T2::Diff)>, &mut Vec<(<T2::Cursor as Cursor>::ValOwned, T2::Diff)>)+'static,
+            T2::Builder: Builder<Input = ((K, V), T2::Time, T2::Diff)>,
+            L: FnMut(&K, &[(&V, R)], &mut Vec<(V,T2::Diff)>, &mut Vec<(V, T2::Diff)>)+'static,
     {
         self.arrange_by_key_named(&format!("Arrange: {}", name))
-            .reduce_core(name, logic)
+            .reduce_core(name, from, logic)
     }
 }
 
 /// A key-wise reduction of values in an input trace.
 ///
 /// This method exists to provide reduce functionality without opinions about qualifying trace types.
-pub fn reduce_trace<G, T1, T2, L>(trace: &Arranged<G, T1>, name: &str, mut logic: L) -> Arranged<G, TraceAgent<T2>>
+pub fn reduce_trace<G, T1, T2, V, F, L>(trace: &Arranged<G, T1>, name: &str, from: F, mut logic: L) -> Arranged<G, TraceAgent<T2>>
 where
     G: Scope<Timestamp=T1::Time>,
     T1: TraceReader + Clone + 'static,
     T2: for<'a> Trace<Key<'a>=T1::Key<'a>, Time=T1::Time> + 'static,
-    T2::ValOwned: Data,
+    V: Data,
+    F: Fn(T2::Val<'_>) -> V + 'static,
     T2::Batch: Batch,
-    T2::Builder: Builder<Input = ((T1::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
-    L: FnMut(T1::Key<'_>, &[(T1::Val<'_>, T1::Diff)], &mut Vec<(T2::ValOwned,T2::Diff)>, &mut Vec<(T2::ValOwned, T2::Diff)>)+'static,
+    T2::Builder: Builder<Input = ((T1::KeyOwned, V), T2::Time, T2::Diff)>,
+    L: FnMut(T1::Key<'_>, &[(T1::Val<'_>, T1::Diff)], &mut Vec<(V,T2::Diff)>, &mut Vec<(V, T2::Diff)>)+'static,
 {
     let mut result_trace = None;
 
@@ -445,7 +449,7 @@ where
                         //
                         // TODO: It would be better if all updates went into one batch, but timely dataflow prevents
                         //       this as long as it requires that there is only one capability for each message.
-                        let mut buffers = Vec::<(G::Timestamp, Vec<(<T2::Cursor as Cursor>::ValOwned, G::Timestamp, T2::Diff)>)>::new();
+                        let mut buffers = Vec::<(G::Timestamp, Vec<(V, G::Timestamp, T2::Diff)>)>::new();
                         let mut builders = Vec::new();
                         for cap in capabilities.iter() {
                             buffers.push((cap.time().clone(), Vec::new()));
@@ -472,7 +476,7 @@ where
 
                             use std::borrow::Borrow;
                             use crate::trace::cursor::MyTrait;
-                            
+
                             // Determine the next key we will work on; could be synthetic, could be from a batch.
                             let key1 = exposed.get(exposed_position).map(|x| <_ as MyTrait>::borrow_as(&x.0));
                             let key2 = batch_cursor.get_key(batch_storage);
@@ -505,6 +509,7 @@ where
                                 (&mut output_cursor, output_storage),
                                 (&mut batch_cursor, batch_storage),
                                 &mut interesting_times,
+                                &|v| from(v),
                                 &mut logic,
                                 &upper_limit,
                                 &mut buffers[..],
@@ -622,30 +627,33 @@ fn sort_dedup<T: Ord>(list: &mut Vec<T>) {
     list.dedup();
 }
 
-trait PerKeyCompute<'a, C1, C2, C3>
+trait PerKeyCompute<'a, C1, C2, C3, V>
 where
     C1: Cursor,
     C2: Cursor<Key<'a> = C1::Key<'a>, Time = C1::Time>,
     C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, Time = C1::Time, Diff = C1::Diff>,
+    V: Clone + Ord,
 {
     fn new() -> Self;
-    fn compute<L>(
+    fn compute<F, L>(
         &mut self,
         key: C1::Key<'a>,
         source_cursor: (&mut C1, &'a C1::Storage),
         output_cursor: (&mut C2, &'a C2::Storage),
         batch_cursor: (&mut C3, &'a C3::Storage),
         times: &mut Vec<C1::Time>,
+        from: &F,
         logic: &mut L,
         upper_limit: &Antichain<C1::Time>,
-        outputs: &mut [(C2::Time, Vec<(C2::ValOwned, C2::Time, C2::Diff)>)],
+        outputs: &mut [(C2::Time, Vec<(V, C2::Time, C2::Diff)>)],
         new_interesting: &mut Vec<C1::Time>) -> (usize, usize)
     where
+        F: Fn(C2::Val<'_>) -> V,
         L: FnMut(
             C1::Key<'a>, 
             &[(C1::Val<'a>, C1::Diff)],
-            &mut Vec<(C2::ValOwned, C2::Diff)>,
-            &mut Vec<(C2::ValOwned, C2::Diff)>,
+            &mut Vec<(V, C2::Diff)>,
+            &mut Vec<(V, C2::Diff)>,
         );
 }
 
@@ -664,30 +672,32 @@ mod history_replay {
 
     /// The `HistoryReplayer` is a compute strategy based on moving through existing inputs, interesting times, etc in
     /// time order, maintaining consolidated representations of updates with respect to future interesting times.
-    pub struct HistoryReplayer<'a, C1, C2, C3>
+    pub struct HistoryReplayer<'a, C1, C2, C3, V>
     where
         C1: Cursor,
         C2: Cursor<Key<'a> = C1::Key<'a>, Time = C1::Time>,
         C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, Time = C1::Time, Diff = C1::Diff>,
+        V: Clone + Ord,
     {
         input_history: ValueHistory<'a, C1>,
         output_history: ValueHistory<'a, C2>,
         batch_history: ValueHistory<'a, C3>,
         input_buffer: Vec<(C1::Val<'a>, C1::Diff)>,
-        output_buffer: Vec<(C2::ValOwned, C2::Diff)>,
-        update_buffer: Vec<(C2::ValOwned, C2::Diff)>,
-        output_produced: Vec<((C2::ValOwned, C2::Time), C2::Diff)>,
+        output_buffer: Vec<(V, C2::Diff)>,
+        update_buffer: Vec<(V, C2::Diff)>,
+        output_produced: Vec<((V, C2::Time), C2::Diff)>,
         synth_times: Vec<C1::Time>,
         meets: Vec<C1::Time>,
         times_current: Vec<C1::Time>,
         temporary: Vec<C1::Time>,
     }
 
-    impl<'a, C1, C2, C3> PerKeyCompute<'a, C1, C2, C3> for HistoryReplayer<'a, C1, C2, C3>
+    impl<'a, C1, C2, C3, V> PerKeyCompute<'a, C1, C2, C3, V> for HistoryReplayer<'a, C1, C2, C3, V>
     where
         C1: Cursor,
         C2: Cursor<Key<'a> = C1::Key<'a>, Time = C1::Time>,
         C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, Time = C1::Time, Diff = C1::Diff>,
+        V: Clone + Ord,
     {
         fn new() -> Self {
             HistoryReplayer {
@@ -705,23 +715,25 @@ mod history_replay {
             }
         }
         #[inline(never)]
-        fn compute<L>(
+        fn compute<F, L>(
             &mut self,
             key: C1::Key<'a>,
             (source_cursor, source_storage): (&mut C1, &'a C1::Storage),
             (output_cursor, output_storage): (&mut C2, &'a C2::Storage),
             (batch_cursor, batch_storage): (&mut C3, &'a C3::Storage),
             times: &mut Vec<C1::Time>,
+            from: &F,
             logic: &mut L,
             upper_limit: &Antichain<C1::Time>,
-            outputs: &mut [(C2::Time, Vec<(C2::ValOwned, C2::Time, C2::Diff)>)],
+            outputs: &mut [(C2::Time, Vec<(V, C2::Time, C2::Diff)>)],
             new_interesting: &mut Vec<C1::Time>) -> (usize, usize)
         where
+            F: Fn(C2::Val<'_>) -> V,
             L: FnMut(
                 C1::Key<'a>, 
                 &[(C1::Val<'a>, C1::Diff)],
-                &mut Vec<(C2::ValOwned, C2::Diff)>,
-                &mut Vec<(C2::ValOwned, C2::Diff)>,
+                &mut Vec<(V, C2::Diff)>,
+                &mut Vec<(V, C2::Diff)>,
             )
         {
 
@@ -884,8 +896,7 @@ mod history_replay {
                         meet.as_ref().map(|meet| output_replay.advance_buffer_by(meet));
                         for &((value, ref time), ref diff) in output_replay.buffer().iter() {
                             if time.less_equal(&next_time) {
-                                use crate::trace::cursor::MyTrait;
-                                self.output_buffer.push((<_ as MyTrait>::into_owned(value), diff.clone()));
+                                self.output_buffer.push((from(value), diff.clone()));
                             }
                             else {
                                 self.temporary.push(next_time.join(time));

--- a/src/trace/cursor/cursor_list.rs
+++ b/src/trace/cursor/cursor_list.rs
@@ -88,7 +88,6 @@ impl<C: Cursor> Cursor for CursorList<C> {
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type ValOwned = C::ValOwned;
     type Time = C::Time;
     type Diff = C::Diff;
 

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -119,9 +119,9 @@ pub trait Cursor {
     fn rewind_vals(&mut self, storage: &Self::Storage);
 
     /// Rewinds the cursor and outputs its contents to a Vec
-    fn to_vec<V, I>(&mut self, into: I, storage: &Self::Storage) -> Vec<((Self::KeyOwned, V), Vec<(Self::Time, Self::Diff)>)>
+    fn to_vec<V, F>(&mut self, from: F, storage: &Self::Storage) -> Vec<((Self::KeyOwned, V), Vec<(Self::Time, Self::Diff)>)>
     where 
-        I: Fn(Self::Val<'_>) -> V,
+        F: Fn(Self::Val<'_>) -> V,
     {
         let mut out = Vec::new();
         self.rewind_keys(storage);
@@ -132,7 +132,7 @@ pub trait Cursor {
                 self.map_times(storage, |ts, r| {
                     kv_out.push((ts.clone(), r.clone()));
                 });
-                out.push(((self.key(storage).into_owned(), into(self.val(storage))), kv_out));
+                out.push(((self.key(storage).into_owned(), from(self.val(storage))), kv_out));
                 self.step_val(storage);
             }
             self.step_key(storage);

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -63,9 +63,7 @@ pub trait Cursor {
     /// Owned version of the above.
     type KeyOwned: Ord + Clone;
     /// Values associated with keys.
-    type Val<'a>: Copy + Clone + MyTrait<'a, Owned = Self::ValOwned> + for<'b> PartialOrd<Self::Val<'b>>;
-    /// Owned version of the above.
-    type ValOwned: Ord + Clone;
+    type Val<'a>: Copy + Clone + MyTrait<'a> + for<'b> PartialOrd<Self::Val<'b>>;
     /// Timestamps associated with updates
     type Time: Timestamp + Lattice + Ord + Clone;
     /// Associated update.
@@ -121,7 +119,10 @@ pub trait Cursor {
     fn rewind_vals(&mut self, storage: &Self::Storage);
 
     /// Rewinds the cursor and outputs its contents to a Vec
-    fn to_vec(&mut self, storage: &Self::Storage) -> Vec<((Self::KeyOwned, Self::ValOwned), Vec<(Self::Time, Self::Diff)>)> {
+    fn to_vec<V, I>(&mut self, into: I, storage: &Self::Storage) -> Vec<((Self::KeyOwned, V), Vec<(Self::Time, Self::Diff)>)>
+    where 
+        I: Fn(Self::Val<'_>) -> V,
+    {
         let mut out = Vec::new();
         self.rewind_keys(storage);
         self.rewind_vals(storage);
@@ -131,7 +132,7 @@ pub trait Cursor {
                 self.map_times(storage, |ts, r| {
                     kv_out.push((ts.clone(), r.clone()));
                 });
-                out.push(((self.key(storage).into_owned(), self.val(storage).into_owned()), kv_out));
+                out.push(((self.key(storage).into_owned(), into(self.val(storage))), kv_out));
                 self.step_val(storage);
             }
             self.step_key(storage);

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -140,7 +140,6 @@ mod val_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
-        type ValOwned = <L::Target as Update>::Val;
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 
@@ -447,7 +446,6 @@ mod val_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
-        type ValOwned = <L::Target as Update>::Val;
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 
@@ -700,7 +698,6 @@ mod key_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = &'a ();
-        type ValOwned = ();
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 
@@ -918,7 +915,6 @@ mod key_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = &'a ();
-        type ValOwned = ();
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -256,7 +256,6 @@ mod val_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
-        type ValOwned = <L::Target as Update>::Val;
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 
@@ -608,7 +607,6 @@ mod val_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
-        type ValOwned = <L::Target as Update>::Val;
         type Time = <L::Target as Update>::Time;
         type Diff = <L::Target as Update>::Diff;
 

--- a/src/trace/implementations/spine_fueled.rs
+++ b/src/trace/implementations/spine_fueled.rs
@@ -112,7 +112,6 @@ where
     type Key<'a> = B::Key<'a>;
     type KeyOwned = B::KeyOwned;
     type Val<'a> = B::Val<'a>;
-    type ValOwned = B::ValOwned;
     type Time = B::Time;
     type Diff = B::Diff;
 

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -56,22 +56,20 @@ pub trait TraceReader {
     /// Owned version of the above.
     type KeyOwned: Ord + Clone;
     /// Values associated with keys.
-    type Val<'a>: Copy + Clone + MyTrait<'a, Owned = Self::ValOwned>;
-    /// Owned version of the above.
-    type ValOwned: Ord + Clone;
+    type Val<'a>: Copy + Clone + MyTrait<'a>;
     /// Timestamps associated with updates
     type Time: Timestamp + Lattice + Ord + Clone;
     /// Associated update.
     type Diff: Semigroup;
 
     /// The type of an immutable collection of updates.
-    type Batch: for<'a> BatchReader<Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, ValOwned = Self::ValOwned, Time = Self::Time, Diff = Self::Diff>+Clone+'static;
+    type Batch: for<'a> BatchReader<Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, Time = Self::Time, Diff = Self::Diff>+Clone+'static;
 
     /// Storage type for `Self::Cursor`. Likely related to `Self::Batch`.
     type Storage;
 
     /// The type used to enumerate the collections contents.
-    type Cursor: for<'a> Cursor<Storage=Self::Storage, Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, ValOwned = Self::ValOwned, Time = Self::Time, Diff = Self::Diff>;
+    type Cursor: for<'a> Cursor<Storage=Self::Storage, Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, Time = Self::Time, Diff = Self::Diff>;
 
     /// Provides a cursor over updates contained in the trace.
     fn cursor(&mut self) -> (Self::Cursor, Self::Storage) {
@@ -264,16 +262,14 @@ where
     /// Owned version of the above.
     type KeyOwned: Ord + Clone;
     /// Values associated with keys.
-    type Val<'a>: Copy + Clone + MyTrait<'a, Owned = Self::ValOwned>;
-    /// Owned version of the above.
-    type ValOwned: Ord + Clone;
+    type Val<'a>: Copy + Clone + MyTrait<'a>;
     /// Timestamps associated with updates
     type Time: Timestamp + Lattice + Ord + Clone;
     /// Associated update.
     type Diff: Semigroup;
 
     /// The type used to enumerate the batch's contents.
-    type Cursor: for<'a> Cursor<Storage=Self, Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, ValOwned = Self::ValOwned, Time = Self::Time, Diff = Self::Diff>;
+    type Cursor: for<'a> Cursor<Storage=Self, Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, Time = Self::Time, Diff = Self::Diff>;
     /// Acquires a cursor to the batch's contents.
     fn cursor(&self) -> Self::Cursor;
     /// The number of updates in the batch.
@@ -384,7 +380,6 @@ pub mod rc_blanket_impls {
         type Key<'a> = B::Key<'a>;
         type KeyOwned = B::KeyOwned;
         type Val<'a> = B::Val<'a>;
-        type ValOwned = B::ValOwned;
         type Time = B::Time;
         type Diff = B::Diff;
 
@@ -419,7 +414,6 @@ pub mod rc_blanket_impls {
         type Key<'a> = C::Key<'a>;
         type KeyOwned = C::KeyOwned;
         type Val<'a> = C::Val<'a>;
-        type ValOwned = C::ValOwned;
         type Time = C::Time;
         type Diff = C::Diff;
 
@@ -490,7 +484,6 @@ pub mod abomonated_blanket_impls {
         type Key<'a> = B::Key<'a>;
         type KeyOwned = B::KeyOwned;
         type Val<'a> = B::Val<'a>;
-        type ValOwned = B::ValOwned;
         type Time = B::Time;
         type Diff = B::Diff;
 
@@ -525,7 +518,6 @@ pub mod abomonated_blanket_impls {
         type Key<'a> = C::Key<'a>;
         type KeyOwned = C::KeyOwned;
         type Val<'a> = C::Val<'a>;
-        type ValOwned = C::ValOwned;
         type Time = C::Time;
         type Diff = C::Diff;
 

--- a/src/trace/wrappers/enter.rs
+++ b/src/trace/wrappers/enter.rs
@@ -34,7 +34,6 @@ where
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type ValOwned = Tr::ValOwned;
     type Time = TInner;
     type Diff = Tr::Diff;
 
@@ -118,7 +117,6 @@ where
     type Key<'a> = B::Key<'a>;
     type KeyOwned = B::KeyOwned;
     type Val<'a> = B::Val<'a>;
-    type ValOwned = B::ValOwned;
     type Time = TInner;
     type Diff = B::Diff;
 
@@ -172,7 +170,6 @@ where
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type ValOwned = C::ValOwned;
     type Time = TInner;
     type Diff = C::Diff;
 
@@ -225,7 +222,6 @@ where
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type ValOwned = C::ValOwned;
     type Time = TInner;
     type Diff = C::Diff;
 

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -52,7 +52,6 @@ where
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type ValOwned = Tr::ValOwned;
     type Time = TInner;
     type Diff = Tr::Diff;
 
@@ -141,7 +140,6 @@ where
     type Key<'a> = B::Key<'a>;
     type KeyOwned = B::KeyOwned;
     type Val<'a> = B::Val<'a>;
-    type ValOwned = B::ValOwned;
     type Time = TInner;
     type Diff = B::Diff;
 
@@ -199,7 +197,6 @@ where
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type ValOwned = C::ValOwned;
     type Time = TInner;
     type Diff = C::Diff;
 
@@ -258,7 +255,6 @@ where
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type ValOwned = C::ValOwned;
     type Time = TInner;
     type Diff = C::Diff;
 

--- a/src/trace/wrappers/filter.rs
+++ b/src/trace/wrappers/filter.rs
@@ -33,7 +33,6 @@ where
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type ValOwned = Tr::ValOwned;
     type Time = Tr::Time;
     type Diff = Tr::Diff;
 
@@ -87,7 +86,6 @@ where
     type Key<'a> = B::Key<'a>;
     type KeyOwned = B::KeyOwned;
     type Val<'a> = B::Val<'a>;
-    type ValOwned = B::ValOwned;
     type Time = B::Time;
     type Diff = B::Diff;
 
@@ -136,7 +134,6 @@ where
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type ValOwned = C::ValOwned;
     type Time = C::Time;
     type Diff = C::Diff;
 
@@ -191,7 +188,6 @@ where
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type ValOwned = C::ValOwned;
     type Time = C::Time;
     type Diff = C::Diff;
 

--- a/src/trace/wrappers/freeze.rs
+++ b/src/trace/wrappers/freeze.rs
@@ -78,7 +78,6 @@ where
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type ValOwned = Tr::ValOwned;
     type Time = Tr::Time;
     type Diff = Tr::Diff;
 
@@ -142,7 +141,6 @@ where
     type Key<'a> = B::Key<'a>;
     type KeyOwned = B::KeyOwned;
     type Val<'a> = B::Val<'a>;
-    type ValOwned = B::ValOwned;
     type Time = B::Time;
     type Diff = B::Diff;
 
@@ -186,7 +184,6 @@ where
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type ValOwned = C::ValOwned;
     type Time = C::Time;
     type Diff = C::Diff;
 
@@ -238,7 +235,6 @@ where
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type ValOwned = C::ValOwned;
     type Time = C::Time;
     type Diff = C::Diff;
 

--- a/src/trace/wrappers/frontier.rs
+++ b/src/trace/wrappers/frontier.rs
@@ -35,7 +35,6 @@ impl<Tr: TraceReader> TraceReader for TraceFrontier<Tr> {
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type ValOwned = Tr::ValOwned;
     type Time = Tr::Time;
     type Diff = Tr::Diff;
 
@@ -86,7 +85,6 @@ impl<B: BatchReader> BatchReader for BatchFrontier<B> {
     type Key<'a> = B::Key<'a>;
     type KeyOwned = B::KeyOwned;
     type Val<'a> = B::Val<'a>;
-    type ValOwned = B::ValOwned;
     type Time = B::Time;
     type Diff = B::Diff;
 
@@ -131,7 +129,6 @@ impl<C: Cursor> Cursor for CursorFrontier<C, C::Time> {
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type ValOwned = C::ValOwned;
     type Time = C::Time;
     type Diff = C::Diff;
 
@@ -193,7 +190,6 @@ where
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type ValOwned = C::ValOwned;
     type Time = C::Time;
     type Diff = C::Diff;
 

--- a/src/trace/wrappers/rc.rs
+++ b/src/trace/wrappers/rc.rs
@@ -82,7 +82,6 @@ impl<Tr: TraceReader> TraceReader for TraceRc<Tr> {
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type ValOwned = Tr::ValOwned;
     type Time = Tr::Time;
     type Diff = Tr::Diff;
 

--- a/tests/trace.rs
+++ b/tests/trace.rs
@@ -35,11 +35,11 @@ fn test_trace() {
     let mut trace = get_trace();
 
     let (mut cursor1, storage1) = trace.cursor_through(AntichainRef::new(&[1])).unwrap();
-    let vec_1 = cursor1.to_vec(&storage1);
+    let vec_1 = cursor1.to_vec(|v| v.clone(), &storage1);
     assert_eq!(vec_1, vec![((1, 2), vec![(0, 1)])]);
 
     let (mut cursor2, storage2) = trace.cursor_through(AntichainRef::new(&[2])).unwrap();
-    let vec_2 = cursor2.to_vec(&storage2);
+    let vec_2 = cursor2.to_vec(|v| v.clone(), &storage2);
     println!("--> {:?}", vec_2);
     assert_eq!(vec_2, vec![
                ((1, 2), vec![(0, 1)]),
@@ -47,13 +47,13 @@ fn test_trace() {
     ]);
 
     let (mut cursor3, storage3) = trace.cursor_through(AntichainRef::new(&[3])).unwrap();
-    let vec_3 = cursor3.to_vec(&storage3);
+    let vec_3 = cursor3.to_vec(|v| v.clone(), &storage3);
     assert_eq!(vec_3, vec![
                ((1, 2), vec![(0, 1)]),
                ((2, 3), vec![(1, 1), (2, -1)]),
     ]);
 
     let (mut cursor4, storage4) = trace.cursor();
-    let vec_4 = cursor4.to_vec(&storage4);
+    let vec_4 = cursor4.to_vec(|v| v.clone(), &storage4);
     assert_eq!(vec_4, vec_3);
 }


### PR DESCRIPTION
Thought experiment removing `ValOwned` from traces, batches, cursors, etc. It removes any opinions about the owned forms of the value GAT, other than that implied by `MyTrait::Owned` (which .. can vary as a function of the lifetime, and probably isn't load bearing at this point).

The pain here is that you do want some relationship between `V` and `Tr::Val<'a>`. All we seem to need is a function from the latter to the former, although `From` and `Into` do not work because they are not implemented for e.g. `&T` where `T: Clone` which we see a lot. Instead, core methods take a `from: Fn(Tr::Val<'_>) -> V`, which is not the most ergonomic but seemed better than having an ongoing struggle with new traits.