### PR TITLE
Allow joins to produce arbitrary containers

### DIFF
--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -427,6 +427,7 @@ where
     {
         use crate::operators::join::join_traces;
         join_traces(self, other, result)
+            .as_collection()
     }
 }
 


### PR DESCRIPTION
Add a `join_traces_core` function that allows the caller to specify the output stream container type. The existing `join_traces` function forces it to be vectors, by virtue of wrapping the output in a collection.