### PR TITLE
`join_traces` uses timely's container builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,7 @@ timely = {workspace = true}
 
 [workspace.dependencies]
 #timely = { version = "0.12", default-features = false }
-#timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
-timely = { git = "https://github.com/antiguru/timely-dataflow", branch = "container_builder", default-features = false }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
 #timely = { path = "../timely-dataflow/timely/", default-features = false }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,8 @@ timely = {workspace = true}
 
 [workspace.dependencies]
 #timely = { version = "0.12", default-features = false }
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
+#timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
+timely = { git = "https://github.com/antiguru/timely-dataflow", branch = "container_builder", default-features = false }
 #timely = { path = "../timely-dataflow/timely/", default-features = false }
 
 [features]

--- a/examples/spines.rs
+++ b/examples/spines.rs
@@ -55,11 +55,11 @@ fn main() {
                     let data =
                     data.map(|x| (x.clone().into_bytes(), x.into_bytes()))
                         .arrange::<PreferredSpine<[u8],[u8],_,_>>()
-                        .reduce_abelian::<_, _, _, PreferredSpine<[u8],(),_,_>>("distinct", |v| v.clone(), |_,_,output| output.push(((), 1)));
+                        .reduce_abelian::<_, _, _, PreferredSpine<[u8],(),_,_>>("distinct", |_| (), |_,_,output| output.push(((), 1)));
                     let keys =
                     keys.map(|x| (x.clone().into_bytes(), 7))
                         .arrange::<PreferredSpine<[u8],u8,_,_>>()
-                        .reduce_abelian::<_, _, _, PreferredSpine<[u8],(),_,_>>("distinct", |v| v.clone(), |_,_,output| output.push(((), 1)));
+                        .reduce_abelian::<_, _, _, PreferredSpine<[u8],(),_,_>>("distinct", |_| (), |_,_,output| output.push(((), 1)));
 
                     keys.join_core(&data, |k,_v1,_v2| {
                         println!("{:?}", k.text);

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,7 +10,7 @@ path="../"
 [dependencies]
 rand="0.3.13"
 libloading="*"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
+timely = { workspace = true }
 
 #[workspace]
 #members = [

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -399,7 +399,7 @@ pub mod source {
                     for message in source.by_ref() {
                         match message {
                             Message::Updates(mut updates) => {
-                                updates_session.give_vec(&mut updates);
+                                updates_session.give_container(&mut updates);
                             }
                             Message::Progress(progress) => {
                                 // We must send a copy of each progress message to all workers,

--- a/src/consolidation.rs
+++ b/src/consolidation.rs
@@ -177,11 +177,13 @@ where
         }
     }
 
-    fn extract(&mut self) -> impl Iterator<Item=Self::Container> {
+    type ExtractIter<'a> = std::vec::Drain<'a, Vec<(D,T,R)>>;
+    fn extract(&mut self) -> Self::ExtractIter<'_> {
         self.pending.drain(..)
     }
 
-    fn finish(&mut self) -> impl Iterator<Item=Self::Container> {
+    type FinishIter<'a> = std::vec::Drain<'a, Vec<(D,T,R)>>;
+    fn finish(&mut self) -> Self::FinishIter<'_> {
         let preferred_capacity = timely::container::buffer::default_capacity::<T>();
         consolidate_updates(&mut self.current);
         while self.current.len() > 0 {

--- a/src/dynamic/mod.rs
+++ b/src/dynamic/mod.rs
@@ -60,7 +60,7 @@ where
                     vec.truncate(level - 1);
                     time.inner = PointStamp::new(vec);
                 }
-                output.session(&new_cap).give_vec(&mut vector);
+                output.session(&new_cap).give_container(&mut vector);
             });
         });
 

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -75,6 +75,8 @@ where
 
 use ::timely::dataflow::scopes::Child;
 use ::timely::progress::timestamp::Refines;
+use timely::container::ContainerBuilder;
+use crate::consolidation::ConsolidatingContainerBuilder;
 
 impl<G, Tr> Arranged<G, Tr>
 where
@@ -264,7 +266,7 @@ where
         L: FnMut(T1::Key<'_>, T1::Val<'_>,T2::Val<'_>,&G::Timestamp,&T1::Diff,&T2::Diff)->I+'static,
     {
         use crate::operators::join::join_traces;
-        join_traces(self, other, move |k, v1, v2, t, d1, d2, c: &mut Vec<(D,G::Timestamp,ROut)>| {
+        join_traces(self, other, move |k, v1, v2, t, d1, d2, c: &mut ConsolidatingContainerBuilder<Vec<(D,G::Timestamp,ROut)>>| {
             for datum in result(k, v1, v2, t, d1, d2) {
                 c.push(datum);
             }

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -75,8 +75,6 @@ where
 
 use ::timely::dataflow::scopes::Child;
 use ::timely::progress::timestamp::Refines;
-use timely::container::ContainerBuilder;
-use crate::consolidation::ConsolidatingContainerBuilder;
 
 impl<G, Tr> Arranged<G, Tr>
 where
@@ -266,11 +264,15 @@ where
         L: FnMut(T1::Key<'_>, T1::Val<'_>,T2::Val<'_>,&G::Timestamp,&T1::Diff,&T2::Diff)->I+'static,
     {
         use crate::operators::join::join_traces;
-        join_traces(self, other, move |k, v1, v2, t, d1, d2, c: &mut ConsolidatingContainerBuilder<Vec<(D,G::Timestamp,ROut)>>| {
-            for datum in result(k, v1, v2, t, d1, d2) {
-                c.push(datum);
+        join_traces::<_, _, _, _, crate::consolidation::ConsolidatingContainerBuilder<_>>(
+            self,
+            other,
+            move |k, v1, v2, t, d1, d2, c| {
+                for datum in result(k, v1, v2, t, d1, d2) {
+                    c.give(datum);
+                }
             }
-        })
+        )
             .as_collection()
     }
 }

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -255,7 +255,7 @@ where
         self.join_core_internal_unsafe(other, result)
     }
     /// A direct implementation of the `JoinCore::join_core_internal_unsafe` method.
-    pub fn join_core_internal_unsafe<T2,I,L,D,ROut> (&self, other: &Arranged<G,T2>, result: L) -> Collection<G,D,ROut>
+    pub fn join_core_internal_unsafe<T2,I,L,D,ROut> (&self, other: &Arranged<G,T2>, mut result: L) -> Collection<G,D,ROut>
     where
         T2: for<'a> TraceReader<Key<'a>=T1::Key<'a>, Time=T1::Time>+Clone+'static,
         D: Data,
@@ -264,7 +264,11 @@ where
         L: FnMut(T1::Key<'_>, T1::Val<'_>,T2::Val<'_>,&G::Timestamp,&T1::Diff,&T2::Diff)->I+'static,
     {
         use crate::operators::join::join_traces;
-        join_traces(self, other, result)
+        join_traces(self, other, move |k, v1, v2, t, d1, d2, c: &mut Vec<(D,G::Timestamp,ROut)>| {
+            for datum in result(k, v1, v2, t, d1, d2) {
+                c.push(datum);
+            }
+        })
             .as_collection()
     }
 }

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -99,7 +99,7 @@ where
                     input.for_each(|time, data| {
                         data.swap(&mut vector);
                         crate::consolidation::consolidate_updates(&mut vector);
-                        output.session(&time).give_vec(&mut vector);
+                        output.session(&time).give_container(&mut vector);
                     })
                 }
             })

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -361,14 +361,13 @@ impl<CB: ContainerBuilder> ContainerBuilder for EffortBuilder<CB> {
 /// even potentially unrelated to the input collection data. Importantly, the key and value types could be generic
 /// associated types (GATs) of the traces, and we would seemingly struggle to frame these types as trait arguments.
 ///
-/// The implementation produces a caller-specified container, with the requirement that the container
-/// can absorb `(D, G::Timestamp, R)` triples. Implementations can use [`AsCollection`] to wrap the
+/// The implementation produces a caller-specified container. Implementations can use [`AsCollection`] to wrap the
 /// output stream in a collection.
 ///
 /// The "correctness" of this method depends heavily on the behavior of the supplied `result` function.
 ///
 /// [`AsCollection`]: crate::collection::AsCollection
-pub fn join_traces<G, T1, T2,L, CB>(arranged1: &Arranged<G,T1>, arranged2: &Arranged<G,T2>, mut result: L) -> StreamCore<G, CB::Container>
+pub fn join_traces<G, T1, T2, L, CB>(arranged1: &Arranged<G,T1>, arranged2: &Arranged<G,T2>, mut result: L) -> StreamCore<G, CB::Container>
 where
     G: Scope<Timestamp=T1::Time>,
     T1: TraceReader+Clone+'static,

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -686,12 +686,8 @@ where
                         logic(key, v1, v2, &t, r1, r2, &mut session);
                     });
 
-                    // TODO: This consolidation is optional, and it may not be very
-                    //       helpful. We might try harder to understand whether we
-                    //       should do this work here, or downstream at consumers.
-                    // TODO: Perhaps `thinker` should have the buffer, do smarter
-                    //       consolidation, and then deposit results in `session`.
-
+                    // TODO: Effort isn't perfectly tracked as we might still have some data in the
+                    // session at the moment it's dropped.
                     effort += session.builder().0.take();
                     batch.step_key(batch_storage);
                     trace.step_key(trace_storage);
@@ -701,7 +697,6 @@ where
                 }
             }
         }
-        effort += session.builder().0.take();
         self.done = !batch.key_valid(batch_storage) || !trace.key_valid(trace_storage);
 
         if effort > *fuel { *fuel = 0; }


### PR DESCRIPTION
Switch `join_traces` to use timely's container builder, and add a container builder that consolidates in-place.