### PR TITLE
Correct defects in getting started

### DIFF
--- a/mdbook/src/chapter_0/chapter_0_0.md
+++ b/mdbook/src/chapter_0/chapter_0_0.md
@@ -25,8 +25,8 @@ version = "0.1.0"
 authors = ["Your Name <your_name@you.ch>"]
 
 [dependencies]
-timely = "0.11.1"
-differential-dataflow = "0.11.0"
+timely = "0.12.0"
+differential-dataflow = "0.12.0"
 ```
 
 You should only need to add those last two lines there, which bring in dependencies on both [timely dataflow](https://github.com/TimelyDataflow/timely-dataflow) and [differential dataflow](https://github.com/TimelyDataflow/differential-dataflow). We will be using both of those.

--- a/mdbook/src/chapter_0/chapter_0_1.md
+++ b/mdbook/src/chapter_0/chapter_0_1.md
@@ -34,8 +34,8 @@ fn main() {
                 .inspect(|x| println!("{:?}", x));
         });
 
-        // Set an arbitrary size for our organization.
-        let size = 100;
+        // Set a size for our organization from the input.
+        let size = std::env::args().nth(1).and_then(|s| s.parse::<u32>().ok()).unwrap_or(10);
 
         // Load input (a binary tree).
         input.advance_to(0);

--- a/mdbook/src/chapter_0/chapter_0_3.md
+++ b/mdbook/src/chapter_0/chapter_0_3.md
@@ -107,7 +107,7 @@ We can then use this probe to limit the introduction of new data, by waiting for
 This starts to print out a mess of data, indicating not only how long it takes to start up the computation, but also how long each individual round of updates takes.
 
 ``` ignore
-    Echidnatron% cargo run --release --example hello 10000000
+    Echidnatron% cargo run --release -- 10000000
         Finished release [optimized + debuginfo] target(s) in 0.06s
          Running `target/release/examples/hello 10000000`
     4.092895186s    data loaded


### PR DESCRIPTION
Issue #483 observed that the quickstart guide results in horrible failure on a modern `rustc`. This is because it pins an old version of the libraries, which the modern `rustc` observes are presently defective. The updated libraries don't have the same complaints, although we have moved even further away from the `unsafe` code they complain about and should further update things once we have a version we'd like to cut.

Other defects observed in the docs, mostly around supplied a `size` argument and calling the right code.

fixes #483 
