### PR TITLE
GAT time and diff

### DIFF
--- a/dogsdogsdogs/src/operators/count.rs
+++ b/dogsdogsdogs/src/operators/count.rs
@@ -18,7 +18,7 @@ pub fn count<G, Tr, R, F, P>(
     index: usize,
 ) -> Collection<G, (P, usize, usize), R>
 where
-    G: Scope<Timestamp=Tr::TimeOwned>,
+    G: Scope<Timestamp=Tr::Time>,
     Tr: TraceReader<DiffOwned=isize>+Clone+'static,
     Tr::KeyOwned: Hashable + Default,
     R: Monoid+Multiply<Output = R>+ExchangeData,

--- a/dogsdogsdogs/src/operators/count.rs
+++ b/dogsdogsdogs/src/operators/count.rs
@@ -18,8 +18,8 @@ pub fn count<G, Tr, R, F, P>(
     index: usize,
 ) -> Collection<G, (P, usize, usize), R>
 where
-    G: Scope<Timestamp=Tr::Time>,
-    Tr: TraceReader<Diff=isize>+Clone+'static,
+    G: Scope<Timestamp=Tr::TimeOwned>,
+    Tr: TraceReader<DiffOwned=isize>+Clone+'static,
     Tr::KeyOwned: Hashable + Default,
     R: Monoid+Multiply<Output = R>+ExchangeData,
     F: Fn(&P)->Tr::KeyOwned+Clone+'static,

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -76,7 +76,7 @@ pub fn half_join<G, V, R, Tr, FF, CF, DOut, S>(
     mut output_func: S,
 ) -> Collection<G, (DOut, G::Timestamp), <R as Mul<Tr::DiffOwned>>::Output>
 where
-    G: Scope<Timestamp = Tr::TimeOwned>,
+    G: Scope<Timestamp = Tr::Time>,
     Tr::KeyOwned: Hashable + ExchangeData,
     V: ExchangeData,
     R: ExchangeData + Monoid,
@@ -129,7 +129,7 @@ pub fn half_join_internal_unsafe<G, V, R, Tr, FF, CF, DOut, ROut, Y, I, S>(
     mut output_func: S,
 ) -> Collection<G, DOut, ROut>
 where
-    G: Scope<Timestamp = Tr::TimeOwned>,
+    G: Scope<Timestamp = Tr::Time>,
     Tr::KeyOwned: Hashable + ExchangeData,
     V: ExchangeData,
     R: ExchangeData + Monoid,

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -214,7 +214,7 @@ where
                                     while let Some(val2) = cursor.get_val(&storage) {
                                         cursor.map_times(&storage, |t, d| {
                                             if comparison(t, initial) {
-                                                output_buffer.push((t.join(time), d.clone()))
+                                                output_buffer.push((t.join(time), d.into_owned()))
                                             }
                                         });
                                         consolidate(&mut output_buffer);

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -74,21 +74,21 @@ pub fn half_join<G, V, R, Tr, FF, CF, DOut, S>(
     frontier_func: FF,
     comparison: CF,
     mut output_func: S,
-) -> Collection<G, (DOut, G::Timestamp), <R as Mul<Tr::Diff>>::Output>
+) -> Collection<G, (DOut, G::Timestamp), <R as Mul<Tr::DiffOwned>>::Output>
 where
-    G: Scope<Timestamp = Tr::Time>,
+    G: Scope<Timestamp = Tr::TimeOwned>,
     Tr::KeyOwned: Hashable + ExchangeData,
     V: ExchangeData,
     R: ExchangeData + Monoid,
     Tr: TraceReader+Clone+'static,
-    R: Mul<Tr::Diff>,
-    <R as Mul<Tr::Diff>>::Output: Semigroup,
+    R: Mul<Tr::DiffOwned>,
+    <R as Mul<Tr::DiffOwned>>::Output: Semigroup,
     FF: Fn(&G::Timestamp, &mut Antichain<G::Timestamp>) + 'static,
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
     DOut: Clone+'static,
     S: FnMut(&Tr::KeyOwned, &V, Tr::Val<'_>)->DOut+'static,
 {
-    let output_func = move |k: &Tr::KeyOwned, v1: &V, v2: Tr::Val<'_>, initial: &G::Timestamp, time: &G::Timestamp, diff1: &R, diff2: &Tr::Diff| {
+    let output_func = move |k: &Tr::KeyOwned, v1: &V, v2: Tr::Val<'_>, initial: &G::Timestamp, time: &G::Timestamp, diff1: &R, diff2: &Tr::DiffOwned| {
         let diff = diff1.clone() * diff2.clone();
         let dout = (output_func(k, v1, v2), time.clone());
         Some((dout, initial.clone(), diff))
@@ -129,7 +129,7 @@ pub fn half_join_internal_unsafe<G, V, R, Tr, FF, CF, DOut, ROut, Y, I, S>(
     mut output_func: S,
 ) -> Collection<G, DOut, ROut>
 where
-    G: Scope<Timestamp = Tr::Time>,
+    G: Scope<Timestamp = Tr::TimeOwned>,
     Tr::KeyOwned: Hashable + ExchangeData,
     V: ExchangeData,
     R: ExchangeData + Monoid,
@@ -140,7 +140,7 @@ where
     ROut: Semigroup,
     Y: Fn(std::time::Instant, usize) -> bool + 'static,
     I: IntoIterator<Item=(DOut, G::Timestamp, ROut)>,
-    S: FnMut(&Tr::KeyOwned, &V, Tr::Val<'_>, &G::Timestamp, &G::Timestamp, &R, &Tr::Diff)-> I + 'static,
+    S: FnMut(&Tr::KeyOwned, &V, Tr::Val<'_>, &G::Timestamp, &G::Timestamp, &R, &Tr::DiffOwned)-> I + 'static,
 {
     // No need to block physical merging for this operator.
     arrangement.trace.set_physical_compaction(Antichain::new().borrow());

--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -72,6 +72,7 @@ where
         input2.for_each(|_, _| { });
 
         if let Some(ref mut trace) = propose_trace {
+            let mut owned_diff = None;
 
             for (capability, prefixes) in stash.iter_mut() {
 
@@ -99,6 +100,12 @@ where
                                 while let Some(value) = cursor.get_val(&storage) {
                                     let mut count = Tr::DiffOwned::zero();
                                     cursor.map_times(&storage, |t, d| {
+                                        let d = if let Some(owned_diff) = &mut owned_diff {
+                                            d.clone_onto(owned_diff);
+                                            &*owned_diff
+                                        } else {
+                                            owned_diff.insert(d.into_owned())
+                                        };
                                         if t.less_equal(time) { count.plus_equals(d); }
                                     });
                                     if !count.is_zero() {

--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -26,7 +26,7 @@ pub fn lookup_map<G, D, R, Tr, F, DOut, ROut, S>(
     supplied_key2: Tr::KeyOwned,
 ) -> Collection<G, DOut, ROut>
 where
-    G: Scope<Timestamp=Tr::TimeOwned>,
+    G: Scope<Timestamp=Tr::Time>,
     Tr: TraceReader+Clone+'static,
     Tr::KeyOwned: Hashable,
     Tr::DiffOwned: Monoid+ExchangeData,

--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -26,16 +26,16 @@ pub fn lookup_map<G, D, R, Tr, F, DOut, ROut, S>(
     supplied_key2: Tr::KeyOwned,
 ) -> Collection<G, DOut, ROut>
 where
-    G: Scope<Timestamp=Tr::Time>,
+    G: Scope<Timestamp=Tr::TimeOwned>,
     Tr: TraceReader+Clone+'static,
     Tr::KeyOwned: Hashable,
-    Tr::Diff: Monoid+ExchangeData,
+    Tr::DiffOwned: Monoid+ExchangeData,
     F: FnMut(&D, &mut Tr::KeyOwned)+Clone+'static,
     D: ExchangeData,
     R: ExchangeData+Monoid,
     DOut: Clone+'static,
     ROut: Monoid,
-    S: FnMut(&D, &R, Tr::Val<'_>, &Tr::Diff)->(DOut, ROut)+'static,
+    S: FnMut(&D, &R, Tr::Val<'_>, &Tr::DiffOwned)->(DOut, ROut)+'static,
 {
     // No need to block physical merging for this operator.
     arrangement.trace.set_physical_compaction(Antichain::new().borrow());
@@ -97,7 +97,7 @@ where
                             cursor.seek_key(&storage, MyTrait::borrow_as(&key1));
                             if cursor.get_key(&storage) == Some(MyTrait::borrow_as(&key1)) {
                                 while let Some(value) = cursor.get_val(&storage) {
-                                    let mut count = Tr::Diff::zero();
+                                    let mut count = Tr::DiffOwned::zero();
                                     cursor.map_times(&storage, |t, d| {
                                         if t.less_equal(time) { count.plus_equals(d); }
                                     });

--- a/dogsdogsdogs/src/operators/propose.rs
+++ b/dogsdogsdogs/src/operators/propose.rs
@@ -20,7 +20,7 @@ pub fn propose<G, Tr, F, P, V, VF>(
     val_from: VF,
 ) -> Collection<G, (P, V), Tr::DiffOwned>
 where
-    G: Scope<Timestamp=Tr::TimeOwned>,
+    G: Scope<Timestamp=Tr::Time>,
     Tr: TraceReader+Clone+'static,
     Tr::KeyOwned: Hashable + Default,
     Tr::DiffOwned: Monoid+Multiply<Output = Tr::DiffOwned>+ExchangeData,
@@ -52,7 +52,7 @@ pub fn propose_distinct<G, Tr, F, P, V, VF>(
     val_from: VF,
 ) -> Collection<G, (P, V), Tr::DiffOwned>
 where
-    G: Scope<Timestamp=Tr::TimeOwned>,
+    G: Scope<Timestamp=Tr::Time>,
     Tr: TraceReader+Clone+'static,
     Tr::KeyOwned: Hashable + Default,
     Tr::DiffOwned: Monoid+Multiply<Output = Tr::DiffOwned>+ExchangeData,

--- a/dogsdogsdogs/src/operators/propose.rs
+++ b/dogsdogsdogs/src/operators/propose.rs
@@ -14,16 +14,16 @@ use differential_dataflow::trace::TraceReader;
 /// `arrangement` undergoes. More complicated patterns are also appropriate, as in the case
 /// of delta queries.
 pub fn propose<G, Tr, F, P, V, VF>(
-    prefixes: &Collection<G, P, Tr::Diff>,
+    prefixes: &Collection<G, P, Tr::DiffOwned>,
     arrangement: Arranged<G, Tr>,
     key_selector: F,
     val_from: VF,
-) -> Collection<G, (P, V), Tr::Diff>
+) -> Collection<G, (P, V), Tr::DiffOwned>
 where
-    G: Scope<Timestamp=Tr::Time>,
+    G: Scope<Timestamp=Tr::TimeOwned>,
     Tr: TraceReader+Clone+'static,
     Tr::KeyOwned: Hashable + Default,
-    Tr::Diff: Monoid+Multiply<Output = Tr::Diff>+ExchangeData,
+    Tr::DiffOwned: Monoid+Multiply<Output = Tr::DiffOwned>+ExchangeData,
     F: Fn(&P)->Tr::KeyOwned+Clone+'static,
     P: ExchangeData,
     V: Clone + 'static,
@@ -46,16 +46,16 @@ where
 /// prefixes by the number of matches in `arrangement`. This can be useful to
 /// avoid the need to prepare an arrangement of distinct extensions.
 pub fn propose_distinct<G, Tr, F, P, V, VF>(
-    prefixes: &Collection<G, P, Tr::Diff>,
+    prefixes: &Collection<G, P, Tr::DiffOwned>,
     arrangement: Arranged<G, Tr>,
     key_selector: F,
     val_from: VF,
-) -> Collection<G, (P, V), Tr::Diff>
+) -> Collection<G, (P, V), Tr::DiffOwned>
 where
-    G: Scope<Timestamp=Tr::Time>,
+    G: Scope<Timestamp=Tr::TimeOwned>,
     Tr: TraceReader+Clone+'static,
     Tr::KeyOwned: Hashable + Default,
-    Tr::Diff: Monoid+Multiply<Output = Tr::Diff>+ExchangeData,
+    Tr::DiffOwned: Monoid+Multiply<Output = Tr::DiffOwned>+ExchangeData,
     F: Fn(&P)->Tr::KeyOwned+Clone+'static,
     P: ExchangeData,
     V: Clone + 'static,

--- a/dogsdogsdogs/src/operators/validate.rs
+++ b/dogsdogsdogs/src/operators/validate.rs
@@ -18,7 +18,7 @@ pub fn validate<G, K, V, Tr, F, P>(
     key_selector: F,
 ) -> Collection<G, (P, V), Tr::DiffOwned>
 where
-    G: Scope<Timestamp=Tr::TimeOwned>,
+    G: Scope<Timestamp=Tr::Time>,
     Tr: TraceReader<KeyOwned=(K,V)>+Clone+'static,
     K: Ord+Hash+Clone+Default,
     V: ExchangeData+Hash+Default,

--- a/dogsdogsdogs/src/operators/validate.rs
+++ b/dogsdogsdogs/src/operators/validate.rs
@@ -13,16 +13,16 @@ use differential_dataflow::trace::TraceReader;
 /// key with `key_selector` and then proposes all pair af the prefix
 /// and values associated with the key in `arrangement`.
 pub fn validate<G, K, V, Tr, F, P>(
-    extensions: &Collection<G, (P, V), Tr::Diff>,
+    extensions: &Collection<G, (P, V), Tr::DiffOwned>,
     arrangement: Arranged<G, Tr>,
     key_selector: F,
-) -> Collection<G, (P, V), Tr::Diff>
+) -> Collection<G, (P, V), Tr::DiffOwned>
 where
-    G: Scope<Timestamp=Tr::Time>,
+    G: Scope<Timestamp=Tr::TimeOwned>,
     Tr: TraceReader<KeyOwned=(K,V)>+Clone+'static,
     K: Ord+Hash+Clone+Default,
     V: ExchangeData+Hash+Default,
-    Tr::Diff: Monoid+Multiply<Output = Tr::Diff>+ExchangeData,
+    Tr::DiffOwned: Monoid+Multiply<Output = Tr::DiffOwned>+ExchangeData,
     F: Fn(&P)->K+Clone+'static,
     P: ExchangeData,
 {

--- a/src/algorithms/graphs/bfs.rs
+++ b/src/algorithms/graphs/bfs.rs
@@ -26,7 +26,7 @@ use crate::operators::arrange::Arranged;
 /// Returns pairs (node, dist) indicating distance of each node from a root.
 pub fn bfs_arranged<G, N, Tr>(edges: &Arranged<G, Tr>, roots: &Collection<G, N>) -> Collection<G, (N, u32)>
 where
-    G: Scope<Timestamp=Tr::TimeOwned>,
+    G: Scope<Timestamp=Tr::Time>,
     N: ExchangeData+Hash,
     Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, DiffOwned=isize>+Clone+'static,
 {

--- a/src/algorithms/graphs/bfs.rs
+++ b/src/algorithms/graphs/bfs.rs
@@ -26,9 +26,9 @@ use crate::operators::arrange::Arranged;
 /// Returns pairs (node, dist) indicating distance of each node from a root.
 pub fn bfs_arranged<G, N, Tr>(edges: &Arranged<G, Tr>, roots: &Collection<G, N>) -> Collection<G, (N, u32)>
 where
-    G: Scope<Timestamp=Tr::Time>,
+    G: Scope<Timestamp=Tr::TimeOwned>,
     N: ExchangeData+Hash,
-    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Diff=isize>+Clone+'static,
+    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, DiffOwned=isize>+Clone+'static,
 {
     // initialize roots as reaching themselves at distance 0
     let nodes = roots.map(|x| (x, 0));

--- a/src/algorithms/graphs/bijkstra.rs
+++ b/src/algorithms/graphs/bijkstra.rs
@@ -42,7 +42,7 @@ pub fn bidijkstra_arranged<G, N, Tr>(
     goals: &Collection<G, (N,N)>
 ) -> Collection<G, ((N,N), u32)>
 where
-    G: Scope<Timestamp=Tr::TimeOwned>,
+    G: Scope<Timestamp=Tr::Time>,
     N: ExchangeData+Hash,
     Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, DiffOwned=isize>+Clone+'static,
 {

--- a/src/algorithms/graphs/bijkstra.rs
+++ b/src/algorithms/graphs/bijkstra.rs
@@ -42,9 +42,9 @@ pub fn bidijkstra_arranged<G, N, Tr>(
     goals: &Collection<G, (N,N)>
 ) -> Collection<G, ((N,N), u32)>
 where
-    G: Scope<Timestamp=Tr::Time>,
+    G: Scope<Timestamp=Tr::TimeOwned>,
     N: ExchangeData+Hash,
-    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Diff=isize>+Clone+'static,
+    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, DiffOwned=isize>+Clone+'static,
 {
     forward
         .stream

--- a/src/algorithms/graphs/propagate.rs
+++ b/src/algorithms/graphs/propagate.rs
@@ -56,7 +56,7 @@ use crate::operators::arrange::arrangement::Arranged;
 /// of `logic should be a number in the interval [0,64],
 pub fn propagate_core<G, N, L, Tr, F, R>(edges: &Arranged<G,Tr>, nodes: &Collection<G,(N,L),R>, logic: F) -> Collection<G,(N,L),R>
 where
-    G: Scope<Timestamp=Tr::TimeOwned>,
+    G: Scope<Timestamp=Tr::Time>,
     N: ExchangeData+Hash,
     R: ExchangeData+Abelian,
     R: Multiply<R, Output=R>,

--- a/src/algorithms/graphs/propagate.rs
+++ b/src/algorithms/graphs/propagate.rs
@@ -56,13 +56,13 @@ use crate::operators::arrange::arrangement::Arranged;
 /// of `logic should be a number in the interval [0,64],
 pub fn propagate_core<G, N, L, Tr, F, R>(edges: &Arranged<G,Tr>, nodes: &Collection<G,(N,L),R>, logic: F) -> Collection<G,(N,L),R>
 where
-    G: Scope<Timestamp=Tr::Time>,
+    G: Scope<Timestamp=Tr::TimeOwned>,
     N: ExchangeData+Hash,
     R: ExchangeData+Abelian,
     R: Multiply<R, Output=R>,
     R: From<i8>,
     L: ExchangeData,
-    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Diff=R>+Clone+'static,
+    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, DiffOwned=R>+Clone+'static,
     F: Fn(&L)->u64+Clone+'static,
 {
     // Morally the code performs the following iterative computation. However, in the interest of a simplified

--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -31,9 +31,9 @@ where
 {
     trace: Rc<RefCell<TraceBox<Tr>>>,
     queues: Weak<RefCell<Vec<TraceAgentQueueWriter<Tr>>>>,
-    logical_compaction: Antichain<Tr::Time>,
-    physical_compaction: Antichain<Tr::Time>,
-    temp_antichain: Antichain<Tr::Time>,
+    logical_compaction: Antichain<Tr::TimeOwned>,
+    physical_compaction: Antichain<Tr::TimeOwned>,
+    temp_antichain: Antichain<Tr::TimeOwned>,
 
     operator: OperatorInfo,
     logging: Option<crate::logging::Logger>,
@@ -46,14 +46,14 @@ where
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type Time = Tr::Time;
-    type Diff = Tr::Diff;
+    type TimeOwned = Tr::TimeOwned;
+    type DiffOwned = Tr::DiffOwned;
 
     type Batch = Tr::Batch;
     type Storage = Tr::Storage;
     type Cursor = Tr::Cursor;
 
-    fn set_logical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) {
+    fn set_logical_compaction(&mut self, frontier: AntichainRef<Tr::TimeOwned>) {
         // This method does not enforce that `frontier` is greater or equal to `self.logical_compaction`.
         // Instead, it determines the joint consequences of both guarantees and moves forward with that.
         crate::lattice::antichain_join_into(&self.logical_compaction.borrow()[..], &frontier[..], &mut self.temp_antichain);
@@ -61,10 +61,10 @@ where
         ::std::mem::swap(&mut self.logical_compaction, &mut self.temp_antichain);
         self.temp_antichain.clear();
     }
-    fn get_logical_compaction(&mut self) -> AntichainRef<Tr::Time> {
+    fn get_logical_compaction(&mut self) -> AntichainRef<Tr::TimeOwned> {
         self.logical_compaction.borrow()
     }
-    fn set_physical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) {
+    fn set_physical_compaction(&mut self, frontier: AntichainRef<Tr::TimeOwned>) {
         // This method does not enforce that `frontier` is greater or equal to `self.physical_compaction`.
         // Instead, it determines the joint consequences of both guarantees and moves forward with that.
         crate::lattice::antichain_join_into(&self.physical_compaction.borrow()[..], &frontier[..], &mut self.temp_antichain);
@@ -72,10 +72,10 @@ where
         ::std::mem::swap(&mut self.physical_compaction, &mut self.temp_antichain);
         self.temp_antichain.clear();
     }
-    fn get_physical_compaction(&mut self) -> AntichainRef<Tr::Time> {
+    fn get_physical_compaction(&mut self) -> AntichainRef<Tr::TimeOwned> {
         self.physical_compaction.borrow()
     }
-    fn cursor_through(&mut self, frontier: AntichainRef<Tr::Time>) -> Option<(Self::Cursor, Self::Storage)> {
+    fn cursor_through(&mut self, frontier: AntichainRef<Tr::TimeOwned>) -> Option<(Self::Cursor, Self::Storage)> {
         self.trace.borrow_mut().trace.cursor_through(frontier)
     }
     fn map_batches<F: FnMut(&Self::Batch)>(&self, f: F) { self.trace.borrow().trace.map_batches(f) }
@@ -108,7 +108,7 @@ impl<Tr: TraceReader> TraceAgent<Tr> {
         };
 
         let writer = TraceWriter::new(
-            vec![<Tr::Time as Timestamp>::minimum()],
+            vec![<Tr::TimeOwned as Timestamp>::minimum()],
             Rc::downgrade(&trace),
             queues,
         );
@@ -132,7 +132,7 @@ impl<Tr: TraceReader> TraceAgent<Tr> {
             .borrow_mut()
             .trace
             .map_batches(|batch| {
-                new_queue.push_back(TraceReplayInstruction::Batch(batch.clone(), Some(<Tr::Time as Timestamp>::minimum())));
+                new_queue.push_back(TraceReplayInstruction::Batch(batch.clone(), Some(<Tr::TimeOwned as Timestamp>::minimum())));
                 upper = Some(batch.upper().clone());
             });
 
@@ -223,7 +223,7 @@ where
     /// ```
     pub fn import<G>(&mut self, scope: &G) -> Arranged<G, TraceAgent<Tr>>
     where
-        G: Scope<Timestamp=Tr::Time>,
+        G: Scope<Timestamp=Tr::TimeOwned>,
     {
         self.import_named(scope, "ArrangedSource")
     }
@@ -231,7 +231,7 @@ where
     /// Same as `import`, but allows to name the source.
     pub fn import_named<G>(&mut self, scope: &G, name: &str) -> Arranged<G, TraceAgent<Tr>>
     where
-        G: Scope<Timestamp=Tr::Time>,
+        G: Scope<Timestamp=Tr::TimeOwned>,
     {
         // Drop ShutdownButton and return only the arrangement.
         self.import_core(scope, name).0
@@ -286,9 +286,9 @@ where
     ///
     /// }).unwrap();
     /// ```
-    pub fn import_core<G>(&mut self, scope: &G, name: &str) -> (Arranged<G, TraceAgent<Tr>>, ShutdownButton<CapabilitySet<Tr::Time>>)
+    pub fn import_core<G>(&mut self, scope: &G, name: &str) -> (Arranged<G, TraceAgent<Tr>>, ShutdownButton<CapabilitySet<Tr::TimeOwned>>)
     where
-        G: Scope<Timestamp=Tr::Time>,
+        G: Scope<Timestamp=Tr::TimeOwned>,
     {
         let trace = self.clone();
 
@@ -403,9 +403,9 @@ where
     ///
     /// }).unwrap();
     /// ```
-    pub fn import_frontier<G>(&mut self, scope: &G, name: &str) -> (Arranged<G, TraceFrontier<TraceAgent<Tr>>>, ShutdownButton<CapabilitySet<Tr::Time>>)
+    pub fn import_frontier<G>(&mut self, scope: &G, name: &str) -> (Arranged<G, TraceFrontier<TraceAgent<Tr>>>, ShutdownButton<CapabilitySet<Tr::TimeOwned>>)
     where
-        G: Scope<Timestamp=Tr::Time>,
+        G: Scope<Timestamp=Tr::TimeOwned>,
         Tr: TraceReader,
     {
         // This frontier describes our only guarantee on the compaction frontier.
@@ -421,9 +421,9 @@ where
     ///
     /// Invoking this method with an `until` of `Antichain::new()` will perform no filtering, as the empty
     /// frontier indicates the end of times.
-    pub fn import_frontier_core<G>(&mut self, scope: &G, name: &str, since: Antichain<Tr::Time>, until: Antichain<Tr::Time>) -> (Arranged<G, TraceFrontier<TraceAgent<Tr>>>, ShutdownButton<CapabilitySet<Tr::Time>>)
+    pub fn import_frontier_core<G>(&mut self, scope: &G, name: &str, since: Antichain<Tr::TimeOwned>, until: Antichain<Tr::TimeOwned>) -> (Arranged<G, TraceFrontier<TraceAgent<Tr>>>, ShutdownButton<CapabilitySet<Tr::TimeOwned>>)
     where
-        G: Scope<Timestamp=Tr::Time>,
+        G: Scope<Timestamp=Tr::TimeOwned>,
         Tr: TraceReader,
     {
         let trace = self.clone();

--- a/src/operators/arrange/agent.rs
+++ b/src/operators/arrange/agent.rs
@@ -46,7 +46,9 @@ where
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
+    type Time<'a> = Tr::Time<'a>;
     type TimeOwned = Tr::TimeOwned;
+    type Diff<'a> = Tr::Diff<'a>;
     type DiffOwned = Tr::DiffOwned;
 
     type Batch = Tr::Batch;

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -30,6 +30,7 @@ use crate::{Data, ExchangeData, Collection, AsCollection, Hashable};
 use crate::difference::Semigroup;
 use crate::lattice::Lattice;
 use crate::trace::{self, Trace, TraceReader, Batch, BatchReader, Batcher, Builder, Cursor};
+use crate::trace::cursor::MyTrait;
 use crate::trace::implementations::{KeySpine, ValSpine};
 
 use trace::wrappers::enter::{TraceEnter, BatchEnter,};
@@ -119,7 +120,7 @@ where
         where
             TInner: Refines<G::Timestamp>+Lattice+Timestamp+Clone+'static,
             F: FnMut(Tr::Key<'_>, Tr::Val<'_>, &G::Timestamp)->TInner+Clone+'static,
-            P: FnMut(&TInner)->Tr::Time +Clone+'static,
+            P: FnMut(&TInner)->Tr::Time+Clone+'static,
         {
         let logic1 = logic.clone();
         let logic2 = logic.clone();
@@ -279,8 +280,6 @@ where
 
 // Direct reduce implementations.
 use crate::difference::Abelian;
-use crate::trace::cursor::MyTrait;
-
 impl<G, T1> Arranged<G, T1>
 where
     G: Scope<Timestamp = T1::Time>,

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -215,7 +215,7 @@ where
                         while let Some(val) = cursor.get_val(batch) {
                             for datum in logic(key, val) {
                                 cursor.map_times(batch, |time, diff| {
-                                    session.give((datum.clone(), time.clone(), diff.clone()));
+                                    session.give((datum.clone(), time.clone(), diff.into_owned()))
                                 });
                             }
                             cursor.step_val(batch);
@@ -279,6 +279,8 @@ where
 
 // Direct reduce implementations.
 use crate::difference::Abelian;
+use crate::trace::cursor::MyTrait;
+
 impl<G, T1> Arranged<G, T1>
 where
     G: Scope<Timestamp = T1::TimeOwned>,

--- a/src/operators/arrange/mod.rs
+++ b/src/operators/arrange/mod.rs
@@ -53,9 +53,9 @@ where
     Tr: TraceReader,
 {
     /// Describes a frontier advance.
-    Frontier(Antichain<Tr::Time>),
+    Frontier(Antichain<Tr::TimeOwned>),
     /// Describes a batch of data and a capability hint.
-    Batch(Tr::Batch, Option<Tr::Time>),
+    Batch(Tr::Batch, Option<Tr::TimeOwned>),
 }
 
 // Short names for strongly and weakly owned activators and shared queues.

--- a/src/operators/arrange/mod.rs
+++ b/src/operators/arrange/mod.rs
@@ -53,9 +53,9 @@ where
     Tr: TraceReader,
 {
     /// Describes a frontier advance.
-    Frontier(Antichain<Tr::TimeOwned>),
+    Frontier(Antichain<Tr::Time>),
     /// Describes a batch of data and a capability hint.
-    Batch(Tr::Batch, Option<Tr::TimeOwned>),
+    Batch(Tr::Batch, Option<Tr::Time>),
 }
 
 // Short names for strongly and weakly owned activators and shared queues.

--- a/src/operators/arrange/upsert.rs
+++ b/src/operators/arrange/upsert.rs
@@ -255,7 +255,8 @@ where
                                         // Determine the prior value associated with the key.
                                         while let Some(val) = trace_cursor.get_val(&trace_storage) {
                                             let mut count = 0;
-                                            trace_cursor.map_times(&trace_storage, |_time, diff| count += *diff);
+                                            // TODO(antiguru): Re-use `diff` allocation.
+                                            trace_cursor.map_times(&trace_storage, |_time, diff| count += diff.into_owned());
                                             assert!(count == 0 || count == 1);
                                             if count == 1 {
                                                 assert!(prev_value.is_none());

--- a/src/operators/arrange/upsert.rs
+++ b/src/operators/arrange/upsert.rs
@@ -131,14 +131,14 @@ pub fn arrange_from_upsert<G, V, F, Tr>(
     from: F,
 ) -> Arranged<G, TraceAgent<Tr>>
 where
-    G: Scope<Timestamp=Tr::Time>,
-    Tr: Trace+TraceReader<Diff=isize>+'static,
+    G: Scope<Timestamp=Tr::TimeOwned>,
+    Tr: Trace+TraceReader<DiffOwned=isize>+'static,
     Tr::KeyOwned: ExchangeData+Hashable+std::hash::Hash,
     V: ExchangeData,
     F: Fn(Tr::Val<'_>) -> V + 'static,
-    Tr::Time: TotalOrder+ExchangeData,
+    Tr::TimeOwned: TotalOrder+ExchangeData,
     Tr::Batch: Batch,
-    Tr::Builder: Builder<Input = ((Tr::KeyOwned, V), Tr::Time, Tr::Diff)>,
+    Tr::Builder: Builder<Input = ((Tr::KeyOwned, V), Tr::TimeOwned, Tr::DiffOwned)>,
 {
     let mut reader: Option<TraceAgent<Tr>> = None;
 

--- a/src/operators/arrange/upsert.rs
+++ b/src/operators/arrange/upsert.rs
@@ -131,14 +131,14 @@ pub fn arrange_from_upsert<G, V, F, Tr>(
     from: F,
 ) -> Arranged<G, TraceAgent<Tr>>
 where
-    G: Scope<Timestamp=Tr::TimeOwned>,
+    G: Scope<Timestamp=Tr::Time>,
     Tr: Trace+TraceReader<DiffOwned=isize>+'static,
     Tr::KeyOwned: ExchangeData+Hashable+std::hash::Hash,
     V: ExchangeData,
     F: Fn(Tr::Val<'_>) -> V + 'static,
-    Tr::TimeOwned: TotalOrder+ExchangeData,
+    Tr::Time: TotalOrder+ExchangeData,
     Tr::Batch: Batch,
-    Tr::Builder: Builder<Input = ((Tr::KeyOwned, V), Tr::TimeOwned, Tr::DiffOwned)>,
+    Tr::Builder: Builder<Input = ((Tr::KeyOwned, V), Tr::Time, Tr::DiffOwned)>,
 {
     let mut reader: Option<TraceAgent<Tr>> = None;
 

--- a/src/operators/arrange/writer.rs
+++ b/src/operators/arrange/writer.rs
@@ -25,7 +25,7 @@ where
     Tr::Batch: Batch,
 {
     /// Current upper limit.
-    upper: Antichain<Tr::Time>,
+    upper: Antichain<Tr::TimeOwned>,
     /// Shared trace, possibly absent (due to weakness).
     trace: Weak<RefCell<TraceBox<Tr>>>,
     /// A sequence of private queues into which batches are written.
@@ -39,7 +39,7 @@ where
 {
     /// Creates a new `TraceWriter`.
     pub fn new(
-        upper: Vec<Tr::Time>,
+        upper: Vec<Tr::TimeOwned>,
         trace: Weak<RefCell<TraceBox<Tr>>>,
         queues: Rc<RefCell<Vec<TraceAgentQueueWriter<Tr>>>>
     ) -> Self
@@ -61,7 +61,7 @@ where
     /// The `hint` argument is either `None` in the case of an empty batch,
     /// or is `Some(time)` for a time less or equal to all updates in the
     /// batch and which is suitable for use as a capability.
-    pub fn insert(&mut self, batch: Tr::Batch, hint: Option<Tr::Time>) {
+    pub fn insert(&mut self, batch: Tr::Batch, hint: Option<Tr::TimeOwned>) {
 
         // Something is wrong if not a sequence.
         if !(&self.upper == batch.lower()) {
@@ -91,11 +91,11 @@ where
     }
 
     /// Inserts an empty batch up to `upper`.
-    pub fn seal(&mut self, upper: Antichain<Tr::Time>) {
+    pub fn seal(&mut self, upper: Antichain<Tr::TimeOwned>) {
         if self.upper != upper {
             use crate::trace::Builder;
             let builder = Tr::Builder::new();
-            let batch = builder.done(self.upper.clone(), upper, Antichain::from_elem(Tr::Time::minimum()));
+            let batch = builder.done(self.upper.clone(), upper, Antichain::from_elem(Tr::TimeOwned::minimum()));
             self.insert(batch, None);
         }
     }

--- a/src/operators/arrange/writer.rs
+++ b/src/operators/arrange/writer.rs
@@ -25,7 +25,7 @@ where
     Tr::Batch: Batch,
 {
     /// Current upper limit.
-    upper: Antichain<Tr::TimeOwned>,
+    upper: Antichain<Tr::Time>,
     /// Shared trace, possibly absent (due to weakness).
     trace: Weak<RefCell<TraceBox<Tr>>>,
     /// A sequence of private queues into which batches are written.
@@ -39,7 +39,7 @@ where
 {
     /// Creates a new `TraceWriter`.
     pub fn new(
-        upper: Vec<Tr::TimeOwned>,
+        upper: Vec<Tr::Time>,
         trace: Weak<RefCell<TraceBox<Tr>>>,
         queues: Rc<RefCell<Vec<TraceAgentQueueWriter<Tr>>>>
     ) -> Self
@@ -61,7 +61,7 @@ where
     /// The `hint` argument is either `None` in the case of an empty batch,
     /// or is `Some(time)` for a time less or equal to all updates in the
     /// batch and which is suitable for use as a capability.
-    pub fn insert(&mut self, batch: Tr::Batch, hint: Option<Tr::TimeOwned>) {
+    pub fn insert(&mut self, batch: Tr::Batch, hint: Option<Tr::Time>) {
 
         // Something is wrong if not a sequence.
         if !(&self.upper == batch.lower()) {
@@ -91,11 +91,11 @@ where
     }
 
     /// Inserts an empty batch up to `upper`.
-    pub fn seal(&mut self, upper: Antichain<Tr::TimeOwned>) {
+    pub fn seal(&mut self, upper: Antichain<Tr::Time>) {
         if self.upper != upper {
             use crate::trace::Builder;
             let builder = Tr::Builder::new();
-            let batch = builder.done(self.upper.clone(), upper, Antichain::from_elem(Tr::TimeOwned::minimum()));
+            let batch = builder.done(self.upper.clone(), upper, Antichain::from_elem(Tr::Time::minimum()));
             self.insert(batch, None);
         }
     }

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -51,7 +51,7 @@ where
     /// As `consolidate` but with the ability to name the operator and specify the trace type.
     pub fn consolidate_named<Tr>(&self, name: &str) -> Self
     where
-        Tr: crate::trace::Trace<KeyOwned = D, TimeOwned=G::Timestamp, DiffOwned=R>+'static,
+        Tr: crate::trace::Trace<KeyOwned = D, Time=G::Timestamp, DiffOwned=R>+'static,
         Tr::Batch: crate::trace::Batch,
         Tr::Batcher: Batcher<Input=Vec<((D,()),G::Timestamp,R)>>,
     {

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -51,7 +51,7 @@ where
     /// As `consolidate` but with the ability to name the operator and specify the trace type.
     pub fn consolidate_named<Tr>(&self, name: &str) -> Self
     where
-        Tr: crate::trace::Trace<KeyOwned = D,Time=G::Timestamp,Diff=R>+'static,
+        Tr: crate::trace::Trace<KeyOwned = D, TimeOwned=G::Timestamp, DiffOwned=R>+'static,
         Tr::Batch: crate::trace::Batch,
         Tr::Batcher: Batcher<Input=Vec<((D,()),G::Timestamp,R)>>,
     {

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -50,15 +50,15 @@ where G::Timestamp: TotalOrder+Lattice+Ord {
     }
 }
 
-impl<G, T1> CountTotal<G, T1::KeyOwned, T1::Diff> for Arranged<G, T1>
+impl<G, T1> CountTotal<G, T1::KeyOwned, T1::DiffOwned> for Arranged<G, T1>
 where
-    G: Scope<Timestamp=T1::Time>,
+    G: Scope<Timestamp=T1::TimeOwned>,
     T1: for<'a> TraceReader<Val<'a>=&'a ()>+Clone+'static,
     T1::KeyOwned: ExchangeData,
-    T1::Time: TotalOrder,
-    T1::Diff: ExchangeData,
+    T1::TimeOwned: TotalOrder,
+    T1::DiffOwned: ExchangeData,
 {
-    fn count_total_core<R2: Semigroup + From<i8>>(&self) -> Collection<G, (T1::KeyOwned, T1::Diff), R2> {
+    fn count_total_core<R2: Semigroup + From<i8>>(&self) -> Collection<G, (T1::KeyOwned, T1::DiffOwned), R2> {
 
         let mut trace = self.trace.clone();
         let mut buffer = Vec::new();
@@ -80,7 +80,7 @@ where
                         upper_limit.clone_from(batch.upper());
 
                         while let Some(key) = batch_cursor.get_key(&batch) {
-                            let mut count: Option<T1::Diff> = None;
+                            let mut count: Option<T1::DiffOwned> = None;
 
                             trace_cursor.seek_key(&trace_storage, key);
                             if trace_cursor.get_key(&trace_storage) == Some(key) {

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -69,6 +69,7 @@ where
             let mut upper_limit = timely::progress::frontier::Antichain::from_elem(<G::Timestamp as timely::progress::Timestamp>::minimum());
 
             move |input, output| {
+                let mut owned_diff = None;
 
                 use crate::trace::cursor::MyTrait;
                 input.for_each(|capability, batches| {
@@ -85,24 +86,32 @@ where
                             trace_cursor.seek_key(&trace_storage, key);
                             if trace_cursor.get_key(&trace_storage) == Some(key) {
                                 trace_cursor.map_times(&trace_storage, |_, diff| {
-                                    // TODO(antiguru): Re-use `diff` allocation.
-                                    let diff = diff.into_owned();
-                                    count.as_mut().map(|c| c.plus_equals(&diff));
-                                    if count.is_none() { count = Some(diff); }
+                                    let diff = if let Some(owned_diff) = &mut owned_diff {
+                                        diff.clone_onto(owned_diff);
+                                        &*owned_diff
+                                    } else {
+                                        owned_diff.insert(diff.into_owned())
+                                    };
+                                    count.as_mut().map(|c| c.plus_equals(diff));
+                                    if count.is_none() { count = Some(diff.clone()); }
                                 });
                             }
 
                             batch_cursor.map_times(&batch, |time, diff| {
-                                // TODO(antiguru): Re-use `diff` allocation.
-                                let diff = diff.into_owned();
+                                let diff = if let Some(owned_diff) = &mut owned_diff {
+                                    diff.clone_onto(owned_diff);
+                                    &*owned_diff
+                                } else {
+                                    owned_diff.insert(diff.into_owned())
+                                };
 
                                 if let Some(count) = count.as_ref() {
                                     if !count.is_zero() {
                                         session.give(((key.into_owned(), count.clone()), time.clone(), R2::from(-1i8)));
                                     }
                                 }
-                                count.as_mut().map(|c| c.plus_equals(&diff));
-                                if count.is_none() { count = Some(diff); }
+                                count.as_mut().map(|c| c.plus_equals(diff));
+                                if count.is_none() { count = Some(diff.clone()); }
                                 if let Some(count) = count.as_ref() {
                                     if !count.is_zero() {
                                         session.give(((key.into_owned(), count.clone()), time.clone(), R2::from(1i8)));

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -52,10 +52,10 @@ where G::Timestamp: TotalOrder+Lattice+Ord {
 
 impl<G, T1> CountTotal<G, T1::KeyOwned, T1::DiffOwned> for Arranged<G, T1>
 where
-    G: Scope<Timestamp=T1::TimeOwned>,
+    G: Scope<Timestamp=T1::Time>,
     T1: for<'a> TraceReader<Val<'a>=&'a ()>+Clone+'static,
     T1::KeyOwned: ExchangeData,
-    T1::TimeOwned: TotalOrder,
+    T1::Time: TotalOrder,
     T1::DiffOwned: ExchangeData,
 {
     fn count_total_core<R2: Semigroup + From<i8>>(&self) -> Collection<G, (T1::KeyOwned, T1::DiffOwned), R2> {

--- a/src/operators/join.rs
+++ b/src/operators/join.rs
@@ -707,7 +707,7 @@ where
 struct JoinThinker<'a, C1, C2>
 where
     C1: Cursor,
-    C2: Cursor<Time= C1::Time>,
+    C2: Cursor<Time = C1::Time>,
 {
     pub history1: ValueHistory<'a, C1>,
     pub history2: ValueHistory<'a, C2>,
@@ -716,7 +716,7 @@ where
 impl<'a, C1, C2> JoinThinker<'a, C1, C2>
 where
     C1: Cursor,
-    C2: Cursor<Time= C1::Time>,
+    C2: Cursor<Time = C1::Time>,
 {
     fn new() -> Self {
         JoinThinker {

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -20,11 +20,12 @@ pub mod threshold;
 
 use crate::lattice::Lattice;
 use crate::trace::Cursor;
+use crate::trace::cursor::MyTrait;
 
 /// An accumulation of (value, time, diff) updates.
 struct EditList<'a, C: Cursor> {
     values: Vec<(C::Val<'a>, usize)>,
-    edits: Vec<(C::Time, C::Diff)>,
+    edits: Vec<(C::TimeOwned, C::DiffOwned)>,
 }
 
 impl<'a, C: Cursor> EditList<'a, C> {
@@ -39,11 +40,11 @@ impl<'a, C: Cursor> EditList<'a, C> {
     /// Loads the contents of a cursor.
     fn load<L>(&mut self, cursor: &mut C, storage: &'a C::Storage, logic: L)
     where
-        L: Fn(&C::Time)->C::Time,
+        L: Fn(&C::TimeOwned)->C::TimeOwned,
     {
         self.clear();
         while cursor.val_valid(storage) {
-            cursor.map_times(storage, |time1, diff1| self.push(logic(time1), diff1.clone()));
+            cursor.map_times(storage, |time1, diff1| self.push(logic(time1), diff1.into_owned()));
             self.seal(cursor.val(storage));
             cursor.step_val(storage);
         }
@@ -57,7 +58,7 @@ impl<'a, C: Cursor> EditList<'a, C> {
     fn len(&self) -> usize { self.edits.len() }
     /// Inserts a new edit for an as-yet undetermined value.
     #[inline]
-    fn push(&mut self, time: C::Time, diff: C::Diff) {
+    fn push(&mut self, time: C::TimeOwned, diff: C::DiffOwned) {
         // TODO: Could attempt "insertion-sort" like behavior here, where we collapse if possible.
         self.edits.push((time, diff));
     }
@@ -70,7 +71,7 @@ impl<'a, C: Cursor> EditList<'a, C> {
             self.values.push((value, self.edits.len()));
         }
     }
-    fn map<F: FnMut(C::Val<'a>, &C::Time, &C::Diff)>(&self, mut logic: F) {
+    fn map<F: FnMut(C::Val<'a>, &C::TimeOwned, &C::DiffOwned)>(&self, mut logic: F) {
         for index in 0 .. self.values.len() {
             let lower = if index == 0 { 0 } else { self.values[index-1].1 };
             let upper = self.values[index].1;
@@ -83,8 +84,8 @@ impl<'a, C: Cursor> EditList<'a, C> {
 
 struct ValueHistory<'storage, C: Cursor> {
     edits: EditList<'storage, C>,
-    history: Vec<(C::Time, C::Time, usize, usize)>,     // (time, meet, value_index, edit_offset)
-    buffer: Vec<((C::Val<'storage>, C::Time), C::Diff)>,   // where we accumulate / collapse updates.
+    history: Vec<(C::TimeOwned, C::TimeOwned, usize, usize)>,     // (time, meet, value_index, edit_offset)
+    buffer: Vec<((C::Val<'storage>, C::TimeOwned), C::DiffOwned)>,   // where we accumulate / collapse updates.
 }
 
 impl<'storage, C: Cursor> ValueHistory<'storage, C> {
@@ -102,7 +103,7 @@ impl<'storage, C: Cursor> ValueHistory<'storage, C> {
     }
     fn load<L>(&mut self, cursor: &mut C, storage: &'storage C::Storage, logic: L)
     where
-        L: Fn(&C::Time)->C::Time,
+        L: Fn(&C::TimeOwned)->C::TimeOwned,
     {
         self.edits.load(cursor, storage, logic);
     }
@@ -118,7 +119,7 @@ impl<'storage, C: Cursor> ValueHistory<'storage, C> {
         logic: L
     ) -> HistoryReplay<'storage, 'history, C>
     where
-        L: Fn(&C::Time)->C::Time,
+        L: Fn(&C::TimeOwned)->C::TimeOwned,
     {
         self.clear();
         cursor.seek_key(storage, key);
@@ -158,13 +159,13 @@ struct HistoryReplay<'storage, 'history, C: Cursor> {
 }
 
 impl<'storage, 'history, C: Cursor> HistoryReplay<'storage, 'history, C> {
-    fn time(&self) -> Option<&C::Time> { self.replay.history.last().map(|x| &x.0) }
-    fn meet(&self) -> Option<&C::Time> { self.replay.history.last().map(|x| &x.1) }
-    fn edit(&self) -> Option<(C::Val<'storage>, &C::Time, &C::Diff)> {
+    fn time(&self) -> Option<&C::TimeOwned> { self.replay.history.last().map(|x| &x.0) }
+    fn meet(&self) -> Option<&C::TimeOwned> { self.replay.history.last().map(|x| &x.1) }
+    fn edit(&self) -> Option<(C::Val<'storage>, &C::TimeOwned, &C::DiffOwned)> {
         self.replay.history.last().map(|&(ref t, _, v, e)| (self.replay.edits.values[v].0, t, &self.replay.edits.edits[e].1))
     }
 
-    fn buffer(&self) -> &[((C::Val<'storage>, C::Time), C::Diff)] {
+    fn buffer(&self) -> &[((C::Val<'storage>, C::TimeOwned), C::DiffOwned)] {
         &self.replay.buffer[..]
     }
 
@@ -172,7 +173,7 @@ impl<'storage, 'history, C: Cursor> HistoryReplay<'storage, 'history, C> {
         let (time, _, value_index, edit_offset) = self.replay.history.pop().unwrap();
         self.replay.buffer.push(((self.replay.edits.values[value_index].0, time), self.replay.edits.edits[edit_offset].1.clone()));
     }
-    fn step_while_time_is(&mut self, time: &C::Time) -> bool {
+    fn step_while_time_is(&mut self, time: &C::TimeOwned) -> bool {
         let mut found = false;
         while self.time() == Some(time) {
             found = true;
@@ -180,7 +181,7 @@ impl<'storage, 'history, C: Cursor> HistoryReplay<'storage, 'history, C> {
         }
         found
     }
-    fn advance_buffer_by(&mut self, meet: &C::Time) {
+    fn advance_buffer_by(&mut self, meet: &C::TimeOwned) {
         for element in self.replay.buffer.iter_mut() {
             (element.0).1 = (element.0).1.join(meet);
         }

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -628,8 +628,8 @@ fn sort_dedup<T: Ord>(list: &mut Vec<T>) {
 trait PerKeyCompute<'a, C1, C2, C3, V>
 where
     C1: Cursor,
-    C2: Cursor<Key<'a> = C1::Key<'a>, Time = C1::Time>,
-    C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, Time = C1::Time, Diff = C1::Diff>,
+    C2: Cursor<Key<'a> = C1::Key<'a>, TimeOwned= C1::TimeOwned>,
+    C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, TimeOwned= C1::TimeOwned, DiffOwned= C1::DiffOwned>,
     V: Clone + Ord,
 {
     fn new() -> Self;
@@ -639,19 +639,19 @@ where
         source_cursor: (&mut C1, &'a C1::Storage),
         output_cursor: (&mut C2, &'a C2::Storage),
         batch_cursor: (&mut C3, &'a C3::Storage),
-        times: &mut Vec<C1::Time>,
+        times: &mut Vec<C1::TimeOwned>,
         from: &F,
         logic: &mut L,
-        upper_limit: &Antichain<C1::Time>,
-        outputs: &mut [(C2::Time, Vec<(V, C2::Time, C2::Diff)>)],
-        new_interesting: &mut Vec<C1::Time>) -> (usize, usize)
+        upper_limit: &Antichain<C1::TimeOwned>,
+        outputs: &mut [(C2::TimeOwned, Vec<(V, C2::TimeOwned, C2::DiffOwned)>)],
+        new_interesting: &mut Vec<C1::TimeOwned>) -> (usize, usize)
     where
         F: Fn(C2::Val<'_>) -> V,
         L: FnMut(
             C1::Key<'a>, 
-            &[(C1::Val<'a>, C1::Diff)],
-            &mut Vec<(V, C2::Diff)>,
-            &mut Vec<(V, C2::Diff)>,
+            &[(C1::Val<'a>, C1::DiffOwned)],
+            &mut Vec<(V, C2::DiffOwned)>,
+            &mut Vec<(V, C2::DiffOwned)>,
         );
 }
 
@@ -673,28 +673,28 @@ mod history_replay {
     pub struct HistoryReplayer<'a, C1, C2, C3, V>
     where
         C1: Cursor,
-        C2: Cursor<Key<'a> = C1::Key<'a>, Time = C1::Time>,
-        C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, Time = C1::Time, Diff = C1::Diff>,
+        C2: Cursor<Key<'a> = C1::Key<'a>, TimeOwned= C1::TimeOwned>,
+        C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, TimeOwned= C1::TimeOwned, DiffOwned= C1::DiffOwned>,
         V: Clone + Ord,
     {
         input_history: ValueHistory<'a, C1>,
         output_history: ValueHistory<'a, C2>,
         batch_history: ValueHistory<'a, C3>,
-        input_buffer: Vec<(C1::Val<'a>, C1::Diff)>,
-        output_buffer: Vec<(V, C2::Diff)>,
-        update_buffer: Vec<(V, C2::Diff)>,
-        output_produced: Vec<((V, C2::Time), C2::Diff)>,
-        synth_times: Vec<C1::Time>,
-        meets: Vec<C1::Time>,
-        times_current: Vec<C1::Time>,
-        temporary: Vec<C1::Time>,
+        input_buffer: Vec<(C1::Val<'a>, C1::DiffOwned)>,
+        output_buffer: Vec<(V, C2::DiffOwned)>,
+        update_buffer: Vec<(V, C2::DiffOwned)>,
+        output_produced: Vec<((V, C2::TimeOwned), C2::DiffOwned)>,
+        synth_times: Vec<C1::TimeOwned>,
+        meets: Vec<C1::TimeOwned>,
+        times_current: Vec<C1::TimeOwned>,
+        temporary: Vec<C1::TimeOwned>,
     }
 
     impl<'a, C1, C2, C3, V> PerKeyCompute<'a, C1, C2, C3, V> for HistoryReplayer<'a, C1, C2, C3, V>
     where
         C1: Cursor,
-        C2: Cursor<Key<'a> = C1::Key<'a>, Time = C1::Time>,
-        C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, Time = C1::Time, Diff = C1::Diff>,
+        C2: Cursor<Key<'a> = C1::Key<'a>, TimeOwned= C1::TimeOwned>,
+        C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, TimeOwned= C1::TimeOwned, DiffOwned= C1::DiffOwned>,
         V: Clone + Ord,
     {
         fn new() -> Self {
@@ -719,19 +719,19 @@ mod history_replay {
             (source_cursor, source_storage): (&mut C1, &'a C1::Storage),
             (output_cursor, output_storage): (&mut C2, &'a C2::Storage),
             (batch_cursor, batch_storage): (&mut C3, &'a C3::Storage),
-            times: &mut Vec<C1::Time>,
+            times: &mut Vec<C1::TimeOwned>,
             from: &F,
             logic: &mut L,
-            upper_limit: &Antichain<C1::Time>,
-            outputs: &mut [(C2::Time, Vec<(V, C2::Time, C2::Diff)>)],
-            new_interesting: &mut Vec<C1::Time>) -> (usize, usize)
+            upper_limit: &Antichain<C1::TimeOwned>,
+            outputs: &mut [(C2::TimeOwned, Vec<(V, C2::TimeOwned, C2::DiffOwned)>)],
+            new_interesting: &mut Vec<C1::TimeOwned>) -> (usize, usize)
         where
             F: Fn(C2::Val<'_>) -> V,
             L: FnMut(
                 C1::Key<'a>, 
-                &[(C1::Val<'a>, C1::Diff)],
-                &mut Vec<(V, C2::Diff)>,
-                &mut Vec<(V, C2::Diff)>,
+                &[(C1::Val<'a>, C1::DiffOwned)],
+                &mut Vec<(V, C2::DiffOwned)>,
+                &mut Vec<(V, C2::DiffOwned)>,
             )
         {
 

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -629,7 +629,7 @@ trait PerKeyCompute<'a, C1, C2, C3, V>
 where
     C1: Cursor,
     C2: Cursor<Key<'a> = C1::Key<'a>, Time= C1::Time>,
-    C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, Time= C1::Time, DiffOwned= C1::DiffOwned>,
+    C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, Time= C1::Time, DiffOwned = C1::DiffOwned>,
     V: Clone + Ord,
 {
     fn new() -> Self;
@@ -674,7 +674,7 @@ mod history_replay {
     where
         C1: Cursor,
         C2: Cursor<Key<'a> = C1::Key<'a>, Time= C1::Time>,
-        C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, Time= C1::Time, DiffOwned= C1::DiffOwned>,
+        C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, Time= C1::Time, DiffOwned = C1::DiffOwned>,
         V: Clone + Ord,
     {
         input_history: ValueHistory<'a, C1>,
@@ -694,7 +694,7 @@ mod history_replay {
     where
         C1: Cursor,
         C2: Cursor<Key<'a> = C1::Key<'a>, Time= C1::Time>,
-        C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, Time= C1::Time, DiffOwned= C1::DiffOwned>,
+        C3: Cursor<Key<'a> = C1::Key<'a>, Val<'a> = C1::Val<'a>, Time= C1::Time, DiffOwned = C1::DiffOwned>,
         V: Clone + Ord,
     {
         fn new() -> Self {

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -116,6 +116,7 @@ where
             let mut upper_limit = timely::progress::frontier::Antichain::from_elem(<G::Timestamp as timely::progress::Timestamp>::minimum());
 
             move |input, output| {
+                let mut owned_diff = None;
 
                 input.for_each(|capability, batches| {
                     batches.swap(&mut buffer);
@@ -134,35 +135,43 @@ where
                             trace_cursor.seek_key(&trace_storage, key);
                             if trace_cursor.get_key(&trace_storage) == Some(key) {
                                 trace_cursor.map_times(&trace_storage, |_, diff| {
-                                    // TODO(antiguru): Re-use `diff` allocation.
-                                    let diff = diff.into_owned();
-                                    count.as_mut().map(|c| c.plus_equals(&diff));
-                                    if count.is_none() { count = Some(diff); }
+                                    let diff = if let Some(owned_diff) = &mut owned_diff {
+                                        diff.clone_onto(owned_diff);
+                                        &*owned_diff
+                                    } else {
+                                        owned_diff.insert(diff.into_owned())
+                                    };
+                                    count.as_mut().map(|c| c.plus_equals(diff));
+                                    if count.is_none() { count = Some(diff.clone()); }
                                 });
                             }
 
                             // Apply `thresh` both before and after `diff` is applied to `count`.
                             // If the result is non-zero, send it along.
                             batch_cursor.map_times(&batch, |time, diff| {
-                                // TODO(antiguru): Re-use `diff` allocation.
-                                let diff = diff.into_owned();
+                                let diff = if let Some(owned_diff) = &mut owned_diff {
+                                    diff.clone_onto(owned_diff);
+                                    &*owned_diff
+                                } else {
+                                    owned_diff.insert(diff.into_owned())
+                                };
 
                                 let difference =
                                 match &count {
                                     Some(old) => {
                                         let mut temp = old.clone();
-                                        temp.plus_equals(&diff);
+                                        temp.plus_equals(diff);
                                         thresh(key, &temp, Some(old))
                                     },
-                                    None => { thresh(key, &diff, None) },
+                                    None => { thresh(key, diff, None) },
                                 };
 
                                 // Either add or assign `diff` to `count`.
                                 if let Some(count) = &mut count {
-                                    count.plus_equals(&diff);
+                                    count.plus_equals(diff);
                                 }
                                 else {
-                                    count = Some(diff);
+                                    count = Some(diff.clone());
                                 }
 
                                 if let Some(difference) = difference {

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -95,10 +95,10 @@ where G::Timestamp: TotalOrder+Lattice+Ord {
 
 impl<G, K, T1> ThresholdTotal<G, K, T1::DiffOwned> for Arranged<G, T1>
 where
-    G: Scope<Timestamp=T1::TimeOwned>,
+    G: Scope<Timestamp=T1::Time>,
     T1: for<'a> TraceReader<Key<'a>=&'a K, Val<'a>=&'a ()>+Clone+'static,
     K: ExchangeData,
-    T1::TimeOwned: TotalOrder,
+    T1::Time: TotalOrder,
     T1::DiffOwned: ExchangeData,
 {
     fn threshold_semigroup<R2, F>(&self, mut thresh: F) -> Collection<G, K, R2>

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -92,18 +92,18 @@ where G::Timestamp: TotalOrder+Lattice+Ord {
     }
 }
 
-impl<G, K, T1> ThresholdTotal<G, K, T1::Diff> for Arranged<G, T1>
+impl<G, K, T1> ThresholdTotal<G, K, T1::DiffOwned> for Arranged<G, T1>
 where
-    G: Scope<Timestamp=T1::Time>,
+    G: Scope<Timestamp=T1::TimeOwned>,
     T1: for<'a> TraceReader<Key<'a>=&'a K, Val<'a>=&'a ()>+Clone+'static,
     K: ExchangeData,
-    T1::Time: TotalOrder,
-    T1::Diff: ExchangeData,
+    T1::TimeOwned: TotalOrder,
+    T1::DiffOwned: ExchangeData,
 {
     fn threshold_semigroup<R2, F>(&self, mut thresh: F) -> Collection<G, K, R2>
     where
         R2: Semigroup,
-        F: for<'a> FnMut(T1::Key<'a>,&T1::Diff,Option<&T1::Diff>)->Option<R2>+'static,
+        F: for<'a> FnMut(T1::Key<'a>,&T1::DiffOwned,Option<&T1::DiffOwned>)->Option<R2>+'static,
     {
 
         let mut trace = self.trace.clone();
@@ -127,7 +127,7 @@ where
                         upper_limit.clone_from(batch.upper());
 
                         while let Some(key) = batch_cursor.get_key(&batch) {
-                            let mut count: Option<T1::Diff> = None;
+                            let mut count: Option<T1::DiffOwned> = None;
 
                             // Compute the multiplicity of this key before the current batch.
                             trace_cursor.seek_key(&trace_storage, key);

--- a/src/trace/cursor/cursor_list.rs
+++ b/src/trace/cursor/cursor_list.rs
@@ -88,7 +88,7 @@ impl<C: Cursor> Cursor for CursorList<C> {
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type TimeOwned = C::TimeOwned;
+    type Time = C::Time;
     type Diff<'a> = C::Diff<'a>;
     type DiffOwned = C::DiffOwned;
 
@@ -115,7 +115,7 @@ impl<C: Cursor> Cursor for CursorList<C> {
         self.cursors[self.min_val[0]].val(&storage[self.min_val[0]])
     }
     #[inline]
-    fn map_times<L: FnMut(&Self::TimeOwned, Self::Diff<'_>)>(&mut self, storage: &Vec<C::Storage>, mut logic: L) {
+    fn map_times<L: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &Vec<C::Storage>, mut logic: L) {
         for &index in self.min_val.iter() {
             self.cursors[index].map_times(&storage[index], |t,d| logic(t,d));
         }

--- a/src/trace/cursor/cursor_list.rs
+++ b/src/trace/cursor/cursor_list.rs
@@ -88,8 +88,9 @@ impl<C: Cursor> Cursor for CursorList<C> {
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type Time = C::Time;
-    type Diff = C::Diff;
+    type TimeOwned = C::TimeOwned;
+    type Diff<'a> = C::Diff<'a>;
+    type DiffOwned = C::DiffOwned;
 
     type Storage = Vec<C::Storage>;
 
@@ -114,7 +115,7 @@ impl<C: Cursor> Cursor for CursorList<C> {
         self.cursors[self.min_val[0]].val(&storage[self.min_val[0]])
     }
     #[inline]
-    fn map_times<L: FnMut(&Self::Time, &Self::Diff)>(&mut self, storage: &Vec<C::Storage>, mut logic: L) {
+    fn map_times<L: FnMut(&Self::TimeOwned, Self::Diff<'_>)>(&mut self, storage: &Vec<C::Storage>, mut logic: L) {
         for &index in self.min_val.iter() {
             self.cursors[index].map_times(&storage[index], |t,d| logic(t,d));
         }

--- a/src/trace/cursor/cursor_list.rs
+++ b/src/trace/cursor/cursor_list.rs
@@ -115,7 +115,7 @@ impl<C: Cursor> Cursor for CursorList<C> {
         self.cursors[self.min_val[0]].val(&storage[self.min_val[0]])
     }
     #[inline]
-    fn map_times<L: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &Vec<C::Storage>, mut logic: L) {
+    fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Vec<C::Storage>, mut logic: L) {
         for &index in self.min_val.iter() {
             self.cursors[index].map_times(&storage[index], |t,d| logic(t,d));
         }

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -65,9 +65,10 @@ pub trait Cursor {
     /// Values associated with keys.
     type Val<'a>: Copy + Clone + MyTrait<'a> + for<'b> PartialOrd<Self::Val<'b>>;
     /// Timestamps associated with updates
-    type TimeOwned: Timestamp + Lattice + Ord + Clone;
+    type Time: Timestamp + Lattice + Ord + Clone;
     /// Associated update.
     type Diff<'a>: Copy + Clone + MyTrait<'a, Owned = Self::DiffOwned>;
+    /// Owned version of the above.
     type DiffOwned: Semigroup + ?Sized;
 
     /// Storage required by the cursor.
@@ -98,7 +99,7 @@ pub trait Cursor {
 
     /// Applies `logic` to each pair of time and difference. Intended for mutation of the
     /// closure's scope.
-    fn map_times<L: FnMut(&Self::TimeOwned, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, logic: L);
+    fn map_times<L: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, logic: L);
 
     /// Advances the cursor to the next key.
     fn step_key(&mut self, storage: &Self::Storage);
@@ -120,7 +121,7 @@ pub trait Cursor {
     fn rewind_vals(&mut self, storage: &Self::Storage);
 
     /// Rewinds the cursor and outputs its contents to a Vec
-    fn to_vec<V, F>(&mut self, from: F, storage: &Self::Storage) -> Vec<((Self::KeyOwned, V), Vec<(Self::TimeOwned, Self::DiffOwned)>)>
+    fn to_vec<V, F>(&mut self, from: F, storage: &Self::Storage) -> Vec<((Self::KeyOwned, V), Vec<(Self::Time, Self::DiffOwned)>)>
     where 
         F: Fn(Self::Val<'_>) -> V,
     {

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -66,7 +66,7 @@ pub trait Cursor {
     type Val<'a>: Copy + Clone + MyTrait<'a> + for<'b> PartialOrd<Self::Val<'b>>;
     /// Timestamps associated with updates
     type Time: Timestamp + Lattice + Ord + Clone;
-    /// Associated update.
+    /// Associated difference.
     type Diff<'a>: Copy + Clone + MyTrait<'a, Owned = Self::DiffOwned>;
     /// Owned version of the above.
     type DiffOwned: Semigroup + ?Sized;

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -99,7 +99,7 @@ pub trait Cursor {
 
     /// Applies `logic` to each pair of time and difference. Intended for mutation of the
     /// closure's scope.
-    fn map_times<L: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, logic: L);
+    fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, logic: L);
 
     /// Advances the cursor to the next key.
     fn step_key(&mut self, storage: &Self::Storage);

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -93,9 +93,12 @@ pub trait Layout {
     /// Container for update vals.
     type ValContainer:
         BatchContainer<PushItem=<Self::Target as Update>::Val>;
-    /// Container for update vals.
-    type UpdContainer:
-        for<'a> BatchContainer<PushItem=(<Self::Target as Update>::Time, <Self::Target as Update>::Diff), ReadItem<'a> = &'a (<Self::Target as Update>::Time, <Self::Target as Update>::Diff)>;
+    /// Container for time vals.
+    type TimeContainer:
+        for<'a> BatchContainer<PushItem=<Self::Target as Update>::Time>;
+    /// Container for diff vals.
+    type DiffContainer:
+        for<'a> BatchContainer<PushItem=<Self::Target as Update>::Diff>;
     /// Container for offsets.
     type OffsetContainer: BatchContainer<PushItem=usize>;
 }
@@ -113,7 +116,8 @@ where
     type Target = U;
     type KeyContainer = Vec<U::Key>;
     type ValContainer = Vec<U::Val>;
-    type UpdContainer = Vec<(U::Time, U::Diff)>;
+    type TimeContainer = Vec<U::Time>;
+    type DiffContainer = Vec<U::Diff>;
     type OffsetContainer = OffsetList;
 }
 
@@ -132,7 +136,8 @@ where
     type Target = U;
     type KeyContainer = TimelyStack<U::Key>;
     type ValContainer = TimelyStack<U::Val>;
-    type UpdContainer = TimelyStack<(U::Time, U::Diff)>;
+    type TimeContainer = TimelyStack<U::Time>;
+    type DiffContainer = TimelyStack<U::Diff>;
     type OffsetContainer = OffsetList;
 }
 
@@ -185,7 +190,8 @@ where
     type Target = Preferred<K, V, T, D>;
     type KeyContainer = K::Container;
     type ValContainer = V::Container;
-    type UpdContainer = Vec<(T, D)>;
+    type TimeContainer = Vec<T>;
+    type DiffContainer = Vec<D>;
     type OffsetContainer = OffsetList;
 }
 

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -532,8 +532,8 @@ mod val_batch {
         /// to recover the singleton to push it into `updates` to join the second update.
         fn push_update(&mut self, time: <L::Target as Update>::Time, diff: <L::Target as Update>::Diff) {
             // If a just-pushed update exactly equals `(time, diff)` we can avoid pushing it.
-            let time_diff = self.result.times.last().zip(self.result.diffs.last());
-            if time_diff.map(|(t, d)| t.equals(&time) && d.equals(&diff)) == Some(true) {
+            let last_time_diff = self.result.times.last().zip(self.result.diffs.last());
+            if last_time_diff.map(|(t, d)| t.equals(&time) && d.equals(&diff)) == Some(true) {
                 assert!(self.singleton.is_none());
                 self.singleton = Some((time, diff));
             }
@@ -1010,8 +1010,8 @@ mod key_batch {
         /// to recover the singleton to push it into `updates` to join the second update.
         fn push_update(&mut self, time: <L::Target as Update>::Time, diff: <L::Target as Update>::Diff) {
             // If a just-pushed update exactly equals `(time, diff)` we can avoid pushing it.
-            let time_diff = self.result.times.last().zip(self.result.diffs.last());
-            if time_diff.map(|(t, d)| t.equals(&time) && d.equals(&diff)) == Some(true) {
+            let last_time_diff = self.result.times.last().zip(self.result.diffs.last());
+            if last_time_diff.map(|(t, d)| t.equals(&time) && d.equals(&diff)) == Some(true) {
                 assert!(self.singleton.is_none());
                 self.singleton = Some((time, diff));
             }

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -460,7 +460,7 @@ mod val_batch {
 
         fn key<'a>(&self, storage: &'a OrdValBatch<L>) -> Self::Key<'a> { storage.storage.keys.index(self.key_cursor) }
         fn val<'a>(&self, storage: &'a OrdValBatch<L>) -> Self::Val<'a> { storage.storage.vals.index(self.val_cursor) }
-        fn map_times<L2: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &OrdValBatch<L>, mut logic: L2) {
+        fn map_times<'a, L2: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_value(self.val_cursor);
             let mut owned_time = timely::progress::Timestamp::minimum();
             for index in lower .. upper {
@@ -943,7 +943,7 @@ mod key_batch {
 
         fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { storage.storage.keys.index(self.key_cursor) }
         fn val<'a>(&self, _storage: &'a Self::Storage) -> &'a () { &() }
-        fn map_times<L2: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, mut logic: L2) {
+        fn map_times<'a, L2: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_key(self.key_cursor);
             let mut owned_time = timely::progress::Timestamp::minimum();
             for index in lower .. upper {

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -460,7 +460,7 @@ mod val_batch {
 
         fn key<'a>(&self, storage: &'a OrdValBatch<L>) -> Self::Key<'a> { storage.storage.keys.index(self.key_cursor) }
         fn val<'a>(&self, storage: &'a OrdValBatch<L>) -> Self::Val<'a> { storage.storage.vals.index(self.val_cursor) }
-        fn map_times<'a, L2: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, mut logic: L2) {
+        fn map_times<'a, L2: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a OrdValBatch<L>, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_value(self.val_cursor);
             let mut owned_time = timely::progress::Timestamp::minimum();
             for index in lower .. upper {

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -142,8 +142,7 @@ mod val_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
-        type Time<'a> = <L::TimeContainer as BatchContainer>::ReadItem<'a>;
-        type TimeOwned = <L::Target as Update>::Time;
+        type Time = <L::Target as Update>::Time;
         type Diff<'a> = <L::DiffContainer as BatchContainer>::ReadItem<'a>;
         type DiffOwned = <L::Target as Update>::Diff;
 
@@ -193,7 +192,7 @@ mod val_batch {
 
     impl<L: Layout> Merger<OrdValBatch<L>> for OrdValMerger<L>
     where
-        OrdValBatch<L>: Batch<TimeOwned=<L::Target as Update>::Time>
+        OrdValBatch<L>: Batch<Time=<L::Target as Update>::Time>
     {
         fn new(batch1: &OrdValBatch<L>, batch2: &OrdValBatch<L>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
 
@@ -453,7 +452,7 @@ mod val_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
-        type TimeOwned = <L::Target as Update>::Time;
+        type Time = <L::Target as Update>::Time;
         type Diff<'a> = <L::DiffContainer as BatchContainer>::ReadItem<'a>;
         type DiffOwned = <L::Target as Update>::Diff;
 
@@ -461,7 +460,7 @@ mod val_batch {
 
         fn key<'a>(&self, storage: &'a OrdValBatch<L>) -> Self::Key<'a> { storage.storage.keys.index(self.key_cursor) }
         fn val<'a>(&self, storage: &'a OrdValBatch<L>) -> Self::Val<'a> { storage.storage.vals.index(self.val_cursor) }
-        fn map_times<L2: FnMut(&Self::TimeOwned, Self::Diff<'_>)>(&mut self, storage: &OrdValBatch<L>, mut logic: L2) {
+        fn map_times<L2: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &OrdValBatch<L>, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_value(self.val_cursor);
             for index in lower .. upper {
                 let time = storage.storage.times.index(index);
@@ -715,8 +714,7 @@ mod key_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = &'a ();
-        type Time<'a> = <L::TimeContainer as BatchContainer>::ReadItem<'a>;
-        type TimeOwned = <L::Target as Update>::Time;
+        type Time = <L::Target as Update>::Time;
         type Diff<'a> = <L::DiffContainer as BatchContainer>::ReadItem<'a>;
         type DiffOwned = <L::Target as Update>::Diff;
 
@@ -766,7 +764,7 @@ mod key_batch {
 
     impl<L: Layout> Merger<OrdKeyBatch<L>> for OrdKeyMerger<L>
     where
-        OrdKeyBatch<L>: Batch<TimeOwned=<L::Target as Update>::Time>
+        OrdKeyBatch<L>: Batch<Time=<L::Target as Update>::Time>
     {
         fn new(batch1: &OrdKeyBatch<L>, batch2: &OrdKeyBatch<L>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
 
@@ -937,7 +935,7 @@ mod key_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = &'a ();
-        type TimeOwned = <L::Target as Update>::Time;
+        type Time = <L::Target as Update>::Time;
         type Diff<'a> = <L::DiffContainer as BatchContainer>::ReadItem<'a>;
         type DiffOwned = <L::Target as Update>::Diff;
 
@@ -945,7 +943,7 @@ mod key_batch {
 
         fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { storage.storage.keys.index(self.key_cursor) }
         fn val<'a>(&self, _storage: &'a Self::Storage) -> &'a () { &() }
-        fn map_times<L2: FnMut(&Self::TimeOwned, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, mut logic: L2) {
+        fn map_times<L2: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_key(self.key_cursor);
             for index in lower .. upper {
                 let time = storage.storage.times.index(index);

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -623,7 +623,7 @@ mod val_batch {
             storage.storage.keys.index(self.key_cursor) 
         }
         fn val<'a>(&self, storage: &'a RhhValBatch<L>) -> Self::Val<'a> { storage.storage.vals.index(self.val_cursor) }
-        fn map_times<L2: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &RhhValBatch<L>, mut logic: L2) {
+        fn map_times<'a, L2: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_value(self.val_cursor);
             let mut owned_time = timely::progress::Timestamp::minimum();
             for index in lower .. upper {

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -134,8 +134,10 @@ mod val_batch {
         ///
         /// The length of this list is one longer than `vals`, so that we can avoid bounds logic.
         pub vals_offs: L::OffsetContainer,
-        /// Concatenated ordered lists of updates, bracketed by offsets in `vals_offs`.
-        pub updates: L::UpdContainer,
+        /// Ordered lists of updates, bracketed by offsets in `vals_offs`, split into
+        /// times and diffs. Must have equal length.
+        pub times: L::TimeContainer,
+        pub diffs: L::DiffContainer,
     }
 
     impl<L: Layout> RhhValStorage<L> 
@@ -256,8 +258,10 @@ mod val_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
-        type Time = <L::Target as Update>::Time;
-        type Diff = <L::Target as Update>::Diff;
+        type Time<'a> = <L::TimeContainer as BatchContainer>::ReadItem<'a>;
+        type TimeOwned = <L::Target as Update>::Time;
+        type Diff<'a> = <L::DiffContainer as BatchContainer>::ReadItem<'a>;
+        type DiffOwned = <L::Target as Update>::Diff;
 
         type Cursor = RhhValCursor<L>;
         fn cursor(&self) -> Self::Cursor { 
@@ -317,7 +321,7 @@ mod val_batch {
     impl<L: Layout> Merger<RhhValBatch<L>> for RhhValMerger<L>
     where
         <L::Target as Update>::Key: Default + HashOrdered,
-        RhhValBatch<L>: Batch<Time=<L::Target as Update>::Time>,
+        RhhValBatch<L>: Batch<TimeOwned=<L::Target as Update>::Time>,
     {
         fn new(batch1: &RhhValBatch<L>, batch2: &RhhValBatch<L>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
 
@@ -341,7 +345,8 @@ mod val_batch {
                 keys_offs: L::OffsetContainer::with_capacity(batch1.keys_offs.len() + batch2.keys_offs.len()),
                 vals: L::ValContainer::merge_capacity(&batch1.vals, &batch2.vals),
                 vals_offs: L::OffsetContainer::with_capacity(batch1.vals_offs.len() + batch2.vals_offs.len()),
-                updates: L::UpdContainer::merge_capacity(&batch1.updates, &batch2.updates),
+                times: L::TimeContainer::merge_capacity(&batch1.times, &batch2.times),
+                diffs: L::DiffContainer::merge_capacity(&batch1.diffs, &batch2.diffs),
                 key_count: 0,
                 key_capacity: rhh_cap,
                 divisor: RhhValStorage::<L>::divisor_for_capacity(rhh_cap),
@@ -365,7 +370,7 @@ mod val_batch {
         }
         fn done(self) -> RhhValBatch<L> {
             RhhValBatch {
-                updates: self.result.updates.len() + self.singletons,
+                updates: self.result.times.len() + self.singletons,
                 storage: self.result,
                 description: self.description,
             }
@@ -373,7 +378,7 @@ mod val_batch {
         fn work(&mut self, source1: &RhhValBatch<L>, source2: &RhhValBatch<L>, fuel: &mut isize) {
 
             // An (incomplete) indication of the amount of work we've done so far.
-            let starting_updates = self.result.updates.len();
+            let starting_updates = self.result.times.len();
             let mut effort = 0isize;
 
             source1.storage.advance_to_live_key(&mut self.key_cursor1);
@@ -385,7 +390,7 @@ mod val_batch {
                 source1.storage.advance_to_live_key(&mut self.key_cursor1);
                 source2.storage.advance_to_live_key(&mut self.key_cursor2);
                     // An (incomplete) accounting of the work we've done.
-                effort = (self.result.updates.len() - starting_updates) as isize;
+                effort = (self.result.times.len() - starting_updates) as isize;
             }
 
             // Merging is complete, and only copying remains. 
@@ -394,13 +399,13 @@ mod val_batch {
                 self.copy_key(&source1.storage, self.key_cursor1);
                 self.key_cursor1 += 1;
                 source1.storage.advance_to_live_key(&mut self.key_cursor1);
-                effort = (self.result.updates.len() - starting_updates) as isize;
+                effort = (self.result.times.len() - starting_updates) as isize;
             }
             while self.key_cursor2 < source2.storage.keys.len() && effort < *fuel {
                 self.copy_key(&source2.storage, self.key_cursor2);
                 self.key_cursor2 += 1;
                 source2.storage.advance_to_live_key(&mut self.key_cursor2);
-                effort = (self.result.updates.len() - starting_updates) as isize;
+                effort = (self.result.times.len() - starting_updates) as isize;
             }
 
             *fuel -= effort;
@@ -546,11 +551,11 @@ mod val_batch {
             let (lower, upper) = source.updates_for_value(index);
             for i in lower .. upper {
                 // NB: Here is where we would need to look back if `lower == upper`.
-                let (time, diff) = &source.updates.index(i);
-                let mut new_time = time.clone();
+                let mut time = source.times.index(i).into_owned();
+                let diff = source.diffs.index(i).into_owned();
                 use crate::lattice::Lattice;
-                new_time.advance_by(self.description.since().borrow());
-                self.update_stash.push((new_time, diff.clone()));
+                time.advance_by(self.description.since().borrow());
+                self.update_stash.push((time, diff));
             }
         }
 
@@ -561,18 +566,20 @@ mod val_batch {
             if !self.update_stash.is_empty() {
                 // If there is a single element, equal to a just-prior recorded update,
                 // we push nothing and report an unincremented offset to encode this case.
-                if self.update_stash.len() == 1 && self.result.updates.last().map(|l| l.equals(self.update_stash.last().unwrap())).unwrap_or(false) {
+                let ud = self.result.times.last().zip(self.result.diffs.last());
+                if self.update_stash.len() == 1 && self.update_stash.last().zip(ud).map(|((stashed_time, stashed_diff), (time, diff))| time.equals(stashed_time) && diff.equals(stashed_diff)).unwrap_or(false) {
                     // Just clear out update_stash, as we won't drain it here.
                     self.update_stash.clear();
                     self.singletons += 1;
                 }
                 else {
                     // Conventional; move `update_stash` into `updates`.
-                    for item in self.update_stash.drain(..) {
-                        self.result.updates.push(item);
+                    for (time, diff) in self.update_stash.drain(..) {
+                        self.result.times.push(time);
+                        self.result.diffs.push(diff);
                     }
                 }
-                Some(self.result.updates.len())
+                Some(self.result.times.len())
             } else {
                 None
             }
@@ -607,8 +614,9 @@ mod val_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
-        type Time = <L::Target as Update>::Time;
-        type Diff = <L::Target as Update>::Diff;
+        type TimeOwned = <L::Target as Update>::Time;
+        type Diff<'a> = <L::DiffContainer as BatchContainer>::ReadItem<'a>;
+        type DiffOwned = <L::Target as Update>::Diff;
 
         type Storage = RhhValBatch<L>;
 
@@ -616,11 +624,14 @@ mod val_batch {
             storage.storage.keys.index(self.key_cursor) 
         }
         fn val<'a>(&self, storage: &'a RhhValBatch<L>) -> Self::Val<'a> { storage.storage.vals.index(self.val_cursor) }
-        fn map_times<L2: FnMut(&Self::Time, &Self::Diff)>(&mut self, storage: &RhhValBatch<L>, mut logic: L2) {
+        fn map_times<L2: FnMut(&Self::TimeOwned, Self::Diff<'_>)>(&mut self, storage: &RhhValBatch<L>, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_value(self.val_cursor);
             for index in lower .. upper {
-                let (time, diff) = &storage.storage.updates.index(index);
-                logic(time, diff);
+                let time = storage.storage.times.index(index);
+                let diff = storage.storage.diffs.index(index);
+                // TODO(antiguru): We should avoid this clone.
+                let time = time.into_owned();
+                logic(&time, diff);
             }
         }
         fn key_valid(&self, storage: &RhhValBatch<L>) -> bool { self.key_cursor < storage.storage.keys.len() }
@@ -710,16 +721,19 @@ mod val_batch {
         /// to recover the singleton to push it into `updates` to join the second update.
         fn push_update(&mut self, time: <L::Target as Update>::Time, diff: <L::Target as Update>::Diff) {
             // If a just-pushed update exactly equals `(time, diff)` we can avoid pushing it.
-            if self.result.updates.last().map(|(t, d)| t == &time && d == &diff) == Some(true) {
+            let time_diff = self.result.times.last().zip(self.result.diffs.last());
+            if time_diff.map(|(t, d)| t.equals(&time) && d.equals(&diff)) == Some(true) {
                 assert!(self.singleton.is_none());
                 self.singleton = Some((time, diff));
             }
             else {
                 // If we have pushed a single element, we need to copy it out to meet this one.
-                if let Some(time_diff) = self.singleton.take() {
-                    self.result.updates.push(time_diff);
+                if let Some((time, diff)) = self.singleton.take() {
+                    self.result.times.push(time);
+                    self.result.diffs.push(diff);
                 }
-                self.result.updates.push((time, diff));
+                self.result.times.push(time);
+                self.result.diffs.push(diff);
             }
         }
     }
@@ -750,7 +764,8 @@ mod val_batch {
                     keys_offs: L::OffsetContainer::with_capacity(keys + 1),
                     vals: L::ValContainer::with_capacity(vals),
                     vals_offs: L::OffsetContainer::with_capacity(vals + 1),
-                    updates: L::UpdContainer::with_capacity(upds),
+                    times: L::TimeContainer::with_capacity(upds),
+                    diffs: L::DiffContainer::with_capacity(upds),
                     key_count: 0,
                     key_capacity: rhh_capacity,
                     divisor,
@@ -770,14 +785,14 @@ mod val_batch {
                     self.push_update(time, diff);
                 } else {
                     // New value; complete representation of prior value.
-                    self.result.vals_offs.push(self.result.updates.len());
+                    self.result.vals_offs.push(self.result.times.len());
                     if self.singleton.take().is_some() { self.singletons += 1; }
                     self.push_update(time, diff);
                     self.result.vals.push(val);
                 }
             } else {
                 // New key; complete representation of prior key.
-                self.result.vals_offs.push(self.result.updates.len());
+                self.result.vals_offs.push(self.result.times.len());
                 if self.singleton.take().is_some() { self.singletons += 1; }
                 self.result.keys_offs.push(self.result.vals.len());
                 self.push_update(time, diff);
@@ -799,7 +814,7 @@ mod val_batch {
                     self.push_update(time.clone(), diff.clone());
                 } else {
                     // New value; complete representation of prior value.
-                    self.result.vals_offs.push(self.result.updates.len());
+                    self.result.vals_offs.push(self.result.times.len());
                     // Remove any pending singleton, and if it was set increment our count.
                     if self.singleton.take().is_some() { self.singletons += 1; }
                     self.push_update(time.clone(), diff.clone());
@@ -807,7 +822,7 @@ mod val_batch {
                 }
             } else {
                 // New key; complete representation of prior key.
-                self.result.vals_offs.push(self.result.updates.len());
+                self.result.vals_offs.push(self.result.times.len());
                 // Remove any pending singleton, and if it was set increment our count.
                 if self.singleton.take().is_some() { self.singletons += 1; }
                 self.result.keys_offs.push(self.result.vals.len());
@@ -821,12 +836,12 @@ mod val_batch {
         #[inline(never)]
         fn done(mut self, lower: Antichain<Self::Time>, upper: Antichain<Self::Time>, since: Antichain<Self::Time>) -> RhhValBatch<L> {
             // Record the final offsets
-            self.result.vals_offs.push(self.result.updates.len());
+            self.result.vals_offs.push(self.result.times.len());
             // Remove any pending singleton, and if it was set increment our count.
             if self.singleton.take().is_some() { self.singletons += 1; }
             self.result.keys_offs.push(self.result.vals.len());
             RhhValBatch {
-                updates: self.result.updates.len() + self.singletons,
+                updates: self.result.times.len() + self.singletons,
                 storage: self.result,
                 description: Description::new(lower, upper, since),
             }

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -720,8 +720,8 @@ mod val_batch {
         /// to recover the singleton to push it into `updates` to join the second update.
         fn push_update(&mut self, time: <L::Target as Update>::Time, diff: <L::Target as Update>::Diff) {
             // If a just-pushed update exactly equals `(time, diff)` we can avoid pushing it.
-            let time_diff = self.result.times.last().zip(self.result.diffs.last());
-            if time_diff.map(|(t, d)| t.equals(&time) && d.equals(&diff)) == Some(true) {
+            let last_time_diff = self.result.times.last().zip(self.result.diffs.last());
+            if last_time_diff.map(|(t, d)| t.equals(&time) && d.equals(&diff)) == Some(true) {
                 assert!(self.singleton.is_none());
                 self.singleton = Some((time, diff));
             }

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -258,8 +258,7 @@ mod val_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
-        type Time<'a> = <L::TimeContainer as BatchContainer>::ReadItem<'a>;
-        type TimeOwned = <L::Target as Update>::Time;
+        type Time = <L::Target as Update>::Time;
         type Diff<'a> = <L::DiffContainer as BatchContainer>::ReadItem<'a>;
         type DiffOwned = <L::Target as Update>::Diff;
 
@@ -321,7 +320,7 @@ mod val_batch {
     impl<L: Layout> Merger<RhhValBatch<L>> for RhhValMerger<L>
     where
         <L::Target as Update>::Key: Default + HashOrdered,
-        RhhValBatch<L>: Batch<TimeOwned=<L::Target as Update>::Time>,
+        RhhValBatch<L>: Batch<Time=<L::Target as Update>::Time>,
     {
         fn new(batch1: &RhhValBatch<L>, batch2: &RhhValBatch<L>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
 
@@ -614,7 +613,7 @@ mod val_batch {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type KeyOwned = <L::Target as Update>::Key;
         type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
-        type TimeOwned = <L::Target as Update>::Time;
+        type Time = <L::Target as Update>::Time;
         type Diff<'a> = <L::DiffContainer as BatchContainer>::ReadItem<'a>;
         type DiffOwned = <L::Target as Update>::Diff;
 
@@ -624,7 +623,7 @@ mod val_batch {
             storage.storage.keys.index(self.key_cursor) 
         }
         fn val<'a>(&self, storage: &'a RhhValBatch<L>) -> Self::Val<'a> { storage.storage.vals.index(self.val_cursor) }
-        fn map_times<L2: FnMut(&Self::TimeOwned, Self::Diff<'_>)>(&mut self, storage: &RhhValBatch<L>, mut logic: L2) {
+        fn map_times<L2: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &RhhValBatch<L>, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_value(self.val_cursor);
             for index in lower .. upper {
                 let time = storage.storage.times.index(index);

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -625,12 +625,12 @@ mod val_batch {
         fn val<'a>(&self, storage: &'a RhhValBatch<L>) -> Self::Val<'a> { storage.storage.vals.index(self.val_cursor) }
         fn map_times<L2: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &RhhValBatch<L>, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_value(self.val_cursor);
+            let mut owned_time = timely::progress::Timestamp::minimum();
             for index in lower .. upper {
                 let time = storage.storage.times.index(index);
                 let diff = storage.storage.diffs.index(index);
-                // TODO(antiguru): We should avoid this clone.
-                let time = time.into_owned();
-                logic(&time, diff);
+                time.clone_onto(&mut owned_time);
+                logic(&owned_time, diff);
             }
         }
         fn key_valid(&self, storage: &RhhValBatch<L>) -> bool { self.key_cursor < storage.storage.keys.len() }

--- a/src/trace/implementations/spine_fueled.rs
+++ b/src/trace/implementations/spine_fueled.rs
@@ -112,19 +112,19 @@ where
     type Key<'a> = B::Key<'a>;
     type KeyOwned = B::KeyOwned;
     type Val<'a> = B::Val<'a>;
-    type Time = B::Time;
-    type Diff = B::Diff;
+    type TimeOwned = B::Time;
+    type DiffOwned = B::Diff;
 
     type Batch = B;
     type Storage = Vec<B>;
     type Cursor = CursorList<<B as BatchReader>::Cursor>;
 
-    fn cursor_through(&mut self, upper: AntichainRef<Self::Time>) -> Option<(Self::Cursor, Self::Storage)> {
+    fn cursor_through(&mut self, upper: AntichainRef<Self::TimeOwned>) -> Option<(Self::Cursor, Self::Storage)> {
 
         // If `upper` is the minimum frontier, we can return an empty cursor.
         // This can happen with operators that are written to expect the ability to acquire cursors
         // for their prior frontiers, and which start at `[T::minimum()]`, such as `Reduce`, sadly.
-        if upper.less_equal(&<Self::Time as timely::progress::Timestamp>::minimum()) {
+        if upper.less_equal(&<Self::TimeOwned as timely::progress::Timestamp>::minimum()) {
             let cursors = Vec::new();
             let storage = Vec::new();
             return Some((CursorList::new(cursors, &storage), storage));
@@ -324,7 +324,7 @@ where
     fn close(&mut self) {
         if !self.upper.borrow().is_empty() {
             let builder = Self::Builder::new();
-            let batch = builder.done(self.upper.clone(), Antichain::new(), Antichain::from_elem(<Self::Time as timely::progress::Timestamp>::minimum()));
+            let batch = builder.done(self.upper.clone(), Antichain::new(), Antichain::from_elem(<Self::TimeOwned as timely::progress::Timestamp>::minimum()));
             self.insert(batch);
         }
     }

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -65,13 +65,13 @@ pub trait TraceReader {
     type DiffOwned: Semigroup;
 
     /// The type of an immutable collection of updates.
-    type Batch: for<'a> BatchReader<Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, Time= Self::Time, DiffOwned= Self::DiffOwned>+Clone+'static;
+    type Batch: for<'a> BatchReader<Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, Time = Self::Time, DiffOwned= Self::DiffOwned>+Clone+'static;
 
     /// Storage type for `Self::Cursor`. Likely related to `Self::Batch`.
     type Storage;
 
     /// The type used to enumerate the collections contents.
-    type Cursor: for<'a> Cursor<Storage=Self::Storage, Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, Time= Self::Time, DiffOwned= Self::DiffOwned>;
+    type Cursor: for<'a> Cursor<Storage=Self::Storage, Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, Time = Self::Time, DiffOwned= Self::DiffOwned>;
 
     /// Provides a cursor over updates contained in the trace.
     fn cursor(&mut self) -> (Self::Cursor, Self::Storage) {
@@ -273,7 +273,7 @@ where
     type DiffOwned: Semigroup;
 
     /// The type used to enumerate the batch's contents.
-    type Cursor: for<'a> Cursor<Storage=Self, Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, Time= Self::Time, DiffOwned= Self::DiffOwned>;
+    type Cursor: for<'a> Cursor<Storage=Self, Key<'a> = Self::Key<'a>, KeyOwned = Self::KeyOwned, Val<'a> = Self::Val<'a>, Time = Self::Time, DiffOwned= Self::DiffOwned>;
     /// Acquires a cursor to the batch's contents.
     fn cursor(&self) -> Self::Cursor;
     /// The number of updates in the batch.

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -432,7 +432,7 @@ pub mod rc_blanket_impls {
         #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
         #[inline]
-        fn map_times<L: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, logic: L) {
+        fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, logic: L) {
             self.cursor.map_times(storage, logic)
         }
 
@@ -538,7 +538,7 @@ pub mod abomonated_blanket_impls {
         #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
         #[inline]
-        fn map_times<L: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, logic: L) {
+        fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, logic: L) {
             self.cursor.map_times(storage, logic)
         }
 

--- a/src/trace/wrappers/enter.rs
+++ b/src/trace/wrappers/enter.rs
@@ -185,7 +185,7 @@ where
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
     #[inline]
-    fn map_times<L: FnMut(&TInner, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, mut logic: L) {
         self.cursor.map_times(storage, |time, diff| {
             logic(&TInner::to_inner(time.clone()), diff)
         })
@@ -238,7 +238,7 @@ where
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
 
     #[inline]
-    fn map_times<L: FnMut(&TInner, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, mut logic: L) {
         self.cursor.map_times(&storage.batch, |time, diff| {
             logic(&TInner::to_inner(time.clone()), diff)
         })

--- a/src/trace/wrappers/enter.rs
+++ b/src/trace/wrappers/enter.rs
@@ -11,7 +11,7 @@ use crate::trace::cursor::Cursor;
 /// Wrapper to provide trace to nested scope.
 pub struct TraceEnter<Tr: TraceReader, TInner> {
     trace: Tr,
-    stash1: Antichain<Tr::TimeOwned>,
+    stash1: Antichain<Tr::Time>,
     stash2: Antichain<TInner>,
 }
 
@@ -29,13 +29,12 @@ impl<Tr, TInner> TraceReader for TraceEnter<Tr, TInner>
 where
     Tr: TraceReader,
     Tr::Batch: Clone,
-    TInner: Refines<Tr::TimeOwned>+Lattice,
+    TInner: Refines<Tr::Time>+Lattice,
 {
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type Time<'a> = TInner;
-    type TimeOwned = TInner;
+    type Time = TInner;
     type Diff<'a> = Tr::Diff<'a>;
     type DiffOwned = Tr::DiffOwned;
 
@@ -91,7 +90,7 @@ where
 impl<Tr, TInner> TraceEnter<Tr, TInner>
 where
     Tr: TraceReader,
-    TInner: Refines<Tr::TimeOwned>+Lattice,
+    TInner: Refines<Tr::Time>+Lattice,
 {
     /// Makes a new trace wrapper
     pub fn make_from(trace: Tr) -> Self {
@@ -114,13 +113,12 @@ pub struct BatchEnter<B, TInner> {
 impl<B, TInner> BatchReader for BatchEnter<B, TInner>
 where
     B: BatchReader,
-    TInner: Refines<B::TimeOwned>+Lattice,
+    TInner: Refines<B::Time>+Lattice,
 {
     type Key<'a> = B::Key<'a>;
     type KeyOwned = B::KeyOwned;
     type Val<'a> = B::Val<'a>;
-    type Time<'a> = TInner;
-    type TimeOwned = TInner;
+    type Time = TInner;
     type Diff<'a> = B::Diff<'a>;
     type DiffOwned = B::DiffOwned;
 
@@ -136,7 +134,7 @@ where
 impl<B, TInner> BatchEnter<B, TInner>
 where
     B: BatchReader,
-    TInner: Refines<B::TimeOwned>+Lattice,
+    TInner: Refines<B::Time>+Lattice,
 {
     /// Makes a new batch wrapper
     pub fn make_from(batch: B) -> Self {
@@ -169,12 +167,12 @@ impl<C, TInner> CursorEnter<C, TInner> {
 impl<C, TInner> Cursor for CursorEnter<C, TInner>
 where
     C: Cursor,
-    TInner: Refines<C::TimeOwned>+Lattice,
+    TInner: Refines<C::Time>+Lattice,
 {
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type TimeOwned = TInner;
+    type Time = TInner;
     type Diff<'a> = C::Diff<'a>;
     type DiffOwned = C::DiffOwned;
 
@@ -222,12 +220,12 @@ impl<C, TInner> BatchCursorEnter<C, TInner> {
 
 impl<TInner, C: Cursor> Cursor for BatchCursorEnter<C, TInner>
 where
-    TInner: Refines<C::TimeOwned>+Lattice,
+    TInner: Refines<C::Time>+Lattice,
 {
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type TimeOwned = TInner;
+    type Time = TInner;
     type Diff<'a> = C::Diff<'a>;
     type DiffOwned = C::DiffOwned;
 

--- a/src/trace/wrappers/enter.rs
+++ b/src/trace/wrappers/enter.rs
@@ -11,7 +11,7 @@ use crate::trace::cursor::Cursor;
 /// Wrapper to provide trace to nested scope.
 pub struct TraceEnter<Tr: TraceReader, TInner> {
     trace: Tr,
-    stash1: Antichain<Tr::Time>,
+    stash1: Antichain<Tr::TimeOwned>,
     stash2: Antichain<TInner>,
 }
 
@@ -29,13 +29,13 @@ impl<Tr, TInner> TraceReader for TraceEnter<Tr, TInner>
 where
     Tr: TraceReader,
     Tr::Batch: Clone,
-    TInner: Refines<Tr::Time>+Lattice,
+    TInner: Refines<Tr::TimeOwned>+Lattice,
 {
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type Time = TInner;
-    type Diff = Tr::Diff;
+    type TimeOwned = TInner;
+    type DiffOwned = Tr::DiffOwned;
 
     type Batch = BatchEnter<Tr::Batch, TInner>;
     type Storage = Tr::Storage;
@@ -89,7 +89,7 @@ where
 impl<Tr, TInner> TraceEnter<Tr, TInner>
 where
     Tr: TraceReader,
-    TInner: Refines<Tr::Time>+Lattice,
+    TInner: Refines<Tr::TimeOwned>+Lattice,
 {
     /// Makes a new trace wrapper
     pub fn make_from(trace: Tr) -> Self {

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -17,7 +17,7 @@ use crate::trace::cursor::Cursor;
 /// happens use this construct at your own peril!
 pub struct TraceEnter<Tr: TraceReader, TInner, F, G> {
     trace: Tr,
-    stash1: Antichain<Tr::Time>,
+    stash1: Antichain<Tr::TimeOwned>,
     stash2: Antichain<TInner>,
     logic: F,
     prior: G,
@@ -44,16 +44,16 @@ impl<Tr, TInner, F, G> TraceReader for TraceEnter<Tr, TInner, F, G>
 where
     Tr: TraceReader,
     Tr::Batch: Clone,
-    TInner: Refines<Tr::Time>+Lattice,
+    TInner: Refines<Tr::TimeOwned>+Lattice,
     F: 'static,
-    F: FnMut(Tr::Key<'_>, Tr::Val<'_>, &Tr::Time)->TInner+Clone,
-    G: FnMut(&TInner)->Tr::Time+Clone+'static,
+    F: FnMut(Tr::Key<'_>, Tr::Val<'_>, &Tr::TimeOwned)->TInner+Clone,
+    G: FnMut(&TInner)->Tr::TimeOwned +Clone+'static,
 {
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type Time = TInner;
-    type Diff = Tr::Diff;
+    type TimeOwned = TInner;
+    type DiffOwned = Tr::DiffOwned;
 
     type Batch = BatchEnter<Tr::Batch, TInner,F>;
     type Storage = Tr::Storage;
@@ -108,7 +108,7 @@ where
 impl<Tr, TInner, F, G> TraceEnter<Tr, TInner, F, G>
 where
     Tr: TraceReader,
-    TInner: Refines<Tr::Time>+Lattice,
+    TInner: Refines<Tr::TimeOwned>+Lattice,
 {
     /// Makes a new trace wrapper
     pub fn make_from(trace: Tr, logic: F, prior: G) -> Self {

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -212,7 +212,7 @@ where
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
     #[inline]
-    fn map_times<L: FnMut(&TInner, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, mut logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         let logic2 = &mut self.logic;
@@ -271,7 +271,7 @@ where
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
 
     #[inline]
-    fn map_times<L: FnMut(&TInner, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, mut logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         let logic2 = &mut self.logic;

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -47,7 +47,7 @@ where
     TInner: Refines<Tr::Time>+Lattice,
     F: 'static,
     F: FnMut(Tr::Key<'_>, Tr::Val<'_>, &Tr::Time)->TInner+Clone,
-    G: FnMut(&TInner)->Tr::Time +Clone+'static,
+    G: FnMut(&TInner)->Tr::Time+Clone+'static,
 {
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;

--- a/src/trace/wrappers/enter_at.rs
+++ b/src/trace/wrappers/enter_at.rs
@@ -17,7 +17,7 @@ use crate::trace::cursor::Cursor;
 /// happens use this construct at your own peril!
 pub struct TraceEnter<Tr: TraceReader, TInner, F, G> {
     trace: Tr,
-    stash1: Antichain<Tr::TimeOwned>,
+    stash1: Antichain<Tr::Time>,
     stash2: Antichain<TInner>,
     logic: F,
     prior: G,
@@ -44,16 +44,15 @@ impl<Tr, TInner, F, G> TraceReader for TraceEnter<Tr, TInner, F, G>
 where
     Tr: TraceReader,
     Tr::Batch: Clone,
-    TInner: Refines<Tr::TimeOwned>+Lattice,
+    TInner: Refines<Tr::Time>+Lattice,
     F: 'static,
-    F: FnMut(Tr::Key<'_>, Tr::Val<'_>, &Tr::TimeOwned)->TInner+Clone,
-    G: FnMut(&TInner)->Tr::TimeOwned +Clone+'static,
+    F: FnMut(Tr::Key<'_>, Tr::Val<'_>, &Tr::Time)->TInner+Clone,
+    G: FnMut(&TInner)->Tr::Time +Clone+'static,
 {
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type Time<'a> = TInner;
-    type TimeOwned = TInner;
+    type Time = TInner;
     type Diff<'a> = Tr::Diff<'a>;
     type DiffOwned = Tr::DiffOwned;
 
@@ -110,7 +109,7 @@ where
 impl<Tr, TInner, F, G> TraceEnter<Tr, TInner, F, G>
 where
     Tr: TraceReader,
-    TInner: Refines<Tr::TimeOwned>+Lattice,
+    TInner: Refines<Tr::Time>+Lattice,
 {
     /// Makes a new trace wrapper
     pub fn make_from(trace: Tr, logic: F, prior: G) -> Self {
@@ -136,14 +135,13 @@ pub struct BatchEnter<B, TInner, F> {
 impl<B, TInner, F> BatchReader for BatchEnter<B, TInner, F>
 where
     B: BatchReader,
-    TInner: Refines<B::TimeOwned>+Lattice,
-    F: FnMut(B::Key<'_>, <B::Cursor as Cursor>::Val<'_>, &B::TimeOwned)->TInner+Clone,
+    TInner: Refines<B::Time>+Lattice,
+    F: FnMut(B::Key<'_>, <B::Cursor as Cursor>::Val<'_>, &B::Time)->TInner+Clone,
 {
     type Key<'a> = B::Key<'a>;
     type KeyOwned = B::KeyOwned;
     type Val<'a> = B::Val<'a>;
-    type Time<'a> = TInner;
-    type TimeOwned = TInner;
+    type Time = TInner;
     type Diff<'a> = B::Diff<'a>;
     type DiffOwned = B::DiffOwned;
 
@@ -159,7 +157,7 @@ where
 impl<B, TInner, F> BatchEnter<B, TInner, F>
 where
     B: BatchReader,
-    TInner: Refines<B::TimeOwned>+Lattice,
+    TInner: Refines<B::Time>+Lattice,
 {
     /// Makes a new batch wrapper
     pub fn make_from(batch: B, logic: F) -> Self {
@@ -195,13 +193,13 @@ impl<C, TInner, F> CursorEnter<C, TInner, F> {
 impl<C, TInner, F> Cursor for CursorEnter<C, TInner, F>
 where
     C: Cursor,
-    TInner: Refines<C::TimeOwned>+Lattice,
-    F: FnMut(C::Key<'_>, C::Val<'_>, &C::TimeOwned)->TInner,
+    TInner: Refines<C::Time>+Lattice,
+    F: FnMut(C::Key<'_>, C::Val<'_>, &C::Time)->TInner,
 {
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type TimeOwned = TInner;
+    type Time = TInner;
     type Diff<'a> = C::Diff<'a>;
     type DiffOwned = C::DiffOwned;
 
@@ -254,13 +252,13 @@ impl<C, TInner, F> BatchCursorEnter<C, TInner, F> {
 
 impl<TInner, C: Cursor, F> Cursor for BatchCursorEnter<C, TInner, F>
 where
-    TInner: Refines<C::TimeOwned>+Lattice,
-    F: FnMut(C::Key<'_>, C::Val<'_>, &C::TimeOwned)->TInner,
+    TInner: Refines<C::Time>+Lattice,
+    F: FnMut(C::Key<'_>, C::Val<'_>, &C::Time)->TInner,
 {
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type TimeOwned = TInner;
+    type Time = TInner;
     type Diff<'a> = C::Diff<'a>;
     type DiffOwned = C::DiffOwned;
 

--- a/src/trace/wrappers/filter.rs
+++ b/src/trace/wrappers/filter.rs
@@ -33,8 +33,7 @@ where
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type Time<'a> = Tr::Time<'a>;
-    type TimeOwned = Tr::TimeOwned;
+    type Time = Tr::Time;
     type Diff<'a> = Tr::Diff<'a>;
     type DiffOwned = Tr::DiffOwned;
 
@@ -48,13 +47,13 @@ where
             .map_batches(|batch| f(&Self::Batch::make_from(batch.clone(), logic.clone())))
     }
 
-    fn set_logical_compaction(&mut self, frontier: AntichainRef<Tr::TimeOwned>) { self.trace.set_logical_compaction(frontier) }
-    fn get_logical_compaction(&mut self) -> AntichainRef<Tr::TimeOwned> { self.trace.get_logical_compaction() }
+    fn set_logical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.set_logical_compaction(frontier) }
+    fn get_logical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.trace.get_logical_compaction() }
 
-    fn set_physical_compaction(&mut self, frontier: AntichainRef<Tr::TimeOwned>) { self.trace.set_physical_compaction(frontier) }
-    fn get_physical_compaction(&mut self) -> AntichainRef<Tr::TimeOwned> { self.trace.get_physical_compaction() }
+    fn set_physical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.set_physical_compaction(frontier) }
+    fn get_physical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.trace.get_physical_compaction() }
 
-    fn cursor_through(&mut self, upper: AntichainRef<Tr::TimeOwned>) -> Option<(Self::Cursor, Self::Storage)> {
+    fn cursor_through(&mut self, upper: AntichainRef<Tr::Time>) -> Option<(Self::Cursor, Self::Storage)> {
         self.trace.cursor_through(upper).map(|(x,y)| (CursorFilter::new(x, self.logic.clone()), y))
     }
 }
@@ -88,8 +87,7 @@ where
     type Key<'a> = B::Key<'a>;
     type KeyOwned = B::KeyOwned;
     type Val<'a> = B::Val<'a>;
-    type Time<'a> = B::Time<'a>;
-    type TimeOwned = B::TimeOwned;
+    type Time = B::Time;
     type Diff<'a> = B::Diff<'a>;
     type DiffOwned = B::DiffOwned;
 
@@ -99,7 +97,7 @@ where
         BatchCursorFilter::new(self.batch.cursor(), self.logic.clone())
     }
     fn len(&self) -> usize { self.batch.len() }
-    fn description(&self) -> &Description<B::TimeOwned> { self.batch.description() }
+    fn description(&self) -> &Description<B::Time> { self.batch.description() }
 }
 
 impl<B, F> BatchFilter<B, F>
@@ -138,7 +136,7 @@ where
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type TimeOwned = C::TimeOwned;
+    type Time = C::Time;
     type Diff<'a> = C::Diff<'a>;
     type DiffOwned = C::DiffOwned;
 
@@ -151,7 +149,7 @@ where
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
     #[inline]
-    fn map_times<L: FnMut(&Self::TimeOwned,Self::Diff<'_>)>(&mut self, storage: &Self::Storage, logic: L) {
+    fn map_times<L: FnMut(&Self::Time,Self::Diff<'_>)>(&mut self, storage: &Self::Storage, logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         if (self.logic)(key, val) {
@@ -193,7 +191,7 @@ where
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type TimeOwned = C::TimeOwned;
+    type Time = C::Time;
     type Diff<'a> = C::Diff<'a>;
     type DiffOwned = C::DiffOwned;
 
@@ -206,7 +204,7 @@ where
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
 
     #[inline]
-    fn map_times<L: FnMut(&Self::TimeOwned,Self::Diff<'_>)>(&mut self, storage: &Self::Storage, logic: L) {
+    fn map_times<L: FnMut(&Self::Time,Self::Diff<'_>)>(&mut self, storage: &Self::Storage, logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         if (self.logic)(key, val) {

--- a/src/trace/wrappers/filter.rs
+++ b/src/trace/wrappers/filter.rs
@@ -149,7 +149,7 @@ where
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
     #[inline]
-    fn map_times<L: FnMut(&Self::Time,Self::Diff<'_>)>(&mut self, storage: &Self::Storage, logic: L) {
+    fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         if (self.logic)(key, val) {
@@ -204,7 +204,7 @@ where
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
 
     #[inline]
-    fn map_times<L: FnMut(&Self::Time,Self::Diff<'_>)>(&mut self, storage: &Self::Storage, logic: L) {
+    fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         if (self.logic)(key, val) {

--- a/src/trace/wrappers/filter.rs
+++ b/src/trace/wrappers/filter.rs
@@ -33,8 +33,8 @@ where
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type Time = Tr::Time;
-    type Diff = Tr::Diff;
+    type TimeOwned = Tr::TimeOwned;
+    type DiffOwned = Tr::DiffOwned;
 
     type Batch = BatchFilter<Tr::Batch, F>;
     type Storage = Tr::Storage;
@@ -46,13 +46,13 @@ where
             .map_batches(|batch| f(&Self::Batch::make_from(batch.clone(), logic.clone())))
     }
 
-    fn set_logical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.set_logical_compaction(frontier) }
-    fn get_logical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.trace.get_logical_compaction() }
+    fn set_logical_compaction(&mut self, frontier: AntichainRef<Tr::TimeOwned>) { self.trace.set_logical_compaction(frontier) }
+    fn get_logical_compaction(&mut self) -> AntichainRef<Tr::TimeOwned> { self.trace.get_logical_compaction() }
 
-    fn set_physical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) { self.trace.set_physical_compaction(frontier) }
-    fn get_physical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.trace.get_physical_compaction() }
+    fn set_physical_compaction(&mut self, frontier: AntichainRef<Tr::TimeOwned>) { self.trace.set_physical_compaction(frontier) }
+    fn get_physical_compaction(&mut self) -> AntichainRef<Tr::TimeOwned> { self.trace.get_physical_compaction() }
 
-    fn cursor_through(&mut self, upper: AntichainRef<Tr::Time>) -> Option<(Self::Cursor, Self::Storage)> {
+    fn cursor_through(&mut self, upper: AntichainRef<Tr::TimeOwned>) -> Option<(Self::Cursor, Self::Storage)> {
         self.trace.cursor_through(upper).map(|(x,y)| (CursorFilter::new(x, self.logic.clone()), y))
     }
 }

--- a/src/trace/wrappers/filter.rs
+++ b/src/trace/wrappers/filter.rs
@@ -33,7 +33,9 @@ where
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
+    type Time<'a> = Tr::Time<'a>;
     type TimeOwned = Tr::TimeOwned;
+    type Diff<'a> = Tr::Diff<'a>;
     type DiffOwned = Tr::DiffOwned;
 
     type Batch = BatchFilter<Tr::Batch, F>;
@@ -86,8 +88,10 @@ where
     type Key<'a> = B::Key<'a>;
     type KeyOwned = B::KeyOwned;
     type Val<'a> = B::Val<'a>;
-    type Time = B::Time;
-    type Diff = B::Diff;
+    type Time<'a> = B::Time<'a>;
+    type TimeOwned = B::TimeOwned;
+    type Diff<'a> = B::Diff<'a>;
+    type DiffOwned = B::DiffOwned;
 
     type Cursor = BatchCursorFilter<B::Cursor, F>;
 
@@ -95,7 +99,7 @@ where
         BatchCursorFilter::new(self.batch.cursor(), self.logic.clone())
     }
     fn len(&self) -> usize { self.batch.len() }
-    fn description(&self) -> &Description<B::Time> { self.batch.description() }
+    fn description(&self) -> &Description<B::TimeOwned> { self.batch.description() }
 }
 
 impl<B, F> BatchFilter<B, F>
@@ -134,8 +138,9 @@ where
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type Time = C::Time;
-    type Diff = C::Diff;
+    type TimeOwned = C::TimeOwned;
+    type Diff<'a> = C::Diff<'a>;
+    type DiffOwned = C::DiffOwned;
 
     type Storage = C::Storage;
 
@@ -146,7 +151,7 @@ where
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
     #[inline]
-    fn map_times<L: FnMut(&Self::Time,&Self::Diff)>(&mut self, storage: &Self::Storage, logic: L) {
+    fn map_times<L: FnMut(&Self::TimeOwned,Self::Diff<'_>)>(&mut self, storage: &Self::Storage, logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         if (self.logic)(key, val) {
@@ -188,8 +193,9 @@ where
     type Key<'a> = C::Key<'a>;
     type KeyOwned = C::KeyOwned;
     type Val<'a> = C::Val<'a>;
-    type Time = C::Time;
-    type Diff = C::Diff;
+    type TimeOwned = C::TimeOwned;
+    type Diff<'a> = C::Diff<'a>;
+    type DiffOwned = C::DiffOwned;
 
     type Storage = BatchFilter<C::Storage, F>;
 
@@ -200,7 +206,7 @@ where
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
 
     #[inline]
-    fn map_times<L: FnMut(&Self::Time,&Self::Diff)>(&mut self, storage: &Self::Storage, logic: L) {
+    fn map_times<L: FnMut(&Self::TimeOwned,Self::Diff<'_>)>(&mut self, storage: &Self::Storage, logic: L) {
         let key = self.key(storage);
         let val = self.val(storage);
         if (self.logic)(key, val) {

--- a/src/trace/wrappers/freeze.rs
+++ b/src/trace/wrappers/freeze.rs
@@ -198,7 +198,7 @@ where
     #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(storage) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
-    #[inline] fn map_times<L: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, mut logic: L) {
         let func = &self.func;
         self.cursor.map_times(storage, |time, diff| {
             if let Some(time) = func(time) {
@@ -250,7 +250,7 @@ where
     #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(&storage.batch) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
 
-    #[inline] fn map_times<L: FnMut(&Self::Time, Self::Diff<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, mut logic: L) {
         let func = &self.func;
         self.cursor.map_times(&storage.batch, |time, diff| {
             if let Some(time) = func(time) {

--- a/src/trace/wrappers/frontier.rs
+++ b/src/trace/wrappers/frontier.rs
@@ -144,7 +144,7 @@ impl<C: Cursor> Cursor for CursorFrontier<C, C::Time> {
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
     #[inline]
-    fn map_times<L: FnMut(&Self::Time,Self::Diff<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, mut logic: L) {
         let since = self.since.borrow();
         let until = self.until.borrow();
         let mut temp: C::Time = <C::Time as timely::progress::Timestamp>::minimum();
@@ -206,7 +206,7 @@ where
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
 
     #[inline]
-    fn map_times<L: FnMut(&Self::Time,Self::Diff<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<'a, L: FnMut(&Self::Time, Self::Diff<'a>)>(&mut self, storage: &'a Self::Storage, mut logic: L) {
         let since = self.since.borrow();
         let until = self.until.borrow();
         let mut temp: C::Time = <C::Time as timely::progress::Timestamp>::minimum();

--- a/src/trace/wrappers/rc.rs
+++ b/src/trace/wrappers/rc.rs
@@ -25,9 +25,9 @@ use crate::trace::TraceReader;
 /// may influence.
 pub struct TraceBox<Tr: TraceReader> {
     /// accumulated holds on times for advancement.
-    pub logical_compaction: MutableAntichain<Tr::TimeOwned>,
+    pub logical_compaction: MutableAntichain<Tr::Time>,
     /// accumulated holds on times for distinction.
-    pub physical_compaction: MutableAntichain<Tr::TimeOwned>,
+    pub physical_compaction: MutableAntichain<Tr::Time>,
     /// The wrapped trace.
     pub trace: Tr,
 }
@@ -52,14 +52,14 @@ impl<Tr: TraceReader> TraceBox<Tr> {
     }
     /// Replaces elements of `lower` with those of `upper`.
     #[inline]
-    pub fn adjust_logical_compaction(&mut self, lower: AntichainRef<Tr::TimeOwned>, upper: AntichainRef<Tr::TimeOwned>) {
+    pub fn adjust_logical_compaction(&mut self, lower: AntichainRef<Tr::Time>, upper: AntichainRef<Tr::Time>) {
         self.logical_compaction.update_iter(upper.iter().cloned().map(|t| (t,1)));
         self.logical_compaction.update_iter(lower.iter().cloned().map(|t| (t,-1)));
         self.trace.set_logical_compaction(self.logical_compaction.frontier());
     }
     /// Replaces elements of `lower` with those of `upper`.
     #[inline]
-    pub fn adjust_physical_compaction(&mut self, lower: AntichainRef<Tr::TimeOwned>, upper: AntichainRef<Tr::TimeOwned>) {
+    pub fn adjust_physical_compaction(&mut self, lower: AntichainRef<Tr::Time>, upper: AntichainRef<Tr::Time>) {
         self.physical_compaction.update_iter(upper.iter().cloned().map(|t| (t,1)));
         self.physical_compaction.update_iter(lower.iter().cloned().map(|t| (t,-1)));
         self.trace.set_physical_compaction(self.physical_compaction.frontier());
@@ -72,8 +72,8 @@ impl<Tr: TraceReader> TraceBox<Tr> {
 /// timestamps past the frontier maintained by the handle. The intent is that such a handle appears as
 /// if it is a privately maintained trace, despite being backed by shared resources.
 pub struct TraceRc<Tr: TraceReader> {
-    logical_compaction: Antichain<Tr::TimeOwned>,
-    physical_compaction: Antichain<Tr::TimeOwned>,
+    logical_compaction: Antichain<Tr::Time>,
+    physical_compaction: Antichain<Tr::Time>,
     /// Wrapped trace. Please be gentle when using.
     pub wrapper: Rc<RefCell<TraceBox<Tr>>>,
 }
@@ -82,8 +82,7 @@ impl<Tr: TraceReader> TraceReader for TraceRc<Tr> {
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
-    type Time<'a> = Tr::Time<'a>;
-    type TimeOwned = Tr::TimeOwned;
+    type Time = Tr::Time;
     type Diff<'a> = Tr::Diff<'a>;
     type DiffOwned = Tr::DiffOwned;
 
@@ -96,19 +95,19 @@ impl<Tr: TraceReader> TraceReader for TraceRc<Tr> {
     /// This change may not have immediately observable effects. It informs the shared trace that this
     /// handle no longer requires access to times other than those in the future of `frontier`, but if
     /// there are other handles to the same trace, it may not yet be able to compact.
-    fn set_logical_compaction(&mut self, frontier: AntichainRef<Tr::TimeOwned>) {
+    fn set_logical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) {
         self.wrapper.borrow_mut().adjust_logical_compaction(self.logical_compaction.borrow(), frontier);
         self.logical_compaction = frontier.to_owned();
     }
-    fn get_logical_compaction(&mut self) -> AntichainRef<Tr::TimeOwned> { self.logical_compaction.borrow() }
+    fn get_logical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.logical_compaction.borrow() }
     /// Allows the trace to compact batches of times before `frontier`.
-    fn set_physical_compaction(&mut self, frontier: AntichainRef<Tr::TimeOwned>) {
+    fn set_physical_compaction(&mut self, frontier: AntichainRef<Tr::Time>) {
         self.wrapper.borrow_mut().adjust_physical_compaction(self.physical_compaction.borrow(), frontier);
         self.physical_compaction = frontier.to_owned();
     }
-    fn get_physical_compaction(&mut self) -> AntichainRef<Tr::TimeOwned> { self.physical_compaction.borrow() }
+    fn get_physical_compaction(&mut self) -> AntichainRef<Tr::Time> { self.physical_compaction.borrow() }
     /// Creates a new cursor over the wrapped trace.
-    fn cursor_through(&mut self, frontier: AntichainRef<Tr::TimeOwned>) -> Option<(Tr::Cursor, Tr::Storage)> {
+    fn cursor_through(&mut self, frontier: AntichainRef<Tr::Time>) -> Option<(Tr::Cursor, Tr::Storage)> {
         ::std::cell::RefCell::borrow_mut(&self.wrapper).trace.cursor_through(frontier)
     }
 

--- a/src/trace/wrappers/rc.rs
+++ b/src/trace/wrappers/rc.rs
@@ -82,7 +82,9 @@ impl<Tr: TraceReader> TraceReader for TraceRc<Tr> {
     type Key<'a> = Tr::Key<'a>;
     type KeyOwned = Tr::KeyOwned;
     type Val<'a> = Tr::Val<'a>;
+    type Time<'a> = Tr::Time<'a>;
     type TimeOwned = Tr::TimeOwned;
+    type Diff<'a> = Tr::Diff<'a>;
     type DiffOwned = Tr::DiffOwned;
 
     type Batch = Tr::Batch;


### PR DESCRIPTION
Turn time and diff into GATs within the storage layer, and expose the diff GAT trough cursors. This enables more efficient storage for times and diffs in arrangements, while leaving the upper layers mostly the same.