### PR TITLE
Cleanup, fix rhh example

### DIFF
--- a/examples/spines.rs
+++ b/examples/spines.rs
@@ -41,13 +41,13 @@ fn main() {
                     keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
                         .probe_with(&mut probe);
                 },
-                // "rhh" => {
-                //     use differential_dataflow::trace::implementations::rhh::{HashWrapper, VecSpine};
-                //     let data = data.map(|x| HashWrapper { inner: x }).arrange::<VecSpine<_,(),_,_>>();
-                //     let keys = keys.map(|x| HashWrapper { inner: x }).arrange::<VecSpine<_,(),_,_>>();
-                //     keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
-                //         .probe_with(&mut probe);
-                // },
+                "rhh" => {
+                    use differential_dataflow::trace::implementations::rhh::{HashWrapper, VecSpine};
+                    let data = data.map(|x| HashWrapper { inner: x }).arrange::<VecSpine<_,(),_,_>>();
+                    let keys = keys.map(|x| HashWrapper { inner: x }).arrange::<VecSpine<_,(),_,_>>();
+                    keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
+                        .probe_with(&mut probe);
+                },
                 "slc" => {
 
                     use differential_dataflow::trace::implementations::ord_neu::PreferredSpine;
@@ -61,10 +61,7 @@ fn main() {
                         .arrange::<PreferredSpine<[u8],u8,_,_>>()
                         .reduce_abelian::<_, _, _, PreferredSpine<[u8],(),_,_>>("distinct", |_| (), |_,_,output| output.push(((), 1)));
 
-                    keys.join_core(&data, |k,_v1,_v2| {
-                        println!("{:?}", k.text);
-                        Option::<((),isize,isize)>::None
-                    })
+                    keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
                         .probe_with(&mut probe);
                 },
                 _ => {

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -68,7 +68,14 @@ where <T as Hashable>::Output: PartialOrd {
 
 impl<T: std::hash::Hash + Hashable> HashOrdered for HashWrapper<T> { }
 
-impl<T: std::hash::Hash + Hashable> Hashable for HashWrapper<T> { 
+impl<T: std::hash::Hash + Hashable> Hashable for HashWrapper<T> {
+    type Output = T::Output;
+    fn hashed(&self) -> Self::Output { self.inner.hashed() }
+}
+
+impl<T: std::hash::Hash + Hashable> HashOrdered for &HashWrapper<T> { }
+
+impl<T: std::hash::Hash + Hashable> Hashable for &HashWrapper<T> {
     type Output = T::Output;
     fn hashed(&self) -> Self::Output { self.inner.hashed() }
 }


### PR DESCRIPTION
As the title says, cleanup and fix the RHH example. Removes the `SliceContainer2` type, which really just existed as an example on how to implement various requirements for a custom type. Good to have, but wrong place.
