### PR TITLE
Introduce and integrate `IntoOwned` trait

### DIFF
--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -208,9 +208,9 @@ where
                             // Use TOTAL ORDER to allow the release of `time`.
                             yielded = yielded || yield_function(timer, work);
                             if !yielded && !input2.frontier.frontier().iter().any(|t| comparison(t, initial)) {
-                                use differential_dataflow::trace::cursor::MyTrait;
-                                cursor.seek_key(&storage, MyTrait::borrow_as(key));
-                                if cursor.get_key(&storage) == Some(MyTrait::borrow_as(key)) {
+                                use differential_dataflow::trace::cursor::IntoOwned;
+                                cursor.seek_key(&storage, IntoOwned::borrow_as(key));
+                                if cursor.get_key(&storage) == Some(IntoOwned::borrow_as(key)) {
                                     while let Some(val2) = cursor.get_val(&storage) {
                                         cursor.map_times(&storage, |t, d| {
                                             if comparison(t, initial) {

--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -93,9 +93,9 @@ where
                     for &mut (ref prefix, ref time, ref mut diff) in prefixes.iter_mut() {
                         if !input2.frontier.less_equal(time) {
                             logic2(prefix, &mut key1);
-                            use differential_dataflow::trace::cursor::MyTrait;
-                            cursor.seek_key(&storage, MyTrait::borrow_as(&key1));
-                            if cursor.get_key(&storage) == Some(MyTrait::borrow_as(&key1)) {
+                            use differential_dataflow::trace::cursor::IntoOwned;
+                            cursor.seek_key(&storage, IntoOwned::borrow_as(&key1));
+                            if cursor.get_key(&storage) == Some(IntoOwned::borrow_as(&key1)) {
                                 while let Some(value) = cursor.get_val(&storage) {
                                     let mut count = Tr::Diff::zero();
                                     cursor.map_times(&storage, |t, d| {

--- a/src/operators/arrange/upsert.rs
+++ b/src/operators/arrange/upsert.rs
@@ -244,14 +244,14 @@ where
                                 let mut builder = Tr::Builder::new();
                                 for (key, mut list) in to_process.drain(..) {
 
-                                    use trace::cursor::MyTrait;
+                                    use trace::cursor::IntoOwned;
 
                                     // The prior value associated with the key.
                                     let mut prev_value: Option<V> = None;
 
                                     // Attempt to find the key in the trace.
-                                    trace_cursor.seek_key_owned(&trace_storage, &key);
-                                    if trace_cursor.get_key(&trace_storage).map(|k| k.equals(&key)).unwrap_or(false) {
+                                    trace_cursor.seek_key(&trace_storage, IntoOwned::borrow_as(&key));
+                                    if trace_cursor.get_key(&trace_storage).map(|k| k.eq(&IntoOwned::borrow_as(&key))).unwrap_or(false) {
                                         // Determine the prior value associated with the key.
                                         while let Some(val) = trace_cursor.get_val(&trace_storage) {
                                             let mut count = 0;

--- a/src/operators/consolidate.rs
+++ b/src/operators/consolidate.rs
@@ -57,7 +57,7 @@ where
         Tr::Batcher: Batcher<Input=Vec<((D,()),G::Timestamp,R)>>,
     {
         use crate::operators::arrange::arrangement::Arrange;
-        use crate::trace::cursor::MyTrait;
+        use crate::trace::cursor::IntoOwned;
         self.map(|k| (k, ()))
             .arrange_named::<Tr>(name)
             .as_collection(|d, _| d.into_owned())

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -70,7 +70,7 @@ where
 
             move |input, output| {
 
-                use crate::trace::cursor::MyTrait;
+                use crate::trace::cursor::IntoOwned;
                 input.for_each(|capability, batches| {
                     batches.swap(&mut buffer);
                     let mut session = output.session(&capability);

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -478,10 +478,10 @@ where
                         while batch_cursor.key_valid(batch_storage) || exposed_position < exposed.len() {
 
                             use std::borrow::Borrow;
-                            use crate::trace::cursor::MyTrait;
+                            use crate::trace::cursor::IntoOwned;
 
                             // Determine the next key we will work on; could be synthetic, could be from a batch.
-                            let key1 = exposed.get(exposed_position).map(|x| <_ as MyTrait>::borrow_as(&x.0));
+                            let key1 = exposed.get(exposed_position).map(|x| <_ as IntoOwned>::borrow_as(&x.0));
                             let key2 = batch_cursor.get_key(batch_storage);
                             let key = match (key1, key2) {
                                 (Some(key1), Some(key2)) => ::std::cmp::min(key1, key2),
@@ -497,7 +497,7 @@ where
                             interesting_times.clear();
 
                             // Populate `interesting_times` with synthetic interesting times (below `upper_limit`) for this key.
-                            while exposed.get(exposed_position).map(|x| x.0.borrow()).map(|k| key.equals(k)).unwrap_or(false) {
+                            while exposed.get(exposed_position).map(|x| x.0.borrow()).map(|k| key.eq(&<T1::Key<'_> as IntoOwned>::borrow_as(&k))).unwrap_or(false) {
                                 interesting_times.push(exposed[exposed_position].1.clone());
                                 exposed_position += 1;
                             }

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -14,56 +14,39 @@ pub mod cursor_list;
 pub use self::cursor_list::CursorList;
 
 use std::borrow::Borrow;
-use std::cmp::Ordering;
 
-/// A type that may be converted into and compared with another type.
+/// A reference type corresponding to an owned type, supporting conversion in each direction.
 ///
-/// The type must also be comparable with itself, and follow the same 
-/// order as if converting instances to `T` and comparing the results.
-pub trait MyTrait<'a> : Ord {
+/// This trait is analogous to `ToOwned`, but not as prescriptive. Specifically, it avoids the
+/// requirement that the other trait implement `Borrow`, which unfortunately does not support
+/// GATs (the borrow must result in a `&Self::Borrowed` rather than a `Self::Borrowed<'_>`).
+pub trait IntoOwned<'a> {
     /// Owned type into which this type can be converted.
     type Owned;
     /// Conversion from an instance of this type to the owned type.
     fn into_owned(self) -> Self::Owned;
-    ///
+    /// Clones `self` onto an existing instance of the owned type.
     fn clone_onto(&self, other: &mut Self::Owned); 
-    /// Indicates that `self <= other`; used for sorting.
-    fn compare(&self, other: &Self::Owned) -> Ordering;
-    /// `self <= other`
-    fn less_equals(&self, other: &Self::Owned) -> bool {
-        self.compare(other) != Ordering::Greater
-    }
-    /// `self == other`
-    fn equals(&self, other: &Self::Owned) -> bool {
-        self.compare(other) == Ordering::Equal
-    }
-    /// `self < other`
-    fn less_than(&self, other: &Self::Owned) -> bool {
-        self.compare(other) == Ordering::Less
-    }
     /// Borrows an owned instance as onesself.
     fn borrow_as(other: &'a Self::Owned) -> Self; 
 }
 
-impl<'a, T: Ord+ToOwned+?Sized> MyTrait<'a> for &'a T {
+impl<'a, T: ToOwned+?Sized> IntoOwned<'a> for &'a T {
     type Owned = T::Owned;
     fn into_owned(self) -> Self::Owned { self.to_owned() }
     fn clone_onto(&self, other: &mut Self::Owned) { <T as ToOwned>::clone_into(self, other) }
-    fn compare(&self, other: &Self::Owned) -> Ordering { self.cmp(&other.borrow()) }
-    fn borrow_as(other: &'a Self::Owned) -> Self {
-        other.borrow()
-    }
+    fn borrow_as(other: &'a Self::Owned) -> Self { other.borrow() }
 }
 
 /// A cursor for navigating ordered `(key, val, time, diff)` updates.
 pub trait Cursor {
 
     /// Key by which updates are indexed.
-    type Key<'a>: Copy + Clone + MyTrait<'a, Owned = Self::KeyOwned>;
+    type Key<'a>: Copy + Clone + Ord + IntoOwned<'a, Owned = Self::KeyOwned>;
     /// Owned version of the above.
     type KeyOwned: Ord + Clone;
     /// Values associated with keys.
-    type Val<'a>: Copy + Clone + MyTrait<'a> + for<'b> PartialOrd<Self::Val<'b>>;
+    type Val<'a>: Copy + Clone + Ord + IntoOwned<'a> + for<'b> PartialOrd<Self::Val<'b>>;
     /// Timestamps associated with updates
     type Time: Timestamp + Lattice + Ord + Clone;
     /// Associated update.
@@ -103,10 +86,6 @@ pub trait Cursor {
     fn step_key(&mut self, storage: &Self::Storage);
     /// Advances the cursor to the specified key.
     fn seek_key(&mut self, storage: &Self::Storage, key: Self::Key<'_>);
-    /// Convenience method to get access by reference to an owned key.
-    fn seek_key_owned(&mut self, storage: &Self::Storage, key: &Self::KeyOwned) {
-        self.seek_key(storage, MyTrait::borrow_as(key));
-    }
 
     /// Advances the cursor to the next value.
     fn step_val(&mut self, storage: &Self::Storage);

--- a/src/trace/implementations/huffman_container.rs
+++ b/src/trace/implementations/huffman_container.rs
@@ -33,7 +33,7 @@ where
 }
 
 use crate::trace::implementations::containers::Push;
-impl<B: Ord + Clone + Sized + 'static> Push<Vec<B>> for HuffmanContainer<B> {
+impl<B: Ord + Clone + 'static> Push<Vec<B>> for HuffmanContainer<B> {
     fn push(&mut self, item: Vec<B>) {
         for x in item.iter() { *self.stats.entry(x.clone()).or_insert(0) += 1; }
         match &mut self.inner {
@@ -49,10 +49,7 @@ impl<B: Ord + Clone + Sized + 'static> Push<Vec<B>> for HuffmanContainer<B> {
     }
 }
 
-impl<B> BatchContainer for HuffmanContainer<B>
-where
-    B: Ord + Clone + Sized + 'static,
-{
+impl<B: Ord + Clone + 'static> BatchContainer for HuffmanContainer<B> {
     type OwnedItem = Vec<B>;
     type ReadItem<'a> = Wrapped<'a, B>;
 
@@ -221,8 +218,8 @@ mod wrapper {
                 Err(bytes) => other.extend_from_slice(bytes),
             }
         }
-        fn borrow_as(other: &'a Self::Owned) -> Self {
-            Self { inner: Err(&other[..]) }
+        fn borrow_as(owned: &'a Self::Owned) -> Self {
+            Self { inner: Err(&owned[..]) }
         }
     }
 }

--- a/src/trace/implementations/huffman_container.rs
+++ b/src/trace/implementations/huffman_container.rs
@@ -32,12 +32,8 @@ where
     }
 }
 
-impl<B> BatchContainer for HuffmanContainer<B>
-where
-    B: Ord + Clone + Sized + 'static,
-{
-    type PushItem = Vec<B>;
-    type ReadItem<'a> = Wrapped<'a, B>;
+use crate::trace::implementations::containers::Push;
+impl<B: Ord + Clone + Sized + 'static> Push<Vec<B>> for HuffmanContainer<B> {
     fn push(&mut self, item: Vec<B>) {
         for x in item.iter() { *self.stats.entry(x.clone()).or_insert(0) += 1; }
         match &mut self.inner {
@@ -51,10 +47,15 @@ where
             }
         }
     }
-    fn copy_push(&mut self, item: &Vec<B>) {
-        use crate::trace::MyTrait;
-        self.copy(<_ as MyTrait>::borrow_as(item));
-    }
+}
+
+impl<B> BatchContainer for HuffmanContainer<B>
+where
+    B: Ord + Clone + Sized + 'static,
+{
+    type OwnedItem = Vec<B>;
+    type ReadItem<'a> = Wrapped<'a, B>;
+
     fn copy(&mut self, item: Self::ReadItem<'_>) {
         match item.decode() {
             Ok(decoded) => {
@@ -152,7 +153,7 @@ impl<B: Ord+Clone> Default for HuffmanContainer<B> {
 
 mod wrapper {
 
-    use crate::trace::MyTrait;
+    use crate::trace::IntoOwned;
     use super::Encoded;
 
     pub struct Wrapped<'a, B: Ord> {
@@ -205,7 +206,7 @@ mod wrapper {
             self.partial_cmp(other).unwrap()
         }
     }
-    impl<'a, B: Ord+Clone> MyTrait<'a> for Wrapped<'a, B> {
+    impl<'a, B: Ord+Clone> IntoOwned<'a> for Wrapped<'a, B> {
         type Owned = Vec<B>;
         fn into_owned(self) -> Self::Owned {
             match self.decode() {
@@ -218,12 +219,6 @@ mod wrapper {
             match self.decode() {
                 Ok(decode) => other.extend(decode.cloned()),
                 Err(bytes) => other.extend_from_slice(bytes),
-            }
-        }
-        fn compare(&self, other: &Self::Owned) -> std::cmp::Ordering {
-            match self.decode() {
-                Ok(decode) => decode.partial_cmp(other.iter()).unwrap(),
-                Err(bytes) => bytes.cmp(&other[..]),
             }
         }
         fn borrow_as(other: &'a Self::Owned) -> Self {

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -316,8 +316,8 @@ impl<'a, T: Copy + Ord> IntoOwned<'a> for Wrapper<T> {
         *other = self.0;
     }
 
-    fn borrow_as(other: &'a Self::Owned) -> Self {
-        Self(*other)
+    fn borrow_as(owned: &'a Self::Owned) -> Self {
+        Self(*owned)
     }
 }
 

--- a/src/trace/implementations/option_container.rs
+++ b/src/trace/implementations/option_container.rs
@@ -101,9 +101,9 @@ where
         }
     }
 }
-impl<'a, C: BatchContainer> Eq for OptionWrapper<'a, C> where 
-C::OwnedItem: Default + Ord
-{ }
+
+impl<'a, C: BatchContainer> Eq for OptionWrapper<'a, C> where C::OwnedItem: Default + Ord { }
+
 impl<'a, 'b, C: BatchContainer> PartialOrd<OptionWrapper<'a, C>> for OptionWrapper<'b, C> where 
 C::OwnedItem: Default + Ord,
 {
@@ -143,9 +143,9 @@ where
             *other = Default::default();
         }
     }
-    fn borrow_as(other: &'a Self::Owned) -> Self {
+    fn borrow_as(owned: &'a Self::Owned) -> Self {
         Self {
-            inner: Some(<_>::borrow_as(other))
+            inner: Some(IntoOwned::borrow_as(owned))
         }
     }
 } 

--- a/src/trace/implementations/option_container.rs
+++ b/src/trace/implementations/option_container.rs
@@ -1,6 +1,6 @@
 //! A container optimized for identical contents.
 
-use crate::trace::cursor::MyTrait;
+use crate::trace::cursor::IntoOwned;
 use crate::trace::implementations::BatchContainer;
 
 /// A container that effectively represents default values.
@@ -14,15 +14,13 @@ pub struct OptionContainer<C> {
     container: C,
 }
 
-impl<C> BatchContainer for OptionContainer<C> 
+use crate::trace::implementations::containers::Push;
+impl<C: BatchContainer> Push<C::OwnedItem> for OptionContainer<C> 
 where 
-    C: BatchContainer,
-    C::PushItem: Default + Ord,
+    C: BatchContainer + Push<C::OwnedItem>,
+    C::OwnedItem: Default + Ord,
 {
-    type PushItem = C::PushItem;
-    type ReadItem<'a> = OptionWrapper<'a, C>;
-
-    fn push(&mut self, item: Self::PushItem) {
+    fn push(&mut self, item: C::OwnedItem) {
         if item == Default::default() && self.container.is_empty() {
             self.defaults += 1;
         }
@@ -30,8 +28,18 @@ where
             self.container.push(item)
         }
     }
+}
+
+impl<C> BatchContainer for OptionContainer<C>
+where
+    C: BatchContainer ,
+    C::OwnedItem: Default + Ord,
+{
+    type OwnedItem = C::OwnedItem;
+    type ReadItem<'a> = OptionWrapper<'a, C>;
+
     fn copy<'a>(&mut self, item: Self::ReadItem<'a>) {
-        if item.equals(&Default::default()) && self.container.is_empty() {
+        if item.eq(&IntoOwned::borrow_as(&Default::default())) && self.container.is_empty() {
             self.defaults += 1;
         }
         else {
@@ -39,7 +47,7 @@ where
                 self.container.copy(item);
             }
             else {
-                self.container.push(Default::default());
+                self.container.copy(IntoOwned::borrow_as(&Default::default()));
             }
         }
     }
@@ -82,22 +90,22 @@ impl<'a, C: BatchContainer> Clone for OptionWrapper<'a, C> {
 use std::cmp::Ordering;
 impl<'a, 'b, C: BatchContainer> PartialEq<OptionWrapper<'a, C>> for OptionWrapper<'b, C> 
 where 
-    C::PushItem: Default + Ord,
+    C::OwnedItem: Default + Ord,
 {
     fn eq(&self, other: &OptionWrapper<'a, C>) -> bool {
         match (&self.inner, &other.inner) {
             (None, None) => true,
-            (None, Some(item2)) => item2.equals(&Default::default()),
-            (Some(item1), None) => item1.equals(&Default::default()),
+            (None, Some(item2)) => item2.eq(&<C::ReadItem<'_> as IntoOwned>::borrow_as(&Default::default())),
+            (Some(item1), None) => item1.eq(&<C::ReadItem<'_> as IntoOwned>::borrow_as(&Default::default())),
             (Some(item1), Some(item2)) => item1.eq(item2)
         }
     }
 }
 impl<'a, C: BatchContainer> Eq for OptionWrapper<'a, C> where 
-C::PushItem: Default + Ord
+C::OwnedItem: Default + Ord
 { }
 impl<'a, 'b, C: BatchContainer> PartialOrd<OptionWrapper<'a, C>> for OptionWrapper<'b, C> where 
-C::PushItem: Default + Ord,
+C::OwnedItem: Default + Ord,
 {
     fn partial_cmp(&self, other: &OptionWrapper<'a, C>) -> Option<Ordering> {
         let default = Default::default();
@@ -110,7 +118,7 @@ C::PushItem: Default + Ord,
     }
 }
 impl<'a, C: BatchContainer> Ord for OptionWrapper<'a, C> where 
-C::PushItem: Default + Ord,
+C::OwnedItem: Default + Ord,
 {
     fn cmp(&self, other: &Self) -> Ordering {
         self.partial_cmp(other).unwrap()
@@ -118,11 +126,11 @@ C::PushItem: Default + Ord,
 }
 
 
-impl<'a, C: BatchContainer> MyTrait<'a> for OptionWrapper<'a, C> 
+impl<'a, C: BatchContainer> IntoOwned<'a> for OptionWrapper<'a, C>
 where
-    C::PushItem : Default + Ord,
+    C::OwnedItem : Default + Ord,
 {
-    type Owned = C::PushItem;
+    type Owned = C::OwnedItem;
 
     fn into_owned(self) -> Self::Owned {
         self.inner.map(|r| r.into_owned()).unwrap_or_else(Default::default)
@@ -133,14 +141,6 @@ where
         } 
         else {
             *other = Default::default();
-        }
-    }
-    fn compare(&self, other: &Self::Owned) -> std::cmp::Ordering {
-        if let Some(item) = &self.inner {
-            item.compare(other)
-        } 
-        else {
-            <C::PushItem>::default().cmp(other)
         }
     }
     fn borrow_as(other: &'a Self::Owned) -> Self {

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -72,9 +72,11 @@ mod val_batch {
     use timely::container::PushInto;
     use timely::progress::{Antichain, frontier::AntichainRef};
 
+    use crate::trace::implementations::containers::Push;
+
     use crate::trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
     use crate::trace::implementations::{BatchContainer, BuilderInput};
-    use crate::trace::cursor::MyTrait;
+    use crate::trace::cursor::IntoOwned;
 
     use super::{Layout, Update};
 
@@ -416,7 +418,7 @@ mod val_batch {
             if !self.update_stash.is_empty() {
                 // If there is a single element, equal to a just-prior recorded update,
                 // we push nothing and report an unincremented offset to encode this case.
-                if self.update_stash.len() == 1 && self.result.updates.last().map(|ud| self.update_stash.last().unwrap().equals(ud)).unwrap_or(false) {
+                if self.update_stash.len() == 1 && self.result.updates.last().map(|ud| self.update_stash.last().unwrap().eq(IntoOwned::borrow_as(ud))).unwrap_or(false) {
                         // Just clear out update_stash, as we won't drain it here.
                     self.update_stash.clear();
                     self.singletons += 1;
@@ -620,9 +622,10 @@ mod key_batch {
     use timely::container::PushInto;
     use timely::progress::{Antichain, frontier::AntichainRef};
 
+    use crate::trace::implementations::containers::Push;
     use crate::trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
     use crate::trace::implementations::{BatchContainer, BuilderInput};
-    use crate::trace::cursor::MyTrait;
+    use crate::trace::cursor::IntoOwned;
 
     use super::{Layout, Update};
 

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -19,7 +19,7 @@ use timely::progress::{Antichain, frontier::AntichainRef};
 use timely::progress::Timestamp;
 
 use crate::logging::DifferentialEvent;
-use crate::trace::cursor::MyTrait;
+use crate::trace::cursor::IntoOwned;
 use crate::difference::Semigroup;
 use crate::lattice::Lattice;
 // use ::difference::Semigroup;
@@ -52,11 +52,11 @@ pub type ExertionLogic = std::sync::Arc<dyn for<'a> Fn(&'a [(usize, usize, usize
 pub trait TraceReader {
 
     /// Key by which updates are indexed.
-    type Key<'a>: Copy + Clone + MyTrait<'a, Owned = Self::KeyOwned>;
+    type Key<'a>: Copy + Clone + Ord + IntoOwned<'a, Owned = Self::KeyOwned>;
     /// Owned version of the above.
     type KeyOwned: Ord + Clone;
     /// Values associated with keys.
-    type Val<'a>: Copy + Clone + MyTrait<'a>;
+    type Val<'a>: Copy + Clone + IntoOwned<'a>;
     /// Timestamps associated with updates
     type Time: Timestamp + Lattice + Ord + Clone;
     /// Associated update.
@@ -258,11 +258,11 @@ where
     Self: ::std::marker::Sized,
 {
     /// Key by which updates are indexed.
-    type Key<'a>: Copy + Clone + MyTrait<'a, Owned = Self::KeyOwned>;
+    type Key<'a>: Copy + Clone + Ord + IntoOwned<'a, Owned = Self::KeyOwned>;
     /// Owned version of the above.
     type KeyOwned: Ord + Clone;
     /// Values associated with keys.
-    type Val<'a>: Copy + Clone + MyTrait<'a>;
+    type Val<'a>: Copy + Clone + IntoOwned<'a>;
     /// Timestamps associated with updates
     type Time: Timestamp + Lattice + Ord + Clone;
     /// Associated update.


### PR DESCRIPTION
This PR rebrands `MyTrait<'a>` as `IntoOwned<'a>`, an analogue of `ToOwned` that is more GAT-friendly. GATs can implement `IntoOwned<'_>` and support the re-borrowing of the owned type back into the GAT. The existing `ToOwned` infrastructure relies instead on Rust's `Borrow`, which can only borrow into a reference to a `Borrowed` type.

The PR also streamlines `MyTrait`, removing comparison functionality from it. The inequalities were unused, and the equality method can be locally implemented using `borrow_as`, as our implementors all support co-variant `PartialOrd` implementations.

Some other light changes around removing the `push` functionality for `BatchContainer` preceded this work (pointed out that the remaining complexity was `MyTrait`), but I think we agree that these changes are good too.

Only known regression is in `rhh.rs`, where previously we supported a non-allocating hash evaluation, but now call `into_owned()`. We can shake that out once things are more stable and `rhh` is actually expected to work.