### PR TITLE
Remove `BatchContainer::copy`

### DIFF
--- a/src/trace/implementations/huffman_container.rs
+++ b/src/trace/implementations/huffman_container.rs
@@ -49,11 +49,9 @@ impl<B: Ord + Clone + 'static> PushInto<Vec<B>> for HuffmanContainer<B> {
     }
 }
 
-impl<B: Ord + Clone + 'static> BatchContainer for HuffmanContainer<B> {
-    type OwnedItem = Vec<B>;
-    type ReadItem<'a> = Wrapped<'a, B>;
 
-    fn copy(&mut self, item: Self::ReadItem<'_>) {
+impl<'a, B: Ord + Clone + 'static> PushInto<Wrapped<'a, B>> for HuffmanContainer<B> {
+    fn push_into(&mut self, item: Wrapped<'a, B>) {
         match item.decode() {
             Ok(decoded) => {
                 for x in decoded { *self.stats.entry(x.clone()).or_insert(0) += 1; }
@@ -82,11 +80,13 @@ impl<B: Ord + Clone + 'static> BatchContainer for HuffmanContainer<B> {
             }
         }
     }
-    fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
-        for index in start .. end {
-            self.copy(other.index(index));
-        }
-    }
+}
+
+
+impl<B: Ord + Clone + 'static> BatchContainer for HuffmanContainer<B> {
+    type OwnedItem = Vec<B>;
+    type ReadItem<'a> = Wrapped<'a, B>;
+
     fn with_capacity(size: usize) -> Self {
         let mut offsets = OffsetList::with_capacity(size + 1);
         offsets.push(0);

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -283,14 +283,14 @@ mod val_batch {
                 self.stash_updates_for_val(source, lower);
                 if let Some(off) = self.consolidate_updates() {
                     self.result.vals_offs.push(off);
-                    self.result.vals.copy(source.vals.index(lower));
+                    self.result.vals.push(source.vals.index(lower));
                 }
                 lower += 1;
             }            
 
             // If we have pushed any values, copy the key as well.
             if self.result.vals.len() > init_vals {
-                self.result.keys.copy(source.keys.index(cursor));
+                self.result.keys.push(source.keys.index(cursor));
                 self.result.keys_offs.push(self.result.vals.len());
             }           
         }
@@ -310,7 +310,7 @@ mod val_batch {
                     let (lower1, upper1) = source1.values_for_key(self.key_cursor1);
                     let (lower2, upper2) = source2.values_for_key(self.key_cursor2);
                     if let Some(off) = self.merge_vals((source1, lower1, upper1), (source2, lower2, upper2)) {
-                        self.result.keys.copy(source1.keys.index(self.key_cursor1));
+                        self.result.keys.push(source1.keys.index(self.key_cursor1));
                         self.result.keys_offs.push(off);
                     }
                     // Increment cursors in either case; the keys are merged.
@@ -345,7 +345,7 @@ mod val_batch {
                         self.stash_updates_for_val(source1, lower1);
                         if let Some(off) = self.consolidate_updates() {
                             self.result.vals_offs.push(off);
-                            self.result.vals.copy(source1.vals.index(lower1));
+                            self.result.vals.push(source1.vals.index(lower1));
                         }
                         lower1 += 1;
                     },
@@ -354,7 +354,7 @@ mod val_batch {
                         self.stash_updates_for_val(source2, lower2);
                         if let Some(off) = self.consolidate_updates() {
                             self.result.vals_offs.push(off);
-                            self.result.vals.copy(source1.vals.index(lower1));
+                            self.result.vals.push(source1.vals.index(lower1));
                         }
                         lower1 += 1;
                         lower2 += 1;
@@ -364,7 +364,7 @@ mod val_batch {
                         self.stash_updates_for_val(source2, lower2);
                         if let Some(off) = self.consolidate_updates() {
                             self.result.vals_offs.push(off);
-                            self.result.vals.copy(source2.vals.index(lower2));
+                            self.result.vals.push(source2.vals.index(lower2));
                         }
                         lower2 += 1;
                     },
@@ -375,7 +375,7 @@ mod val_batch {
                 self.stash_updates_for_val(source1, lower1);
                 if let Some(off) = self.consolidate_updates() {
                     self.result.vals_offs.push(off);
-                    self.result.vals.copy(source1.vals.index(lower1));
+                    self.result.vals.push(source1.vals.index(lower1));
                 }
                 lower1 += 1;
             }
@@ -383,7 +383,7 @@ mod val_batch {
                 self.stash_updates_for_val(source2, lower2);
                 if let Some(off) = self.consolidate_updates() {
                     self.result.vals_offs.push(off);
-                    self.result.vals.copy(source2.vals.index(lower2));
+                    self.result.vals.push(source2.vals.index(lower2));
                 }
                 lower2 += 1;
             }
@@ -813,7 +813,7 @@ mod key_batch {
             self.stash_updates_for_key(source, cursor);
             if let Some(off) = self.consolidate_updates() {
                 self.result.keys_offs.push(off);
-                self.result.keys.copy(source.keys.index(cursor));
+                self.result.keys.push(source.keys.index(cursor));
             }
         }
         /// Merge the next key in each of `source1` and `source2` into `self`, updating the appropriate cursors.
@@ -833,7 +833,7 @@ mod key_batch {
                     self.stash_updates_for_key(source2, self.key_cursor2);
                     if let Some(off) = self.consolidate_updates() {
                         self.result.keys_offs.push(off);
-                        self.result.keys.copy(source1.keys.index(self.key_cursor1));
+                        self.result.keys.push(source1.keys.index(self.key_cursor1));
                     }
                     // Increment cursors in either case; the keys are merged.
                     self.key_cursor1 += 1;

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -416,7 +416,7 @@ mod val_batch {
             if !self.update_stash.is_empty() {
                 // If there is a single element, equal to a just-prior recorded update,
                 // we push nothing and report an unincremented offset to encode this case.
-                if self.update_stash.len() == 1 && self.result.updates.last().map(|ud| self.update_stash.last().unwrap().eq(IntoOwned::borrow_as(ud))).unwrap_or(false) {
+                if self.update_stash.len() == 1 && self.result.updates.last().map(|ud| self.update_stash.last().unwrap().eq(ud)).unwrap_or(false) {
                         // Just clear out update_stash, as we won't drain it here.
                     self.update_stash.clear();
                     self.singletons += 1;

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -188,7 +188,7 @@ mod val_batch {
             while self.keys.len() < desired {
                 // We insert a default (dummy) key and repeat the offset to indicate this.
                 let current_offset = self.keys_offs.index(self.keys.len()).into_owned();
-                self.keys.push(Default::default());
+                self.keys.push(<<L::Target as Update>::Key>::default());
                 self.keys_offs.push(current_offset);
             }
 
@@ -439,7 +439,7 @@ mod val_batch {
                 self.stash_updates_for_val(source, lower);
                 if let Some(off) = self.consolidate_updates() {
                     self.result.vals_offs.push(off);
-                    self.result.vals.copy(source.vals.index(lower));
+                    self.result.vals.push(source.vals.index(lower));
                 }
                 lower += 1;
             }            
@@ -500,7 +500,7 @@ mod val_batch {
                         self.stash_updates_for_val(source1, lower1);
                         if let Some(off) = self.consolidate_updates() {
                             self.result.vals_offs.push(off);
-                            self.result.vals.copy(source1.vals.index(lower1));
+                            self.result.vals.push(source1.vals.index(lower1));
                         }
                         lower1 += 1;
                     },
@@ -509,7 +509,7 @@ mod val_batch {
                         self.stash_updates_for_val(source2, lower2);
                         if let Some(off) = self.consolidate_updates() {
                             self.result.vals_offs.push(off);
-                            self.result.vals.copy(source1.vals.index(lower1));
+                            self.result.vals.push(source1.vals.index(lower1));
                         }
                         lower1 += 1;
                         lower2 += 1;
@@ -519,7 +519,7 @@ mod val_batch {
                         self.stash_updates_for_val(source2, lower2);
                         if let Some(off) = self.consolidate_updates() {
                             self.result.vals_offs.push(off);
-                            self.result.vals.copy(source2.vals.index(lower2));
+                            self.result.vals.push(source2.vals.index(lower2));
                         }
                         lower2 += 1;
                     },
@@ -530,7 +530,7 @@ mod val_batch {
                 self.stash_updates_for_val(source1, lower1);
                 if let Some(off) = self.consolidate_updates() {
                     self.result.vals_offs.push(off);
-                    self.result.vals.copy(source1.vals.index(lower1));
+                    self.result.vals.push(source1.vals.index(lower1));
                 }
                 lower1 += 1;
             }
@@ -538,7 +538,7 @@ mod val_batch {
                 self.stash_updates_for_val(source2, lower2);
                 if let Some(off) = self.consolidate_updates() {
                     self.result.vals_offs.push(off);
-                    self.result.vals.copy(source2.vals.index(lower2));
+                    self.result.vals.push(source2.vals.index(lower2));
                 }
                 lower2 += 1;
             }

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -571,7 +571,7 @@ mod val_batch {
             if !self.update_stash.is_empty() {
                 // If there is a single element, equal to a just-prior recorded update,
                 // we push nothing and report an unincremented offset to encode this case.
-                if self.update_stash.len() == 1 && self.result.updates.last().map(|l| l.eq(IntoOwned::borrow_as(self.update_stash.last().unwrap()))).unwrap_or(false) {
+                if self.update_stash.len() == 1 && self.result.updates.last().map(|l| l.eq(self.update_stash.last().unwrap())).unwrap_or(false) {
                     // Just clear out update_stash, as we won't drain it here.
                     self.update_stash.clear();
                     self.singletons += 1;


### PR DESCRIPTION
The `copy` method is essentially the same as the requirement `: PushInto<Self::ReadItem<'_>>`. Trying this out to see what it looks like. Potentially it is better to have the method with a default implementation, so that calls to `copy()` clearly signal that this is the type's GAT (and potentially to remove footguns where the wrong thing is pushed in, and it doesn't end up as cheap as one might want).

The downside to the PR is that `OptionContainer` ends up with conflicting implementations, and so loses the ability to push any type that its wrapped container could push. Because that might be its own associated type. 

Anyhow, up for discussion.