### PR TITLE
Replace covariant PartialOrd with reborrow()

### DIFF
--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -45,7 +45,7 @@ pub trait Cursor {
     /// Key by which updates are indexed.
     type Key<'a>: Copy + Clone + Ord;
     /// Values associated with keys.
-    type Val<'a>: Copy + Clone + Ord + for<'b> PartialOrd<Self::Val<'b>>;
+    type Val<'a>: Copy + Clone + Ord;
     /// Timestamps associated with updates
     type Time: Timestamp + Lattice + Ord + Clone;
     /// Associated update.

--- a/src/trace/implementations/huffman_container.rs
+++ b/src/trace/implementations/huffman_container.rs
@@ -52,6 +52,8 @@ impl<B: Ord + Clone + 'static> PushInto<Vec<B>> for HuffmanContainer<B> {
 impl<B: Ord + Clone + 'static> BatchContainer for HuffmanContainer<B> {
     type ReadItem<'a> = Wrapped<'a, B>;
 
+    fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b> { item }
+
     fn copy(&mut self, item: Self::ReadItem<'_>) {
         match item.decode() {
             Ok(decoded) => {

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -473,7 +473,7 @@ mod val_batch {
             }
         }
         fn seek_key(&mut self, storage: &OrdValBatch<L>, key: Self::Key<'_>) {
-            self.key_cursor += storage.storage.keys.advance(self.key_cursor, storage.storage.keys.len(), |x| x.lt(&key));
+            self.key_cursor += storage.storage.keys.advance(self.key_cursor, storage.storage.keys.len(), |x| <L::KeyContainer as BatchContainer>::reborrow(x).lt(&<L::KeyContainer as BatchContainer>::reborrow(key)));
             if self.key_valid(storage) {
                 self.rewind_vals(storage);
             }
@@ -485,7 +485,7 @@ mod val_batch {
             }
         }
         fn seek_val(&mut self, storage: &OrdValBatch<L>, val: Self::Val<'_>) {
-            self.val_cursor += storage.storage.vals.advance(self.val_cursor, storage.storage.values_for_key(self.key_cursor).1, |x| x.lt(&val));
+            self.val_cursor += storage.storage.vals.advance(self.val_cursor, storage.storage.values_for_key(self.key_cursor).1, |x| <L::ValContainer as BatchContainer>::reborrow(x).lt(&<L::ValContainer as BatchContainer>::reborrow(val)));
         }
         fn rewind_keys(&mut self, storage: &OrdValBatch<L>) {
             self.key_cursor = 0;
@@ -921,7 +921,7 @@ mod key_batch {
             }
         }
         fn seek_key(&mut self, storage: &Self::Storage, key: Self::Key<'_>) {
-            self.key_cursor += storage.storage.keys.advance(self.key_cursor, storage.storage.keys.len(), |x| x.lt(&key));
+            self.key_cursor += storage.storage.keys.advance(self.key_cursor, storage.storage.keys.len(), |x| <L::KeyContainer as BatchContainer>::reborrow(x).lt(&<L::KeyContainer as BatchContainer>::reborrow(key)));
             if self.key_valid(storage) {
                 self.rewind_vals(storage);
             }

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -213,7 +213,7 @@ mod val_batch {
         /// Returns true if one should advance one's index in the search for `key`.
         fn advance_key(&self, index: usize, key: <L::KeyContainer as BatchContainer>::ReadItem<'_>) -> bool {
             // Ideally this short-circuits, as `self.keys[index]` is bogus data.
-            !self.live_key(index) || self.keys.index(index).lt(&key)
+            !self.live_key(index) || self.keys.index(index).lt(&<L::KeyContainer as BatchContainer>::reborrow(key))
         }
 
         /// Indicates that a key is valid, rather than dead space, by looking for a valid offset range.
@@ -675,7 +675,7 @@ mod val_batch {
             }
         }
         fn seek_val(&mut self, storage: &RhhValBatch<L>, val: Self::Val<'_>) {
-            self.val_cursor += storage.storage.vals.advance(self.val_cursor, storage.storage.values_for_key(self.key_cursor).1, |x| x.lt(&val));
+            self.val_cursor += storage.storage.vals.advance(self.val_cursor, storage.storage.values_for_key(self.key_cursor).1, |x| <L::ValContainer as BatchContainer>::reborrow(x).lt(&<L::ValContainer as BatchContainer>::reborrow(val)));
         }
         fn rewind_keys(&mut self, storage: &RhhValBatch<L>) {
             self.key_cursor = 0;


### PR DESCRIPTION
Batch containers have required that their items are comparable across lifetimes. This seems to confound Rust when presented with the `Ord` constraint in addition. Another option is to remove the constraint, and require that the contain know how to reborrow its items, narrowing their lifetimes.

At the moment this is a thing to consider; there are other ways to achieve the same goal we think (e.g. removing `Ord` instead).

cc: @antiguru 