### PR TITLE
Remove `'static` requirement from difference traits

### DIFF
--- a/dogsdogsdogs/src/calculus.rs
+++ b/dogsdogsdogs/src/calculus.rs
@@ -34,7 +34,7 @@ impl<G, D, R> Differentiate<G, D, R> for Collection<G, D, R>
 where
     G: Scope,
     D: Data,
-    R: Abelian,
+    R: Abelian + 'static,
 {
     // For each (data, Alt(time), diff) we add a (data, Neu(time), -diff).
     fn differentiate<'a>(&self, child: &Child<'a, G, AltNeu<G::Timestamp>>) -> Collection<Child<'a, G, AltNeu<G::Timestamp>>, D, R> {
@@ -53,7 +53,7 @@ impl<'a, G, D, R> Integrate<G, D, R> for Collection<Child<'a, G, AltNeu<G::Times
 where
     G: Scope,
     D: Data,
-    R: Abelian,
+    R: Abelian + 'static,
 {
     // We discard each `neu` variant and strip off the `alt` wrapper.
     fn integrate(&self) -> Collection<G, D, R> {

--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -44,7 +44,7 @@ impl<G, P, R> ProposeExtensionMethod<G, P, R> for Collection<G, P, R>
 where
     G: Scope,
     P: ExchangeData+Ord,
-    R: Monoid+Multiply<Output = R>,
+    R: Monoid+Multiply<Output = R>+'static,
 {
     fn propose_using<PE>(&self, extender: &mut PE) -> Collection<G, (P, PE::Extension), R>
     where

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -140,7 +140,7 @@ where
     FF: Fn(&G::Timestamp, &mut Antichain<G::Timestamp>) + 'static,
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
     DOut: Clone+'static,
-    ROut: Semigroup,
+    ROut: Semigroup + 'static,
     Y: Fn(std::time::Instant, usize) -> bool + 'static,
     I: IntoIterator<Item=(DOut, G::Timestamp, ROut)>,
     S: FnMut(&K, &V, Tr::Val<'_>, &G::Timestamp, &G::Timestamp, &R, &Tr::Diff)-> I + 'static,

--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -36,7 +36,7 @@ where
     D: ExchangeData,
     R: ExchangeData+Monoid,
     DOut: Clone+'static,
-    ROut: Monoid,
+    ROut: Monoid + 'static,
     S: FnMut(&D, &R, Tr::Val<'_>, &Tr::Diff)->(DOut, ROut)+'static,
 {
     // No need to block physical merging for this operator.

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -45,7 +45,7 @@ pub struct Collection<G: Scope, D, R: Semigroup = isize> {
     pub inner: Stream<G, (D, G::Timestamp, R)>
 }
 
-impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Data {
+impl<G: Scope, D: Data, R: Semigroup+'static> Collection<G, D, R> where G::Timestamp: Data {
     /// Creates a new Collection from a timely dataflow stream.
     ///
     /// This method seems to be rarely used, with the `as_collection` method on streams being a more
@@ -226,7 +226,7 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     pub fn explode<D2, R2, I, L>(&self, mut logic: L) -> Collection<G, D2, <R2 as Multiply<R>>::Output>
     where D2: Data,
           R2: Semigroup+Multiply<R>,
-          <R2 as Multiply<R>>::Output: Data+Semigroup,
+          <R2 as Multiply<R>>::Output: Semigroup+'static,
           I: IntoIterator<Item=(D2,R2)>,
           L: FnMut(D)->I+'static,
     {
@@ -261,7 +261,7 @@ impl<G: Scope, D: Data, R: Semigroup> Collection<G, D, R> where G::Timestamp: Da
     where G::Timestamp: Lattice,
           D2: Data,
           R2: Semigroup+Multiply<R>,
-          <R2 as Multiply<R>>::Output: Data+Semigroup,
+          <R2 as Multiply<R>>::Output: Semigroup+'static,
           I: IntoIterator<Item=(D2,G::Timestamp,R2)>,
           L: FnMut(D)->I+'static,
     {
@@ -476,7 +476,7 @@ use timely::dataflow::scopes::ScopeParent;
 use timely::progress::timestamp::Refines;
 
 /// Methods requiring a nested scope.
-impl<'a, G: Scope, T: Timestamp, D: Data, R: Semigroup> Collection<Child<'a, G, T>, D, R>
+impl<'a, G: Scope, T: Timestamp, D: Data, R: Semigroup+'static> Collection<Child<'a, G, T>, D, R>
 where
     T: Refines<<G as ScopeParent>::Timestamp>,
 {
@@ -509,7 +509,7 @@ where
 }
 
 /// Methods requiring a region as the scope.
-impl<'a, G: Scope, D: Data, R: Semigroup> Collection<Child<'a, G, G::Timestamp>, D, R>
+impl<'a, G: Scope, D: Data, R: Semigroup+'static> Collection<Child<'a, G, G::Timestamp>, D, R>
 {
     /// Returns the value of a Collection from a nested region to its containing scope.
     ///
@@ -523,7 +523,7 @@ impl<'a, G: Scope, D: Data, R: Semigroup> Collection<Child<'a, G, G::Timestamp>,
 }
 
 /// Methods requiring an Abelian difference, to support negation.
-impl<G: Scope, D: Data, R: Abelian> Collection<G, D, R> where G::Timestamp: Data {
+impl<G: Scope, D: Data, R: Abelian+'static> Collection<G, D, R> where G::Timestamp: Data {
     /// Creates a new collection whose counts are the negation of those in the input.
     ///
     /// This method is most commonly used with `concat` to get those element in one collection but not another.
@@ -594,7 +594,7 @@ pub trait AsCollection<G: Scope, D: Data, R: Semigroup> {
     fn as_collection(&self) -> Collection<G, D, R>;
 }
 
-impl<G: Scope, D: Data, R: Semigroup> AsCollection<G, D, R> for Stream<G, (D, G::Timestamp, R)> {
+impl<G: Scope, D: Data, R: Semigroup+'static> AsCollection<G, D, R> for Stream<G, (D, G::Timestamp, R)> {
     fn as_collection(&self) -> Collection<G, D, R> {
         Collection::new(self.clone())
     }
@@ -625,7 +625,7 @@ pub fn concatenate<G, D, R, I>(scope: &mut G, iterator: I) -> Collection<G, D, R
 where
     G: Scope,
     D: Data,
-    R: Semigroup,
+    R: Semigroup+'static,
     I: IntoIterator<Item=Collection<G, D, R>>,
 {
     scope

--- a/src/consolidation.rs
+++ b/src/consolidation.rs
@@ -145,7 +145,7 @@ impl<D,T,R> ConsolidatingContainerBuilder<Vec<(D, T, R)>>
 where
     D: Data,
     T: Data,
-    R: Semigroup,
+    R: Semigroup+'static,
 {
     /// Flush `self.current` up to the biggest `multiple` of elements. Pass 1 to flush all elements.
     // TODO: Can we replace `multiple` by a bool?
@@ -165,7 +165,7 @@ impl<D,T,R> ContainerBuilder for ConsolidatingContainerBuilder<Vec<(D, T, R)>>
 where
     D: Data,
     T: Data,
-    R: Semigroup,
+    R: Semigroup+'static,
 {
     type Container = Vec<(D,T,R)>;
 

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -6,8 +6,6 @@
 //! dataflow collections would then track for each record the total of counts and heights, which allows
 //! us to track something like the average.
 
-use crate::Data;
-
 #[deprecated]
 pub use self::Abelian as Diff;
 
@@ -22,7 +20,7 @@ pub use self::Abelian as Diff;
 /// There is a light presumption of commutativity here, in that while we will largely perform addition
 /// in order of timestamps, for many types of timestamps there is no total order and consequently no
 /// obvious order to respect. Non-commutative semigroups should be used with care.
-pub trait Semigroup<Rhs: ?Sized = Self> : Data + Clone {
+pub trait Semigroup<Rhs: ?Sized = Self> : Clone {
     /// The method of `std::ops::AddAssign`, for types that do not implement `AddAssign`.
     fn plus_equals(&mut self, rhs: &Rhs);
     /// Returns true if the element is the additive identity.

--- a/src/dynamic/mod.rs
+++ b/src/dynamic/mod.rs
@@ -30,7 +30,7 @@ impl<G, D, R, T, TOuter> Collection<G, D, R>
 where
     G: Scope<Timestamp = Product<TOuter, PointStamp<T>>>,
     D: Data,
-    R: Semigroup,
+    R: Semigroup+'static,
     T: Timestamp+Default,
     TOuter: Timestamp,
 {

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -244,7 +244,7 @@ where
     where
         T2: for<'a> TraceReader<Key<'a>=T1::Key<'a>,Time=T1::Time>+Clone+'static,
         T1::Diff: Multiply<T2::Diff>,
-        <T1::Diff as Multiply<T2::Diff>>::Output: Semigroup,
+        <T1::Diff as Multiply<T2::Diff>>::Output: Semigroup+'static,
         I: IntoIterator,
         I::Item: Data,
         L: FnMut(T1::Key<'_>,T1::Val<'_>,T2::Val<'_>)->I+'static
@@ -261,7 +261,7 @@ where
     where
         T2: for<'a> TraceReader<Key<'a>=T1::Key<'a>, Time=T1::Time>+Clone+'static,
         D: Data,
-        ROut: Semigroup,
+        ROut: Semigroup+'static,
         I: IntoIterator<Item=(D, G::Timestamp, ROut)>,
         L: FnMut(T1::Key<'_>, T1::Val<'_>,T2::Val<'_>,&G::Timestamp,&T1::Diff,&T2::Diff)->I+'static,
     {
@@ -603,7 +603,7 @@ where
 /// This arrangement requires `Key: Hashable`, and uses the `hashed()` method to place keys in a hashed
 /// map. This can result in many hash calls, and in some cases it may help to first transform `K` to the
 /// pair `(u64, K)` of hash value and key.
-pub trait ArrangeByKey<G: Scope, K: Data+Hashable, V: Data, R: Semigroup>
+pub trait ArrangeByKey<G: Scope, K: Data+Hashable, V: Data, R: Ord+Semigroup+'static>
 where G::Timestamp: Lattice+Ord {
     /// Arranges a collection of `(Key, Val)` records by `Key`.
     ///
@@ -634,7 +634,7 @@ where
 /// This arrangement requires `Key: Hashable`, and uses the `hashed()` method to place keys in a hashed
 /// map. This can result in many hash calls, and in some cases it may help to first transform `K` to the
 /// pair `(u64, K)` of hash value and key.
-pub trait ArrangeBySelf<G: Scope, K: Data+Hashable, R: Semigroup>
+pub trait ArrangeBySelf<G: Scope, K: Data+Hashable, R: Ord+Semigroup+'static>
 where
     G::Timestamp: Lattice+Ord
 {

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -41,12 +41,12 @@ pub trait CountTotal<G: Scope, K: ExchangeData, R: Semigroup> where G::Timestamp
     /// This method allows `count_total` to produce collections whose difference
     /// type is something other than an `isize` integer, for example perhaps an
     /// `i32`.
-    fn count_total_core<R2: Semigroup + From<i8>>(&self) -> Collection<G, (K, R), R2>;
+    fn count_total_core<R2: Semigroup + From<i8> + 'static>(&self) -> Collection<G, (K, R), R2>;
 }
 
 impl<G: Scope, K: ExchangeData+Hashable, R: ExchangeData+Semigroup> CountTotal<G, K, R> for Collection<G, K, R>
 where G::Timestamp: TotalOrder+Lattice+Ord {
-    fn count_total_core<R2: Semigroup + From<i8>>(&self) -> Collection<G, (K, R), R2> {
+    fn count_total_core<R2: Semigroup + From<i8> + 'static>(&self) -> Collection<G, (K, R), R2> {
         self.arrange_by_self_named("Arrange: CountTotal")
             .count_total_core()
     }
@@ -61,7 +61,7 @@ where
     T1::Time: TotalOrder,
     T1::Diff: ExchangeData,
 {
-    fn count_total_core<R2: Semigroup + From<i8>>(&self) -> Collection<G, (K, T1::Diff), R2> {
+    fn count_total_core<R2: Semigroup + From<i8> + 'static>(&self) -> Collection<G, (K, T1::Diff), R2> {
 
         let mut trace = self.trace.clone();
         let mut buffer = Vec::new();

--- a/src/operators/iterate.rs
+++ b/src/operators/iterate.rs
@@ -76,7 +76,7 @@ pub trait Iterate<G: Scope, D: Data, R: Semigroup> {
             for<'a> F: FnOnce(&Collection<Iterative<'a, G, u64>, D, R>)->Collection<Iterative<'a, G, u64>, D, R>;
 }
 
-impl<G: Scope, D: Ord+Data+Debug, R: Abelian> Iterate<G, D, R> for Collection<G, D, R> {
+impl<G: Scope, D: Ord+Data+Debug, R: Abelian+'static> Iterate<G, D, R> for Collection<G, D, R> {
     fn iterate<F>(&self, logic: F) -> Collection<G, D, R>
         where G::Timestamp: Lattice,
               for<'a> F: FnOnce(&Collection<Iterative<'a, G, u64>, D, R>)->Collection<Iterative<'a, G, u64>, D, R> {
@@ -96,7 +96,7 @@ impl<G: Scope, D: Ord+Data+Debug, R: Abelian> Iterate<G, D, R> for Collection<G,
     }
 }
 
-impl<G: Scope, D: Ord+Data+Debug, R: Semigroup> Iterate<G, D, R> for G {
+impl<G: Scope, D: Ord+Data+Debug, R: Semigroup+'static> Iterate<G, D, R> for G {
     fn iterate<F>(&self, logic: F) -> Collection<G, D, R>
         where G::Timestamp: Lattice,
               for<'a> F: FnOnce(&Collection<Iterative<'a, G, u64>, D, R>)->Collection<Iterative<'a, G, u64>, D, R> {
@@ -151,7 +151,7 @@ impl<G: Scope, D: Ord+Data+Debug, R: Semigroup> Iterate<G, D, R> for G {
 ///     });
 /// })
 /// ```
-pub struct Variable<G: Scope, D: Data, R: Abelian>
+pub struct Variable<G: Scope, D: Data, R: Abelian+'static>
 where G::Timestamp: Lattice {
     collection: Collection<G, D, R>,
     feedback: Handle<G, Vec<(D, G::Timestamp, R)>>,
@@ -222,7 +222,7 @@ impl<G: Scope, D: Data, R: Abelian> Deref for Variable<G, D, R> where G::Timesta
 /// that do not implement `Abelian` and only implement `Semigroup`. This means
 /// that it can be used in settings where the difference type does not support
 /// negation.
-pub struct SemigroupVariable<G: Scope, D: Data, R: Semigroup>
+pub struct SemigroupVariable<G: Scope, D: Data, R: Semigroup+'static>
 where G::Timestamp: Lattice {
     collection: Collection<G, D, R>,
     feedback: Handle<G, Vec<(D, G::Timestamp, R)>>,

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -21,7 +21,7 @@ pub trait ThresholdTotal<G: Scope, K: ExchangeData, R: ExchangeData+Semigroup> w
     /// Reduces the collection to one occurrence of each distinct element.
     fn threshold_semigroup<R2, F>(&self, thresh: F) -> Collection<G, K, R2>
     where
-        R2: Semigroup,
+        R2: Semigroup+'static,
         F: FnMut(&K,&R,Option<&R>)->Option<R2>+'static,
         ;
     /// Reduces the collection to one occurrence of each distinct element.
@@ -39,7 +39,7 @@ pub trait ThresholdTotal<G: Scope, K: ExchangeData, R: ExchangeData+Semigroup> w
     ///          .threshold_total(|_,c| c % 2);
     /// });
     /// ```
-    fn threshold_total<R2: Abelian, F: FnMut(&K,&R)->R2+'static>(&self, mut thresh: F) -> Collection<G, K, R2> {
+    fn threshold_total<R2: Abelian+'static, F: FnMut(&K,&R)->R2+'static>(&self, mut thresh: F) -> Collection<G, K, R2> {
         self.threshold_semigroup(move |key, new, old| {
             let mut new = thresh(key, new);
             if let Some(old) = old { new.plus_equals(&thresh(key, old).negate()); }
@@ -74,7 +74,7 @@ pub trait ThresholdTotal<G: Scope, K: ExchangeData, R: ExchangeData+Semigroup> w
     /// This method allows `distinct` to produce collections whose difference
     /// type is something other than an `isize` integer, for example perhaps an
     /// `i32`.
-    fn distinct_total_core<R2: Abelian+From<i8>>(&self) -> Collection<G, K, R2> {
+    fn distinct_total_core<R2: Abelian+From<i8>+'static>(&self) -> Collection<G, K, R2> {
         self.threshold_total(|_,_| R2::from(1i8))
     }
 
@@ -84,7 +84,7 @@ impl<G: Scope, K: ExchangeData+Hashable, R: ExchangeData+Semigroup> ThresholdTot
 where G::Timestamp: TotalOrder+Lattice+Ord {
     fn threshold_semigroup<R2, F>(&self, thresh: F) -> Collection<G, K, R2>
     where
-        R2: Semigroup,
+        R2: Semigroup+'static,
         F: FnMut(&K,&R,Option<&R>)->Option<R2>+'static,
     {
         self.arrange_by_self_named("Arrange: ThresholdTotal")
@@ -102,7 +102,7 @@ where
 {
     fn threshold_semigroup<R2, F>(&self, mut thresh: F) -> Collection<G, K, R2>
     where
-        R2: Semigroup,
+        R2: Semigroup+'static,
         F: for<'a> FnMut(T1::Key<'a>,&T1::Diff,Option<&T1::Diff>)->Option<R2>+'static,
     {
 

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -58,7 +58,7 @@ pub trait TraceReader {
     /// Timestamps associated with updates
     type Time: Timestamp + Lattice + Ord + Clone;
     /// Associated update.
-    type Diff: Semigroup;
+    type Diff: Semigroup + 'static;
 
     /// The type of an immutable collection of updates.
     type Batch: for<'a> BatchReader<Key<'a> = Self::Key<'a>, Val<'a> = Self::Val<'a>, Time = Self::Time, Diff = Self::Diff>+Clone+'static;


### PR DESCRIPTION
Our difference traits, `Semigroup`, `Monoid`, and `Abelian`, have been defined to require `Data`, which has been a helpful catch-all trait that includes `'static`. However, it is reasonable to want to implement these traits for lifetimed data, for example a `Cow<'a, Diff>` type.

This PR replaces `Data` with `Clone` in the requirements for the difference traits, and moves the `'static` and occasionally `Ord` requirements to those locations where they are required. This is a bit noisier, but I think a bit more "accurate".