### PR TITLE
Introduce `IsZero` trait for `is_zero()`

### DIFF
--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -7,7 +7,7 @@ use timely::dataflow::operators::Operator;
 use timely::progress::Antichain;
 
 use differential_dataflow::{ExchangeData, Collection, AsCollection, Hashable};
-use differential_dataflow::difference::{Semigroup, Monoid};
+use differential_dataflow::difference::{IsZero, Semigroup, Monoid};
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::{Cursor, TraceReader};
 use differential_dataflow::trace::cursor::IntoOwned;

--- a/examples/monoid-bfs.rs
+++ b/examples/monoid-bfs.rs
@@ -18,13 +18,15 @@ pub struct MinSum {
     value: u32,
 }
 
-use differential_dataflow::difference::{Semigroup, Multiply};
+use differential_dataflow::difference::{IsZero, Semigroup, Multiply};
 
+impl IsZero for MinSum {
+    fn is_zero(&self) -> bool { false }
+}
 impl Semigroup for MinSum {
     fn plus_equals(&mut self, rhs: &Self) {
         self.value = std::cmp::min(self.value, rhs.value);
     }
-    fn is_zero(&self) -> bool { false }
 }
 
 impl Multiply<Self> for MinSum {

--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -9,7 +9,7 @@ use crate::trace::cursor::IntoOwned;
 
 use crate::lattice::Lattice;
 use crate::{ExchangeData, Collection};
-use crate::difference::Semigroup;
+use crate::difference::{IsZero, Semigroup};
 use crate::hashable::Hashable;
 use crate::collection::AsCollection;
 use crate::operators::arrange::{Arranged, ArrangeBySelf};


### PR DESCRIPTION
This extracts `is_zero()` from `Semigroup`, which now requires it instead. The reasoning is that while `Semigroup<Rhs>` can have multiple `Rhs` implementations, there cannot be multiple `is_zero()` implementations, and we want to avoid confusion there. In fact, it isn't especially clear what being a zero means for any other `Rhs`, and we don't really end up using `is_zero()` in support of semigroup actions as much as once accumulation has been accomplished, determining whether to discard the update or not.