### PR TITLE
Make `Abelian::negate()` act on borrowed data

### DIFF
--- a/dogsdogsdogs/src/calculus.rs
+++ b/dogsdogsdogs/src/calculus.rs
@@ -41,7 +41,9 @@ where
         self.enter(child)
             .inner
             .flat_map(|(data, time, diff)| {
-                let neu = (data.clone(), AltNeu::neu(time.time.clone()), diff.clone().negate());
+                let mut neg_diff = diff.clone();
+                neg_diff.negate();
+                let neu = (data.clone(), AltNeu::neu(time.time.clone()), neg_diff);
                 let alt = (data, time, diff);
                 Some(alt).into_iter().chain(Some(neu))
             })

--- a/src/algorithms/identifiers.rs
+++ b/src/algorithms/identifiers.rs
@@ -67,12 +67,16 @@ where
                         // keep round-positive records as changes.
                         let ((round, record), count) = &input[0];
                         if *round > 0 {
-                            output.push(((0, record.clone()), count.clone().negate()));
+                            let mut neg_count = count.clone();
+                            neg_count.negate();
+                            output.push(((0, record.clone()), neg_count));
                             output.push(((*round, record.clone()), count.clone()));
                         }
                         // if any losers, increment their rounds.
                         for ((round, record), count) in input[1..].iter() {
-                            output.push(((0, record.clone()), count.clone().negate()));
+                            let mut neg_count = count.clone();
+                            neg_count.negate();
+                            output.push(((0, record.clone()), neg_count));
                             output.push(((*round+1, record.clone()), count.clone()));
                         }
                     })

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -549,7 +549,7 @@ impl<G: Scope, D: Data, R: Abelian+'static> Collection<G, D, R> where G::Timesta
     /// ```
     pub fn negate(&self) -> Collection<G, D, R> {
         self.inner
-            .map_in_place(|x| x.2 = x.2.clone().negate())
+            .map_in_place(|x| x.2.negate())
             .as_collection()
     }
 

--- a/src/operators/arrange/arrangement.rs
+++ b/src/operators/arrange/arrangement.rs
@@ -305,7 +305,7 @@ where
             if !input.is_empty() {
                 logic(key, input, change);
             }
-            change.extend(output.drain(..).map(|(x,d)| (x, d.negate())));
+            change.extend(output.drain(..).map(|(x,mut d)| { d.negate(); (x, d) }));
             crate::consolidation::consolidate(change);
         })
     }

--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -266,7 +266,7 @@ pub trait ReduceCore<G: Scope, K: ToOwned + ?Sized, V: Data, R: Semigroup> where
                 if !input.is_empty() {
                     logic(key, input, change);
                 }
-                change.extend(output.drain(..).map(|(x,d)| (x, d.negate())));
+                change.extend(output.drain(..).map(|(x,mut d)| { d.negate(); (x, d) }));
                 crate::consolidation::consolidate(change);
             })
         }

--- a/src/operators/threshold.rs
+++ b/src/operators/threshold.rs
@@ -43,7 +43,11 @@ pub trait ThresholdTotal<G: Scope, K: ExchangeData, R: ExchangeData+Semigroup> w
     fn threshold_total<R2: Abelian+'static, F: FnMut(&K,&R)->R2+'static>(&self, mut thresh: F) -> Collection<G, K, R2> {
         self.threshold_semigroup(move |key, new, old| {
             let mut new = thresh(key, new);
-            if let Some(old) = old { new.plus_equals(&thresh(key, old).negate()); }
+            if let Some(old) = old { 
+                let mut add = thresh(key, old);
+                add.negate();
+                new.plus_equals(&add); 
+            }
             if !new.is_zero() { Some(new) } else { None }
         })
     }


### PR DESCRIPTION
`Abelian::negate()` took a `self` argument, which meant that in several cases it provoked a `clone()` call that wasn't strictly necessary. The `negate()` dataflow operator, for example, would simply clone the diff in order to negate it, which is fine for `isize` but less great for `Vec<Diff>` types.