### PR TITLE
Remove `BatchContainer::{copy, copy_range}`.

### DIFF
--- a/src/trace/implementations/huffman_container.rs
+++ b/src/trace/implementations/huffman_container.rs
@@ -87,40 +87,6 @@ impl<B: Ord + Clone + 'static> BatchContainer for HuffmanContainer<B> {
 
     fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b> { item }
 
-    fn copy(&mut self, item: Self::ReadItem<'_>) {
-        match item.decode() {
-            Ok(decoded) => {
-                for x in decoded { *self.stats.entry(x.clone()).or_insert(0) += 1; }
-
-            },
-            Err(symbols) => {
-                for x in symbols.iter() { *self.stats.entry(x.clone()).or_insert(0) += 1; }
-            }
-        }
-        match (item.decode(), &mut self.inner) {
-            (Ok(decoded), Ok((huffman, bytes))) => {
-                bytes.extend(huffman.encode(decoded));
-                self.offsets.push(bytes.len());
-            }
-            (Ok(decoded), Err(raw)) => {
-                raw.extend(decoded.cloned());
-                self.offsets.push(raw.len());
-            }
-            (Err(symbols), Ok((huffman, bytes))) => { 
-                bytes.extend(huffman.encode(symbols.iter()));
-                self.offsets.push(bytes.len());
-            }
-            (Err(symbols), Err(raw)) => { 
-                raw.extend(symbols.iter().cloned());
-                self.offsets.push(raw.len());
-            }
-        }
-    }
-    fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
-        for index in start .. end {
-            self.copy(other.index(index));
-        }
-    }
     fn with_capacity(size: usize) -> Self {
         let mut offsets = OffsetList::with_capacity(size + 1);
         offsets.push(0);

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -510,7 +510,7 @@ pub mod containers {
     use crate::trace::IntoOwned;
 
     /// A general-purpose container resembling `Vec<T>`.
-    pub trait BatchContainer: 'static {
+    pub trait BatchContainer: for<'a> PushInto<Self::ReadItem<'a>> + 'static {
         /// An owned instance of `Self::ReadItem<'_>`.
         type Owned;
 

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -300,16 +300,6 @@ impl BatchContainer for OffsetList {
     type Owned = usize;
     type ReadItem<'a> = usize;
 
-    fn copy(&mut self, item: Self::ReadItem<'_>) {
-        self.push(item);
-    }
-
-    fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
-        for offset in start..end {
-            self.push(other.index(offset));
-        }
-    }
-
     fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b> { item }
 
     fn with_capacity(size: usize) -> Self {
@@ -521,14 +511,6 @@ pub mod containers {
         fn push<D>(&mut self, item: D) where Self: PushInto<D> {
             self.push_into(item);
         }
-        /// Inserts a borrowed item.
-        fn copy(&mut self, item: Self::ReadItem<'_>);
-        /// Extends from a range of items in another`Self`.
-        fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
-            for index in start .. end {
-                self.copy(other.index(index));
-            }
-        }
         /// Creates a new container with sufficient capacity.
         fn with_capacity(size: usize) -> Self;
         /// Creates a new container with sufficient capacity.
@@ -606,12 +588,6 @@ pub mod containers {
 
         fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b> { item }
 
-        fn copy(&mut self, item: &T) {
-            self.push(item.clone());
-        }
-        fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
-            self.extend_from_slice(&other[start .. end]);
-        }
         fn with_capacity(size: usize) -> Self {
             Vec::with_capacity(size)
         }
@@ -634,16 +610,6 @@ pub mod containers {
 
         fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b> { item }
 
-        fn copy(&mut self, item: &T) {
-            self.copy(item);
-        }
-        fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
-            let slice = &other[start .. end];
-            self.reserve_items(slice.iter());
-            for item in slice.iter() {
-                self.copy(item);
-            }
-        }
         fn with_capacity(size: usize) -> Self {
             Self::with_capacity(size)
         }
@@ -671,10 +637,6 @@ pub mod containers {
         {
             type Owned = R::Owned;
             type ReadItem<'a> = R::ReadItem<'a>;
-
-            fn copy(&mut self, item: Self::ReadItem<'_>) {
-                self.copy(item);
-            }
 
             fn with_capacity(size: usize) -> Self {
                 Self::with_capacity(size)
@@ -711,13 +673,16 @@ pub mod containers {
 
     impl<B: Ord + Clone + 'static> PushInto<&[B]> for SliceContainer<B> {
         fn push_into(&mut self, item: &[B]) {
-            self.copy(item);
+            for x in item.iter() {
+                self.inner.push_into(x);
+            }
+            self.offsets.push(self.inner.len());
         }
     }
 
     impl<B: Ord + Clone + 'static> PushInto<&Vec<B>> for SliceContainer<B> {
         fn push_into(&mut self, item: &Vec<B>) {
-            self.copy(item);
+            self.push_into(&item[..]);
         }
     }
 
@@ -739,17 +704,6 @@ pub mod containers {
 
         fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b> { item }
 
-        fn copy(&mut self, item: Self::ReadItem<'_>) {
-            for x in item.iter() {
-                self.inner.copy(x);
-            }
-            self.offsets.push(self.inner.len());
-        }
-        fn copy_range(&mut self, other: &Self, start: usize, end: usize) {
-            for index in start .. end {
-                self.copy(other.index(index));
-            }
-        }
         fn with_capacity(size: usize) -> Self {
             let mut offsets = Vec::with_capacity(size + 1);
             offsets.push(0);

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -191,7 +191,7 @@ mod val_batch {
             while self.keys.len() < desired {
                 // We insert a default (dummy) key and repeat the offset to indicate this.
                 let current_offset = self.keys_offs.index(self.keys.len());
-                self.keys.push(Default::default());
+                self.keys.push(<<L::Target as Update>::Key as Default>::default());
                 self.keys_offs.copy(current_offset);
             }
 


### PR DESCRIPTION
This PR replaces `BatchContainer::copy` with a `PushInto` requirement. We could leave the `copy` method while insisting on the `PushInto` implementation, if that provides more clarity about when we are specifically copying back a `ReadItem`, but it felt best to use the one idiom we have for implementing pushing into a container, vs having multiple implementations around (which we had).

`BatchContainer::copy_range` was removed because no one is using it. No harm adding it back, but in that case perhaps we instead want to support `PushInto` for a range type (or some wrapper around one).