### PR TITLE
Reduce: Insert time by ref

### DIFF
--- a/src/operators/reduce.rs
+++ b/src/operators/reduce.rs
@@ -585,7 +585,7 @@ where
                         // Determine the frontier of our interesting times.
                         let mut frontier = Antichain::<G::Timestamp>::new();
                         for (_, time) in &interesting {
-                            frontier.insert(time.clone());
+                            frontier.insert_ref(time);
                         }
 
                         // Update `capabilities` to reflect interesting pairs described by `frontier`.


### PR DESCRIPTION
Insert time by reference into a frontier instead of cloning, which can avoid the clone if inserting the time does not change the frontier. Could result in better performance, but not tested.
