### PR TITLE
Fix panic in to_vec

### DIFF
--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -84,8 +84,8 @@ pub trait Cursor {
     {
         let mut out = Vec::new();
         self.rewind_keys(storage);
-        self.rewind_vals(storage);
         while self.key_valid(storage) {
+            self.rewind_vals(storage);
             while self.val_valid(storage) {
                 let mut kv_out = Vec::new();
                 self.map_times(storage, |ts, r| {


### PR DESCRIPTION
`rewind_vals` only works if there are any values.
