### PR TITLE
Generalize flat container implementations to less specific regions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ timely = {workspace = true}
 
 [workspace.dependencies]
 #timely = { version = "0.12", default-features = false }
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
+timely = { git = "https://github.com/antiguru/timely-dataflow", branch = "flatcontainer_storage", default-features = false }
 #timely = { path = "../timely-dataflow/timely/", default-features = false }
 
 [features]

--- a/src/consolidation.rs
+++ b/src/consolidation.rs
@@ -336,11 +336,19 @@ mod flatcontainer {
         }
 
         fn preferred_capacity() -> usize {
+            // We don't have a good way to present any pre-defined capacity here, since it's a
+            // concept foreign to flat containers. Each region might have a capacity, but overall
+            // the concept of capacity does not exist. For this reason, we just hardcode a number,
+            // which seems to work reasonably well.
+            //
+            // We should revisit this if/once we have an abstraction that can express a capacity
+            // for `FlatStack`, but we arent' there yet.
             1024
         }
 
         fn ensure_preferred_capacity(&mut self) {
-            // Nop
+            // Nop, same reasoning as for `preferred_capacity`. We don't know how to ensure capacity
+            // for a certain number of elements.
         }
     }
 }

--- a/src/consolidation.rs
+++ b/src/consolidation.rs
@@ -280,29 +280,29 @@ where
     }
 }
 
-impl<MC> ConsolidateLayout for FlatStack<MC>
+impl<R> ConsolidateLayout for FlatStack<R>
 where
-    MC: RegionUpdate
+    R: RegionUpdate
         + Region
         + Clone
-        + for<'a> Push<((MC::Key<'a>, MC::Val<'a>), MC::Time<'a>, MC::DiffOwned)>
+        + for<'a> Push<((R::Key<'a>, R::Val<'a>), R::Time<'a>, R::DiffOwned)>
         + 'static,
-    for<'a> MC::DiffOwned: Semigroup<MC::Diff<'a>>,
-    for<'a> MC::ReadItem<'a>: Copy,
+    for<'a> R::DiffOwned: Semigroup<R::Diff<'a>>,
+    for<'a> R::ReadItem<'a>: Copy,
 {
-    type Key<'a> = (MC::Key<'a>, MC::Val<'a>, MC::Time<'a>) where Self: 'a;
-    type Diff<'a> = MC::Diff<'a> where Self: 'a;
-    type DiffOwned = MC::DiffOwned;
+    type Key<'a> = (R::Key<'a>, R::Val<'a>, R::Time<'a>) where Self: 'a;
+    type Diff<'a> = R::Diff<'a> where Self: 'a;
+    type DiffOwned = R::DiffOwned;
 
     fn into_parts(item: Self::Item<'_>) -> (Self::Key<'_>, Self::Diff<'_>) {
-        let (key, val, time, diff) = MC::into_parts(item);
+        let (key, val, time, diff) = R::into_parts(item);
         ((key, val, time), diff)
     }
 
     fn cmp<'a>(item1: &Self::Item<'_>, item2: &Self::Item<'_>) -> Ordering {
-        let (key1, val1, time1, _diff1) = MC::into_parts(*item1);
-        let (key2, val2, time2, _diff2) = MC::into_parts(*item2);
-        (MC::reborrow_key(key1), MC::reborrow_val(val1), MC::reborrow_time(time1)).cmp(&(MC::reborrow_key(key2), MC::reborrow_val(val2), MC::reborrow_time(time2)))
+        let (key1, val1, time1, _diff1) = R::into_parts(*item1);
+        let (key2, val2, time2, _diff2) = R::into_parts(*item2);
+        (R::reborrow_key(key1), R::reborrow_val(val1), R::reborrow_time(time1)).cmp(&(R::reborrow_key(key2), R::reborrow_val(val2), R::reborrow_time(time2)))
     }
 
     fn push_with_diff(&mut self, (key, value, time): Self::Key<'_>, diff: Self::DiffOwned) {

--- a/src/trace/implementations/chunker.rs
+++ b/src/trace/implementations/chunker.rs
@@ -4,7 +4,8 @@ use std::collections::VecDeque;
 use timely::communication::message::RefOrMut;
 use timely::Container;
 use timely::container::columnation::{Columnation, TimelyStack};
-use timely::container::{ContainerBuilder, PushInto};
+use timely::container::{CapacityContainer, ContainerBuilder, PushInto};
+
 use crate::consolidation::{consolidate_updates, consolidate_container, ConsolidateLayout};
 use crate::difference::Semigroup;
 
@@ -292,6 +293,7 @@ impl<'a, Input, Output> PushInto<RefOrMut<'a, Input>> for ContainerChunker<Outpu
 where
     Input: Container,
     Output: ConsolidateLayout
+        + CapacityContainer
         + PushInto<Input::Item<'a>>
         + PushInto<Input::ItemRef<'a>>,
 {

--- a/src/trace/implementations/merge_batcher_flat.rs
+++ b/src/trace/implementations/merge_batcher_flat.rs
@@ -75,6 +75,18 @@ pub trait MergerChunk: Region {
 
     /// Compare two items, ignoring the diff.
     fn cmp_without_diff<'a, 'b>(item1: Self::ReadItem<'a>, item2: Self::ReadItem<'b>) -> Ordering;
+
+    /// Converts a key into one with a narrower lifetime.
+    #[must_use]
+    fn reborrow_key<'b, 'a: 'b>(item: Self::Key<'a>) -> Self::Key<'b>
+    where
+        Self: 'a;
+
+    /// Converts a value into one with a narrower lifetime.
+    #[must_use]
+    fn reborrow_val<'b, 'a: 'b>(item: Self::Val<'a>) -> Self::Val<'b>
+    where
+        Self: 'a;
 }
 
 impl<K,V,T,R> MergerChunk for TupleABCRegion<TupleABRegion<K, V>, T, R>
@@ -100,6 +112,20 @@ where
 
     fn cmp_without_diff<'a, 'b>(((key1, val1), time1, _diff1): Self::ReadItem<'a>, ((key2, val2), time2, _diff2): Self::ReadItem<'b>) -> Ordering {
         (K::reborrow(key1), V::reborrow(val1), T::reborrow(time1)).cmp(&(K::reborrow(key2), V::reborrow(val2), T::reborrow(time2)))
+    }
+
+    fn reborrow_key<'b, 'a: 'b>(item: Self::Key<'a>) -> Self::Key<'b>
+    where
+        Self: 'a
+    {
+        K::reborrow(item)
+    }
+
+    fn reborrow_val<'b, 'a: 'b>(item: Self::Val<'a>) -> Self::Val<'b>
+    where
+        Self: 'a
+    {
+        V::reborrow(item)
     }
 }
 

--- a/src/trace/implementations/merge_batcher_flat.rs
+++ b/src/trace/implementations/merge_batcher_flat.rs
@@ -53,6 +53,9 @@ where
     #[inline]
     fn recycle(&self, mut chunk: FlatStack<R, S>, stash: &mut Vec<FlatStack<R, S>>) {
         // TODO: Should we limit the size of `stash`?
+        // TODO: Ideally, we check that `chunk` has a shape (capacity) that fits, but flat
+        // containers don't have a concept of capacity on a `FlatStack`-level, only on individual
+        // regions.
         chunk.clear();
         stash.push(chunk);
     }

--- a/src/trace/implementations/merge_batcher_flat.rs
+++ b/src/trace/implementations/merge_batcher_flat.rs
@@ -72,6 +72,9 @@ pub trait MergerChunk: Region {
 
     /// Split a read item into its constituents. Must be cheap.
     fn into_parts<'a>(item: Self::ReadItem<'a>) -> (Self::Key<'a>, Self::Val<'a>, Self::Time<'a>, Self::Diff<'a>);
+
+    /// Compare two items, ignoring the diff.
+    fn cmp_without_diff<'a, 'b>(item1: Self::ReadItem<'a>, item2: Self::ReadItem<'b>) -> Ordering;
 }
 
 impl<K,V,T,R> MergerChunk for TupleABCRegion<TupleABRegion<K, V>, T, R>
@@ -93,6 +96,10 @@ where
 
     fn into_parts<'a>(((key, val), time, diff): Self::ReadItem<'a>) -> (Self::Key<'a>, Self::Val<'a>, Self::Time<'a>, Self::Diff<'a>) {
         (key, val, time, diff)
+    }
+
+    fn cmp_without_diff<'a, 'b>(((key1, val1), time1, _diff1): Self::ReadItem<'a>, ((key2, val2), time2, _diff2): Self::ReadItem<'b>) -> Ordering {
+        (K::reborrow(key1), V::reborrow(val1), T::reborrow(time1)).cmp(&(K::reborrow(key2), V::reborrow(val2), T::reborrow(time2)))
     }
 }
 

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -401,6 +401,7 @@ where
 
 mod flatcontainer {
     use timely::container::flatcontainer::{FlatStack, IntoOwned, Push, Region};
+    use timely::container::flatcontainer::impls::index::IndexContainer;
     use timely::progress::Timestamp;
 
     use crate::difference::Semigroup;
@@ -448,13 +449,14 @@ mod flatcontainer {
         type OffsetContainer = OffsetList;
     }
 
-    impl<KBC,VBC, R> BuilderInput<KBC, VBC> for FlatStack<R>
+    impl<KBC,VBC, R, S> BuilderInput<KBC, VBC> for FlatStack<R, S>
     where
         R: RegionUpdate + Region + Clone + 'static,
         KBC: BatchContainer,
         VBC: BatchContainer,
         for<'a> KBC::ReadItem<'a>: PartialEq<R::Key<'a>>,
         for<'a> VBC::ReadItem<'a>: PartialEq<R::Val<'a>>,
+        S: IndexContainer<R::Index> + Clone + 'static,
     {
         type Key<'a> = R::Key<'a>;
         type Val<'a> = R::Val<'a>;
@@ -614,12 +616,14 @@ pub mod containers {
 
     mod flatcontainer {
         use timely::container::flatcontainer::{FlatStack, Push, Region};
+        use timely::container::flatcontainer::impls::index::IndexContainer;
         use crate::trace::implementations::BatchContainer;
 
-        impl<R> BatchContainer for FlatStack<R>
+        impl<R, S> BatchContainer for FlatStack<R, S>
         where
             for<'a> R: Region + Push<<R as Region>::ReadItem<'a>> + 'static,
             for<'a> R::ReadItem<'a>: Copy + Ord,
+            S: IndexContainer<R::Index> + Clone + 'static,
         {
             type Owned = R::Owned;
             type ReadItem<'a> = R::ReadItem<'a>;

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -448,30 +448,30 @@ mod flatcontainer {
         type OffsetContainer = OffsetList;
     }
 
-    impl<KBC,VBC,MC> BuilderInput<KBC, VBC> for FlatStack<MC>
+    impl<KBC,VBC, R> BuilderInput<KBC, VBC> for FlatStack<R>
     where
-        MC: RegionUpdate + Region + Clone + 'static,
+        R: RegionUpdate + Region + Clone + 'static,
         KBC: BatchContainer,
         VBC: BatchContainer,
-        for<'a> KBC::ReadItem<'a>: PartialEq<MC::Key<'a>>,
-        for<'a> VBC::ReadItem<'a>: PartialEq<MC::Val<'a>>,
+        for<'a> KBC::ReadItem<'a>: PartialEq<R::Key<'a>>,
+        for<'a> VBC::ReadItem<'a>: PartialEq<R::Val<'a>>,
     {
-        type Key<'a> = MC::Key<'a>;
-        type Val<'a> = MC::Val<'a>;
-        type Time = MC::TimeOwned;
-        type Diff = MC::DiffOwned;
+        type Key<'a> = R::Key<'a>;
+        type Val<'a> = R::Val<'a>;
+        type Time = R::TimeOwned;
+        type Diff = R::DiffOwned;
 
         fn into_parts<'a>(item: Self::Item<'a>) -> (Self::Key<'a>, Self::Val<'a>, Self::Time, Self::Diff) {
-            let (key, val, time, diff) = MC::into_parts(item);
+            let (key, val, time, diff) = R::into_parts(item);
             (key, val, time.into_owned(), diff.into_owned())
         }
 
         fn key_eq(this: &Self::Key<'_>, other: KBC::ReadItem<'_>) -> bool {
-            KBC::reborrow(other) == MC::reborrow_key(*this)
+            KBC::reborrow(other) == R::reborrow_key(*this)
         }
 
         fn val_eq(this: &Self::Val<'_>, other: VBC::ReadItem<'_>) -> bool {
-            VBC::reborrow(other) == MC::reborrow_val(*this)
+            VBC::reborrow(other) == R::reborrow_val(*this)
         }
     }
 }

--- a/src/trace/implementations/mod.rs
+++ b/src/trace/implementations/mod.rs
@@ -406,7 +406,7 @@ mod flatcontainer {
     use crate::difference::Semigroup;
     use crate::lattice::Lattice;
     use crate::trace::implementations::{BatchContainer, BuilderInput, FlatLayout, Layout, OffsetList, Update};
-    use crate::trace::implementations::merge_batcher_flat::MergerChunk;
+    use crate::trace::implementations::merge_batcher_flat::RegionUpdate;
 
     impl<K, V, T, R> Update for FlatLayout<K, V, T, R>
     where
@@ -450,11 +450,7 @@ mod flatcontainer {
 
     impl<KBC,VBC,MC> BuilderInput<KBC, VBC> for FlatStack<MC>
     where
-        MC: MergerChunk + Region + Clone + 'static,
-        for<'a> MC::Key<'a>: Copy,
-        for<'a> MC::Val<'a>: Copy,
-        for<'a> MC::Time<'a>: IntoOwned<'a, Owned = MC::TimeOwned>,
-        for<'a> MC::Diff<'a>: IntoOwned<'a, Owned = MC::DiffOwned>,
+        MC: RegionUpdate + Region + Clone + 'static,
         KBC: BatchContainer,
         VBC: BatchContainer,
         for<'a> KBC::ReadItem<'a>: PartialEq<MC::Key<'a>>,

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -42,10 +42,10 @@ pub type ColValSpine<K, V, T, R> = Spine<
 >;
 
 /// A trace implementation backed by flatcontainer storage.
-pub type FlatValSpine<L, R, C> = Spine<
+pub type FlatValSpine<L, R, C, S = Vec<<R as timely::container::flatcontainer::Region>::Index>> = Spine<
     Rc<OrdValBatch<L>>,
-    MergeBatcher<C, ContainerChunker<FlatStack<R>>, FlatcontainerMerger<R>, <R as RegionUpdate>::TimeOwned>,
-    RcBuilder<OrdValBuilder<L, FlatStack<R>>>,
+    MergeBatcher<C, ContainerChunker<FlatStack<R, S>>, FlatcontainerMerger<R, S>, <R as RegionUpdate>::TimeOwned>,
+    RcBuilder<OrdValBuilder<L, FlatStack<R, S>>>,
 >;
 
 /// A trace implementation backed by flatcontainer storage, using [`FlatLayout`] as the layout.

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -17,7 +17,7 @@ use crate::trace::implementations::chunker::{ColumnationChunker, ContainerChunke
 use crate::trace::implementations::spine_fueled::Spine;
 use crate::trace::implementations::merge_batcher::{MergeBatcher, VecMerger};
 use crate::trace::implementations::merge_batcher_col::ColumnationMerger;
-use crate::trace::implementations::merge_batcher_flat::{FlatcontainerMerger, MergerChunk};
+use crate::trace::implementations::merge_batcher_flat::{FlatcontainerMerger, RegionUpdate};
 use crate::trace::rc_blanket_impls::RcBuilder;
 
 use super::{Update, Layout, Vector, TStack, Preferred, FlatLayout};
@@ -44,7 +44,7 @@ pub type ColValSpine<K, V, T, R> = Spine<
 /// A trace implementation backed by flatcontainer storage.
 pub type FlatValSpine<L, R, C> = Spine<
     Rc<OrdValBatch<L>>,
-    MergeBatcher<C, ContainerChunker<FlatStack<R>>, FlatcontainerMerger<R>, <R as MergerChunk>::TimeOwned>,
+    MergeBatcher<C, ContainerChunker<FlatStack<R>>, FlatcontainerMerger<R>, <R as RegionUpdate>::TimeOwned>,
     RcBuilder<OrdValBuilder<L, FlatStack<R>>>,
 >;
 
@@ -74,7 +74,7 @@ pub type ColKeySpine<K, T, R> = Spine<
 /// A trace implementation backed by flatcontainer storage.
 pub type FlatKeySpine<L, R, C> = Spine<
     Rc<OrdKeyBatch<L>>,
-    MergeBatcher<C, ContainerChunker<FlatStack<R>>, FlatcontainerMerger<R>, <R as MergerChunk>::TimeOwned>,
+    MergeBatcher<C, ContainerChunker<FlatStack<R>>, FlatcontainerMerger<R>, <R as RegionUpdate>::TimeOwned>,
     RcBuilder<OrdKeyBuilder<L, FlatStack<R>>>,
 >;
 

--- a/tests/bfs.rs
+++ b/tests/bfs.rs
@@ -300,12 +300,13 @@ where
     for<'a> G::Timestamp: PartialOrder<<<G::Timestamp as RegionPreference>::Region as Region>::ReadItem<'a>>,
     <G::Timestamp as RegionPreference>::Region: Region<Owned=G::Timestamp> + Push<G::Timestamp>,
     for<'a> <Product<G::Timestamp, u64> as RegionPreference>::Region: Region<Owned=Product<G::Timestamp, u64>> + Push<<<Product<G::Timestamp, u64> as RegionPreference>::Region as Region>::ReadItem<'a>>,
-    <G::Timestamp as RegionPreference>::Region: Clone + Ord,
+    <G::Timestamp as RegionPreference>::Region: Clone + Ord + for<'a> ReserveItems<&'a G::Timestamp>,
     for<'a> FlatProductRegion<<G::Timestamp as RegionPreference>::Region, MirrorRegion<u64>>: Push<&'a Product<G::Timestamp, u64>>,
     for<'a> <FlatProductRegion<<G::Timestamp as RegionPreference>::Region, MirrorRegion<u64>> as Region>::ReadItem<'a>: Copy + Ord + Debug,
     Product<G::Timestamp, u64>: for<'a> PartialOrder<<<Product<G::Timestamp, u64> as RegionPreference>::Region as Region>::ReadItem<'a>>,
     for<'a> <<Product<G::Timestamp, u64> as RegionPreference>::Region as Region>::ReadItem<'a>: PartialOrder<Product<G::Timestamp, u64>>,
     for<'a> <Product<G::Timestamp, u64> as RegionPreference>::Region: ReserveItems<<<Product<G::Timestamp, u64> as RegionPreference>::Region as Region>::ReadItem<'a>>,
+    for<'a> <Product<G::Timestamp, u64> as RegionPreference>::Region: ReserveItems<&'a <<Product<G::Timestamp, u64> as RegionPreference>::Region as Region>::ReadItem<'a>>,
 {
     // initialize roots as reaching themselves at distance 0
     let nodes = roots.map(|x| (x, 0));


### PR DESCRIPTION
This change redefines some trait implementations in differential for flat containers to be in terms of regions fulfilling some requirements instead of specific regions. The current implementation makes it impossible to implement the traits for specific regions due to Rust's orphan rules, which blocks us from using custom region implementations in Materialize.

The change should be localized to traits and implementations related to flat container. It includes some overdue renaming to make traits and generic parameters slightly more understandable.
