### PR TITLE
Update batch processing to support compacted inputs

### DIFF
--- a/src/operators/count.rs
+++ b/src/operators/count.rs
@@ -101,8 +101,6 @@ where
 
                     use crate::trace::cursor::CursorList;
                     let mut batch_cursor = CursorList::new(batch_cursors, &batch_storage);
-
-                    trace.advance_upper(&mut lower_limit);
                     let (mut trace_cursor, trace_storage) = trace.cursor_through(lower_limit.borrow()).unwrap();
 
                     while let Some(key) = batch_cursor.get_key(&batch_storage) {


### PR DESCRIPTION
The `count_total` and `threshold_total` operators would work batch at a time, which doesn't work out when data are pre-compacted: a prefix of the batches may have `lower` and `upper` frontiers that are no longer valid cut points for the trace, and we cannot get a cursor to "just before" either of them.

The fix used in `reduce.rs` is to drain all input batches before processing any, so that when invoked on compacted data we draw all batches currently available, up through to the minting frontier of the arrangement operator. All drained input batches are processed as one batch, using the `CursorList` tool to bundle them and treat them as one. We only end up using the last batch `upper` to get a trace cursor, which .. is more likely to be valid than other batch uppers (it should be valid, as each worker is single threaded, and there should be no concurrency issues with the batches somehow not being available).

fixes #526