### PR TITLE
Move `Batcher::seal` to `Builder`

### DIFF
--- a/experiments/src/bin/graspan2.rs
+++ b/experiments/src/bin/graspan2.rs
@@ -86,7 +86,7 @@ fn unoptimized() {
 
                     let value_flow_next =
                     value_flow_next
-                        .arrange::<ValBatcher<_,_,_,_>, KeyBuilder<_,_,_>, KeySpine<_,_,_>>()
+                        .arrange::<KeyBatcher<_,_,_>, KeyBuilder<_,_,_>, KeySpine<_,_,_>>()
                         // .distinct_total_core::<Diff>()
                         .threshold_semigroup(|_,_,x| if x.is_none() { Some(Present) } else { None })
                         ;

--- a/src/trace/implementations/ord_neu.rs
+++ b/src/trace/implementations/ord_neu.rs
@@ -694,8 +694,22 @@ mod val_batch {
                 description: Description::new(lower, upper, since),
             }
         }
-    }
 
+        fn seal(
+            chain: &mut Vec<Self::Input>,
+            lower: AntichainRef<Self::Time>,
+            upper: AntichainRef<Self::Time>,
+            since: AntichainRef<Self::Time>,
+        ) -> Self::Output {
+            let (keys, vals, upds) = Self::Input::key_val_upd_counts(&chain[..]);
+            let mut builder = Self::with_capacity(keys, vals, upds);
+            for mut chunk in chain.drain(..) {
+                builder.push(&mut chunk);
+            }
+    
+            builder.done(lower.to_owned(), upper.to_owned(), since.to_owned())
+        }
+    }
 }
 
 mod key_batch {
@@ -1166,6 +1180,21 @@ mod key_batch {
                 storage: self.result,
                 description: Description::new(lower, upper, since),
             }
+        }
+
+        fn seal(
+            chain: &mut Vec<Self::Input>,
+            lower: AntichainRef<Self::Time>,
+            upper: AntichainRef<Self::Time>,
+            since: AntichainRef<Self::Time>,
+        ) -> Self::Output {
+            let (keys, vals, upds) = Self::Input::key_val_upd_counts(&chain[..]);
+            let mut builder = Self::with_capacity(keys, vals, upds);
+            for mut chunk in chain.drain(..) {
+                builder.push(&mut chunk);
+            }
+    
+            builder.done(lower.to_owned(), upper.to_owned(), since.to_owned())
         }
     }
 

--- a/src/trace/implementations/rhh.rs
+++ b/src/trace/implementations/rhh.rs
@@ -867,6 +867,21 @@ mod val_batch {
                 description: Description::new(lower, upper, since),
             }
         }
+
+        fn seal(
+            chain: &mut Vec<Self::Input>,
+            lower: AntichainRef<Self::Time>,
+            upper: AntichainRef<Self::Time>,
+            since: AntichainRef<Self::Time>,
+        ) -> Self::Output {
+            let (keys, vals, upds) = Self::Input::key_val_upd_counts(&chain[..]);
+            let mut builder = Self::with_capacity(keys, vals, upds);
+            for mut chunk in chain.drain(..) {
+                builder.push(&mut chunk);
+            }
+    
+            builder.done(lower.to_owned(), upper.to_owned(), since.to_owned())
+        }
     }
 
 }


### PR DESCRIPTION
This PR moves the `seal` method from the batcher to the builder. The `seal` method was generic in builder, required a leaky abstraction of key, val, and update counts, and .. had very little to do with the batcher. This opens the door to batchers that know less about the structure of their updates, in particular about the key, val structure.