### PR TITLE
Remove (key, val) structure from merge batchers

### DIFF
--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -264,15 +264,14 @@ impl<T> VecMerger<T> {
     }
 }
 
-impl<K, V, T, R> Merger for VecMerger<((K, V), T, R)>
+impl<D, T, R> Merger for VecMerger<(D, T, R)>
 where
-    K: Data,
-    V: Data,
+    D: Data,
     T: Ord + PartialOrder + Clone + 'static,
     R: Semigroup + 'static,
 {
     type Time = T;
-    type Chunk = Vec<((K, V), T, R)>;
+    type Chunk = Vec<(D, T, R)>;
 
     fn merge(&mut self, list1: Vec<Self::Chunk>, list2: Vec<Self::Chunk>, output: &mut Vec<Self::Chunk>, stash: &mut Vec<Self::Chunk>) {
         let mut list1 = list1.into_iter();

--- a/src/trace/implementations/merge_batcher_col.rs
+++ b/src/trace/implementations/merge_batcher_col.rs
@@ -52,15 +52,14 @@ impl<T: Columnation> ColumnationMerger<T> {
     }
 }
 
-impl<K, V, T, R> Merger for ColumnationMerger<((K, V), T, R)>
+impl<D, T, R> Merger for ColumnationMerger<(D, T, R)>
 where
-    K: Columnation + Ord + Data,
-    V: Columnation + Ord + Data,
+    D: Columnation + Ord + Data,
     T: Columnation + Ord + PartialOrder + Data,
     R: Columnation + Semigroup + 'static,
 {
     type Time = T;
-    type Chunk = TimelyStack<((K, V), T, R)>;
+    type Chunk = TimelyStack<(D, T, R)>;
 
     fn merge(&mut self, list1: Vec<Self::Chunk>, list2: Vec<Self::Chunk>, output: &mut Vec<Self::Chunk>, stash: &mut Vec<Self::Chunk>) {
         let mut list1 = list1.into_iter();


### PR DESCRIPTION
The vector and columnation merge batchers require `(key, val)` structure, but their implementation does not require it. Remove that requirement.