### PR TITLE
Simplify ContainerChunker::push_into

### DIFF
--- a/src/consolidation.rs
+++ b/src/consolidation.rs
@@ -311,7 +311,7 @@ where
 /// Consolidate the supplied container.
 pub fn consolidate_container<C: ConsolidateLayout>(container: &mut C, target: &mut C) {
     // Sort input data
-    let mut permutation = Vec::new();
+    let mut permutation = Vec::with_capacity(container.len());
     permutation.extend(container.drain());
     permutation.sort_by(|a, b| C::cmp(a, b));
 


### PR DESCRIPTION
Instead of defining a closure and calling it, just inline the single use of the closure.
