### PR TITLE
Consolidation consolidation

### DIFF
--- a/src/consolidation.rs
+++ b/src/consolidation.rs
@@ -255,6 +255,49 @@ pub trait ConsolidateLayout: Container {
 
     /// Compare two items by key to sort containers.
     fn cmp(item1: &Self::Item<'_>, item2: &Self::Item<'_>) -> Ordering;
+
+    /// Consolidate the supplied container.
+    fn consolidate_into(&mut self, target: &mut Self) {
+        // Sort input data
+        let mut permutation = Vec::with_capacity(self.len());
+        permutation.extend(self.drain());
+        permutation.sort_by(|a, b| Self::cmp(a, b));
+
+        // Consolidate sorted data.
+        let mut previous: Option<(Self::Key<'_>, Self::DiffOwned)> = None;
+        // TODO: We should ensure that `target` has sufficient capacity, but `Container` doesn't
+        // offer a suitable API.
+        for item in permutation.drain(..) {
+            let (key, diff) = Self::into_parts(item);
+            match &mut previous {
+                // Initial iteration, remember key and diff.
+                // TODO: Opportunity for GatCow for diff.
+                None => previous = Some((key, diff.into_owned())),
+                Some((prevkey, d)) => {
+                    // Second and following iteration, compare and accumulate or emit.
+                    if key == *prevkey {
+                        // Keys match, keep accumulating.
+                        d.plus_equals(&diff);
+                    } else {
+                        // Keys don't match, write down result if non-zero.
+                        if !d.is_zero() {
+                            // Unwrap because we checked for `Some` above.
+                            let (prevkey, diff) = previous.take().unwrap();
+                            target.push_with_diff(prevkey, diff);
+                        }
+                        // Remember current key and diff as `previous`
+                        previous = Some((key, diff.into_owned()));
+                    }
+                }
+            }
+        }
+        // Write any residual data, if non-zero.
+        if let Some((previtem, d)) = previous {
+            if !d.is_zero() {
+                target.push_with_diff(previtem, d);
+            }
+        }
+    }
 }
 
 impl<D, T, R> ConsolidateLayout for Vec<(D, T, R)>
@@ -277,6 +320,12 @@ where
 
     fn push_with_diff(&mut self, (data, time): Self::Key<'_>, diff: Self::DiffOwned) {
         self.push((data, time, diff));
+    }
+
+    /// Consolidate the supplied container.
+    fn consolidate_into(&mut self, target: &mut Self) {
+        consolidate_updates(self);
+        std::mem::swap(self, target);
     }
 }
 
@@ -305,49 +354,6 @@ where
 
     fn push_with_diff(&mut self, (key, value, time): Self::Key<'_>, diff: Self::DiffOwned) {
         self.copy(((key, value), time, diff));
-    }
-}
-
-/// Consolidate the supplied container.
-pub fn consolidate_container<C: ConsolidateLayout>(container: &mut C, target: &mut C) {
-    // Sort input data
-    let mut permutation = Vec::with_capacity(container.len());
-    permutation.extend(container.drain());
-    permutation.sort_by(|a, b| C::cmp(a, b));
-
-    // Consolidate sorted data.
-    let mut previous: Option<(C::Key<'_>, C::DiffOwned)> = None;
-    // TODO: We should ensure that `target` has sufficient capacity, but `Container` doesn't
-    // offer a suitable API.
-    for item in permutation.drain(..) {
-        let (key, diff) = C::into_parts(item);
-        match &mut previous {
-            // Initial iteration, remember key and diff.
-            // TODO: Opportunity for GatCow for diff.
-            None => previous = Some((key, diff.into_owned())),
-            Some((prevkey, d)) => {
-                // Second and following iteration, compare and accumulate or emit.
-                if key == *prevkey {
-                    // Keys match, keep accumulating.
-                    d.plus_equals(&diff);
-                } else {
-                    // Keys don't match, write down result if non-zero.
-                    if !d.is_zero() {
-                        // Unwrap because we checked for `Some` above.
-                        let (prevkey, diff) = previous.take().unwrap();
-                        target.push_with_diff(prevkey, diff);
-                    }
-                    // Remember current key and diff as `previous`
-                    previous = Some((key, diff.into_owned()));
-                }
-            }
-        }
-    }
-    // Write any residual data, if non-zero.
-    if let Some((previtem, d)) = previous {
-        if !d.is_zero() {
-            target.push_with_diff(previtem, d);
-        }
     }
 }
 
@@ -445,11 +451,11 @@ mod tests {
     }
 
     #[test]
-    fn test_consolidate_container() {
+    fn test_consolidate_into() {
         let mut data = vec![(1, 1, 1), (2, 1, 1), (1, 1, -1)];
         let mut target = Vec::default();
         data.sort();
-        consolidate_container(&mut data, &mut target);
+        data.consolidate_into(&mut target);
         assert_eq!(target, [(2, 1, 1)]);
     }
 
@@ -477,7 +483,7 @@ mod tests {
             data2.extend((0..LEN).map(|i| (i/4, 1, -2isize + ((i % 4) as isize))));
             data.sort_by(|x,y| x.0.cmp(&y.0));
             let start = std::time::Instant::now();
-            consolidate_container(&mut data, &mut target);
+            data.consolidate_into(&mut target);
             duration += start.elapsed();
 
             consolidate_updates(&mut data2);

--- a/src/trace/implementations/chunker.rs
+++ b/src/trace/implementations/chunker.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 use timely::Container;
 use timely::container::columnation::{Columnation, TimelyStack};
 use timely::container::{ContainerBuilder, PushInto, SizableContainer};
-use crate::consolidation::{consolidate_updates, consolidate_container, ConsolidateLayout};
+use crate::consolidation::{consolidate_updates, ConsolidateLayout};
 use crate::difference::Semigroup;
 
 /// Chunk a stream of vectors into chains of vectors.
@@ -269,7 +269,7 @@ where
             self.pending.push(item);
             if self.pending.at_capacity() {
                 let starting_len = self.pending.len();
-                consolidate_container(&mut self.pending, &mut self.empty);
+                self.pending.consolidate_into(&mut self.empty);
                 std::mem::swap(&mut self.pending, &mut self.empty);
                 self.empty.clear();
                 if self.pending.len() > starting_len / 2 {
@@ -300,7 +300,7 @@ where
 
     fn finish(&mut self) -> Option<&mut Self::Container> {
         if !self.pending.is_empty() {
-            consolidate_container(&mut self.pending, &mut self.empty);
+            self.pending.consolidate_into(&mut self.empty);
             std::mem::swap(&mut self.pending, &mut self.empty);
             self.empty.clear();
             if !self.pending.is_empty() {


### PR DESCRIPTION
Some improvements around consolidation. 

First, the `consolidate_container` method was made into a trait method on `ConsolidateLayout`, which it required anyhow. This provides a default implementation, but allows other implementors to provide their own optimized implementation. For example, `Vec<(D, T, R)>` can simply consolidate in place and then `mem::swap`, which it does. This should make the chunkers based on `ConsolidateLayout` appropriate for `Vec`. I also renamed it `consolidate_into`, which made more sense once it took a `&mut self` argument.

Second, the implementation of `consolidate_into` was streamlined. It maintained an `Option` of the previous key and diff, but always sets this in the first iteration. We can simply take the first step and then maintain a non-optional previous key and diff. Minor, but should be simplifying.