### PR TITLE
Update to track timely changes

### DIFF
--- a/src/trace/implementations/merge_batcher.rs
+++ b/src/trace/implementations/merge_batcher.rs
@@ -3,7 +3,6 @@
 use std::collections::VecDeque;
 use std::marker::PhantomData;
 
-use timely::logging::WorkerIdentifier;
 use timely::logging_core::Logger;
 use timely::progress::frontier::AntichainRef;
 use timely::progress::{frontier::Antichain, Timestamp};
@@ -32,7 +31,7 @@ where
     /// Thing to accept data, merge chains, and talk to the builder.
     merger: M,
     /// Logger for size accounting.
-    logger: Option<Logger<DifferentialEvent, WorkerIdentifier>>,
+    logger: Option<Logger<DifferentialEvent>>,
     /// Timely operator ID.
     operator_id: usize,
     /// Current lower frontier, we sealed up to here.
@@ -52,7 +51,7 @@ where
     type Time = M::Time;
     type Output = M::Chunk;
 
-    fn new(logger: Option<Logger<DifferentialEvent, WorkerIdentifier>>, operator_id: usize) -> Self {
+    fn new(logger: Option<Logger<DifferentialEvent>>, operator_id: usize) -> Self {
         Self {
             logger,
             operator_id,

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -12,7 +12,6 @@ pub mod description;
 pub mod implementations;
 pub mod wrappers;
 
-use timely::logging::WorkerIdentifier;
 use timely::logging_core::Logger;
 use timely::progress::{Antichain, frontier::AntichainRef};
 use timely::progress::Timestamp;
@@ -310,7 +309,7 @@ pub trait Batcher {
     /// Times at which batches are formed.
     type Time: Timestamp;
     /// Allocates a new empty batcher.
-    fn new(logger: Option<Logger<DifferentialEvent, WorkerIdentifier>>, operator_id: usize) -> Self;
+    fn new(logger: Option<Logger<DifferentialEvent>>, operator_id: usize) -> Self;
     /// Adds an unordered container of elements to the batcher.
     fn push_container(&mut self, batch: &mut Self::Input);
     /// Returns all updates not greater or equal to an element of `upper`.


### PR DESCRIPTION
Timely changed some logging generics, in a way that was assessed as non-breaking, but was breaking. This is the fix-up, I think.