### PR TITLE
Variable supports container streams

### DIFF
--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -4,13 +4,15 @@
 //! operators have specialized implementations to make them work efficiently, and are in addition
 //! to several operations defined directly on the `Collection` type (e.g. `map` and `filter`).
 
+pub use self::negate::Negate;
 pub use self::reduce::{Reduce, Threshold, Count};
-pub use self::iterate::Iterate;
+pub use self::iterate::{Iterate, ResultsIn};
 pub use self::join::{Join, JoinCore};
 pub use self::count::CountTotal;
 pub use self::threshold::ThresholdTotal;
 
 pub mod arrange;
+pub mod negate;
 pub mod reduce;
 pub mod consolidate;
 pub mod iterate;

--- a/src/operators/negate.rs
+++ b/src/operators/negate.rs
@@ -1,0 +1,54 @@
+//! Negate the diffs of collections and streams.
+
+use timely::Data;
+use timely::dataflow::{Scope, Stream, StreamCore};
+use timely::dataflow::operators::Map;
+
+use crate::{AsCollection, Collection};
+use crate::difference::Abelian;
+
+/// Negate the contents of a stream.
+pub trait Negate<G, C> {
+    /// Creates a new collection whose counts are the negation of those in the input.
+    ///
+    /// This method is most commonly used with `concat` to get those element in one collection but not another.
+    /// However, differential dataflow computations are still defined for all values of the difference type `R`,
+    /// including negative counts.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use differential_dataflow::input::Input;
+    ///
+    /// ::timely::example(|scope| {
+    ///
+    ///     let data = scope.new_collection_from(1 .. 10).1;
+    ///
+    ///     let odds = data.filter(|x| x % 2 == 1);
+    ///     let evens = data.filter(|x| x % 2 == 0);
+    ///
+    ///     odds.negate()
+    ///         .concat(&data)
+    ///         .assert_eq(&evens);
+    /// });
+    /// ```
+    fn negate(&self) -> Self;
+}
+
+impl<G, D, R, C> Negate<G, C> for Collection<G, D, R, C>
+where
+    G: Scope,
+    C: Clone,
+    StreamCore<G, C>: Negate<G, C>,
+{
+    fn negate(&self) -> Self {
+        self.inner.negate().as_collection()
+    }
+}
+
+impl<G: Scope, D: Data, T: Data, R: Data + Abelian> Negate<G, Vec<(D, T, R)>> for Stream<G, (D, T, R)> {
+    fn negate(&self) -> Self {
+        self.map_in_place(|x| x.2.negate())
+    }
+}
+


### PR DESCRIPTION
Variable supports container streams. The PR achieves this by introducing two new extension traits:
* `ResultsIn` applies `PathSummary::results_in` to every record in the stream.
* `Negate` negates the diffs in a stream.

This is in support of allowing columnar data in Materialize recursive contexts.
