### PR TITLE
Update Timely, Columnar versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,8 @@ jobs:
         run: |
           export DIFFERENTIAL_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "differential-dataflow") | .version')
           export TIMELY_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "timely") | .version')
-          sed -i "s/^differential-dataflow = .*/differential = \"$DIFFERENTIAL_VERSION\"/" mdbook/src/chapter_0/chapter_0_0.md
-          sed -i "s/^timely = .*/timely = \"$TIMELY_VERSION\"/" mdbook/src/chapter_0/chapter_0_0.md
+          sed -i "s/^differential-dataflow = .*/differential = \"=$DIFFERENTIAL_VERSION\"/" mdbook/src/chapter_0/chapter_0_0.md
+          sed -i "s/^timely = .*/timely = \"=$TIMELY_VERSION\"/" mdbook/src/chapter_0/chapter_0_0.md
       - run: cd mdbook && mdbook build
       - uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/test-timely-master.yml
+++ b/.github/workflows/test-timely-master.yml
@@ -25,10 +25,13 @@ jobs:
           [patch.crates-io]
           timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
           EOF
+      - name: Cargo upgrade
+        run: |
+          cargo install cargo-edit
+          cargo upgrade -p timely --incompatible
       - name: Cargo check against Timely master
         run: cargo check --all-targets
       - name: Cargo test against Timely master
-        working-directory: timely_master
         run: cargo test
 
   notify:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,10 @@ bytemuck = "1.18.0"
 serde = { version = "1.0", features = ["derive"] }
 fnv="1.0.2"
 timely = {workspace = true}
-columnar = "0.2"
+columnar = "0.3"
 
 [workspace.dependencies]
-timely = { version = "0.17", default-features = false }
+timely = { version = "0.18", default-features = false }
 #timely = { path = "../timely-dataflow/timely/", default-features = false }
 
 [features]


### PR DESCRIPTION
Update our dependency on timely and columnar, and correct any breaking changes.

Adjusts our mdbook deploy action to encode fixed version dependencies using `=`. Makes the test against timely master more robust by patching the version to the latest version in the repo.
