### PR TITLE
Introduce EnterTime, fix Negate

### DIFF
--- a/differential-dataflow/src/operators/enter.rs
+++ b/differential-dataflow/src/operators/enter.rs
@@ -1,0 +1,54 @@
+//! Enter a collection into a scope.
+
+use timely::Data;
+use timely::dataflow::{Scope, ScopeParent, Stream, StreamCore};
+use timely::dataflow::operators::core::{Enter, Map};
+use timely::dataflow::scopes::Child;
+use timely::progress::timestamp::Refines;
+
+/// Extension trait for streams.
+pub trait EnterTime<C, G, TInner>
+where
+    G: ScopeParent,
+    TInner: Refines<G::Timestamp>,
+{
+    /// The containers in the output stream.
+    type Container: Clone;
+
+    /// Brings a stream into a nested scope.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use timely::dataflow::Scope;
+    /// use differential_dataflow::input::Input;
+    ///
+    /// ::timely::example(|scope| {
+    ///
+    ///     let data = scope.new_collection_from(1 .. 10).1;
+    ///
+    ///     let result = scope.region(|child| {
+    ///         data.enter(child)
+    ///             .leave()
+    ///     });
+    ///
+    ///     data.assert_eq(&result);
+    /// });
+    /// ```
+    fn enter_time<'a>(&self, child: &Child<'a, G, TInner>) -> StreamCore<Child<'a, G, TInner>, Self::Container>;
+}
+
+impl<G, D, R, TInner> EnterTime<Vec<(D, G::Timestamp, R)>, G, TInner> for Stream<G, (D, G::Timestamp, R)>
+where
+    G: Scope,
+    D: Data,
+    R: Data,
+    TInner: Refines<G::Timestamp>,
+{
+    type Container = Vec<(D, TInner, R)>;
+
+    fn enter_time<'a>(&self, child: &Child<'a, G, TInner>) -> Stream<Child<'a, G, TInner>, (D, TInner, R)> {
+        self.enter(child)
+            .map(|(data, time, diff)| (data, TInner::to_inner(time), diff))
+    }
+}

--- a/differential-dataflow/src/operators/iterate.rs
+++ b/differential-dataflow/src/operators/iterate.rs
@@ -169,7 +169,7 @@ where
 impl<G: Scope, D: Data, R: Abelian, C: Container + Clone + 'static> Variable<G, D, R, C>
 where
     G::Timestamp: Lattice,
-    StreamCore<G, C>: crate::operators::Negate<G, C> + ResultsIn<G, C>,
+    StreamCore<G, C>: crate::operators::Negate<C, G> + ResultsIn<G, C>,
 {
     /// Creates a new initially empty `Variable`.
     ///

--- a/differential-dataflow/src/operators/mod.rs
+++ b/differential-dataflow/src/operators/mod.rs
@@ -12,12 +12,13 @@ pub use self::count::CountTotal;
 pub use self::threshold::ThresholdTotal;
 
 pub mod arrange;
-pub mod negate;
-pub mod reduce;
 pub mod consolidate;
+pub mod count;
+pub mod enter;
 pub mod iterate;
 pub mod join;
-pub mod count;
+pub mod negate;
+pub mod reduce;
 pub mod threshold;
 
 use crate::lattice::Lattice;

--- a/differential-dataflow/src/operators/negate.rs
+++ b/differential-dataflow/src/operators/negate.rs
@@ -35,18 +35,18 @@ pub trait Negate<G, C> {
     fn negate(&self) -> Self;
 }
 
-impl<G, D, R, C> Negate<G, C> for Collection<G, D, R, C>
+impl<G, D, R, C> Negate<C, G> for Collection<G, D, R, C>
 where
     G: Scope,
     C: Clone,
-    StreamCore<G, C>: Negate<G, C>,
+    StreamCore<G, C>: Negate<C, G>,
 {
     fn negate(&self) -> Self {
         self.inner.negate().as_collection()
     }
 }
 
-impl<G: Scope, D: Data, T: Data, R: Data + Abelian> Negate<G, Vec<(D, T, R)>> for Stream<G, (D, T, R)> {
+impl<G: Scope, D: Data, T: Data, R: Data + Abelian> Negate<Vec<(D, T, R)>, G> for Stream<G, (D, T, R)> {
     fn negate(&self) -> Self {
         self.map_in_place(|x| x.2.negate())
     }


### PR DESCRIPTION
Introduces the EnterTime trait, which allows streams to explain to
differential how they can modify their timestamp component to match the
inner time.

Fixes the Negate trait so it can be implemented by downstream crates. Due
to Rust's rules, the local type has to come first, so the `G` parameter has
to come after the container type.

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>
