### PR TITLE
Update for TD with linear reachability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 
 [workspace.dependencies]
 differential-dataflow = { path = "differential-dataflow", default-features = false, version = "0.13.7" }
-timely = { version = "0.19", default-features = false }
+timely = { version = "0.20", default-features = false }
 #timely = { path = "../timely-dataflow/timely/", default-features = false }
 
 [profile.release]

--- a/differential-dataflow/src/dynamic/mod.rs
+++ b/differential-dataflow/src/dynamic/mod.rs
@@ -43,7 +43,7 @@ where
         // Create a unary operator that will strip all but `level-1` timestamp coordinates.
         let mut builder = OperatorBuilder::new("LeaveDynamic".to_string(), self.scope());
         let (mut output, stream) = builder.new_output();
-        let mut input = builder.new_input_connection(&self.inner, Pipeline, vec![Antichain::from_elem(Product { outer: Default::default(), inner: PointStampSummary { retain: Some(level - 1), actions: Vec::new() } })]);
+        let mut input = builder.new_input_connection(&self.inner, Pipeline, [(0, Antichain::from_elem(Product { outer: Default::default(), inner: PointStampSummary { retain: Some(level - 1), actions: Vec::new() } }))]);
 
         builder.build(move |_capability| move |_frontier| {
             let mut output = output.activate();


### PR DESCRIPTION
Timely's "linear reachability" changes alter how custom operators are constructed, accepting lists of pairs of port identifiers and path summaries, rather than a dense list of path summaries. Small change to match.