### PR TITLE
Modernize `Cursor` API

### DIFF
--- a/differential-dataflow/src/operators/join.rs
+++ b/differential-dataflow/src/operators/join.rs
@@ -679,8 +679,7 @@ where
 
                     // populate `temp` with the results in the best way we know how.
                     thinker.think(|v1,v2,t,r1,r2| {
-                        let key = batch_key;
-                        logic(key, v1, v2, &t, r1, r2, &mut session);
+                        logic(batch_key, v1, v2, &t, r1, r2, &mut session);
                     });
 
                     // TODO: Effort isn't perfectly tracked as we might still have some data in the

--- a/differential-dataflow/src/operators/join.rs
+++ b/differential-dataflow/src/operators/join.rs
@@ -661,11 +661,11 @@ where
 
         let mut thinker = JoinThinker::new();
 
-        while batch.key_valid(batch_storage) && trace.key_valid(trace_storage) && effort < *fuel {
+        while let (Some(batch_key), Some(trace_key), true) = (batch.get_key(batch_storage), trace.get_key(trace_storage), effort < *fuel) {
 
-            match trace.key(trace_storage).cmp(&batch.key(batch_storage)) {
-                Ordering::Less => trace.seek_key(trace_storage, batch.key(batch_storage)),
-                Ordering::Greater => batch.seek_key(batch_storage, trace.key(trace_storage)),
+            match trace_key.cmp(&batch_key) {
+                Ordering::Less => trace.seek_key(trace_storage, batch_key),
+                Ordering::Greater => batch.seek_key(batch_storage, trace_key),
                 Ordering::Equal => {
 
                     use crate::IntoOwned;
@@ -679,7 +679,7 @@ where
 
                     // populate `temp` with the results in the best way we know how.
                     thinker.think(|v1,v2,t,r1,r2| {
-                        let key = batch.key(batch_storage);
+                        let key = batch_key;
                         logic(key, v1, v2, &t, r1, r2, &mut session);
                     });
 

--- a/differential-dataflow/src/operators/mod.rs
+++ b/differential-dataflow/src/operators/mod.rs
@@ -45,9 +45,9 @@ impl<'a, C: Cursor> EditList<'a, C> {
         L: Fn(C::TimeGat<'_>)->C::Time,
     {
         self.clear();
-        while cursor.val_valid(storage) {
+        while let Some(val) = cursor.get_val(storage) {
             cursor.map_times(storage, |time1, diff1| self.push(logic(time1), diff1.into_owned()));
-            self.seal(cursor.val(storage));
+            self.seal(val);
             cursor.step_val(storage);
         }
     }

--- a/differential-dataflow/src/trace/cursor/cursor_list.rs
+++ b/differential-dataflow/src/trace/cursor/cursor_list.rs
@@ -115,6 +115,15 @@ impl<C: Cursor> Cursor for CursorList<C> {
         self.cursors[self.min_val[0]].val(&storage[self.min_val[0]])
     }
     #[inline]
+    fn get_key<'a>(&self, storage: &'a Vec<C::Storage>) -> Option<Self::Key<'a>> {
+        self.min_key.get(0).map(|idx| self.cursors[*idx].key(&storage[*idx]))
+    }
+    #[inline]
+    fn get_val<'a>(&self, storage: &'a Vec<C::Storage>) -> Option<Self::Val<'a>> {
+        self.min_val.get(0).map(|idx| self.cursors[*idx].val(&storage[*idx]))
+    }
+
+    #[inline]
     fn map_times<L: FnMut(Self::TimeGat<'_>, Self::DiffGat<'_>)>(&mut self, storage: &Vec<C::Storage>, mut logic: L) {
         for &index in self.min_val.iter() {
             self.cursors[index].map_times(&storage[index], |t,d| logic(t,d));

--- a/differential-dataflow/src/trace/cursor/mod.rs
+++ b/differential-dataflow/src/trace/cursor/mod.rs
@@ -50,13 +50,9 @@ pub trait Cursor {
     fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a>;
 
     /// Returns a reference to the current key, if valid.
-    fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> {
-        if self.key_valid(storage) { Some(self.key(storage)) } else { None }
-    }
+    fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>>;
     /// Returns a reference to the current value, if valid.
-    fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> {
-        if self.val_valid(storage) { Some(self.val(storage)) } else { None }
-    }
+    fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>>;
 
     /// Applies `logic` to each pair of time and difference. Intended for mutation of the
     /// closure's scope.

--- a/differential-dataflow/src/trace/cursor/mod.rs
+++ b/differential-dataflow/src/trace/cursor/mod.rs
@@ -81,14 +81,14 @@ pub trait Cursor {
     {
         let mut out = Vec::new();
         self.rewind_keys(storage);
-        while self.key_valid(storage) {
+        while let Some(key) = self.get_key(storage) {
             self.rewind_vals(storage);
-            while self.val_valid(storage) {
+            while let Some(val) = self.get_val(storage) {
                 let mut kv_out = Vec::new();
                 self.map_times(storage, |ts, r| {
                     kv_out.push((ts.into_owned(), r.into_owned()));
                 });
-                out.push(((self.key(storage).into_owned(), self.val(storage).into_owned()), kv_out));
+                out.push(((key.into_owned(), val.into_owned()), kv_out));
                 self.step_val(storage);
             }
             self.step_key(storage);

--- a/differential-dataflow/src/trace/implementations/mod.rs
+++ b/differential-dataflow/src/trace/implementations/mod.rs
@@ -483,6 +483,15 @@ pub mod containers {
 
         /// Reference to the element at this position.
         fn index(&self, index: usize) -> Self::ReadItem<'_>;
+
+        /// Reference to the element at this position, if it exists.
+        fn get(&self, index: usize) -> Option<Self::ReadItem<'_>> {
+            if index < self.len() {
+                Some(self.index(index))
+            }
+            else { None }
+        }
+
         /// Number of contained elements
         fn len(&self) -> usize;
         /// Returns the last item if the container is non-empty.

--- a/differential-dataflow/src/trace/implementations/mod.rs
+++ b/differential-dataflow/src/trace/implementations/mod.rs
@@ -568,6 +568,9 @@ pub mod containers {
         fn index(&self, index: usize) -> Self::ReadItem<'_> {
             &self[index]
         }
+        fn get(&self, index: usize) -> Option<Self::ReadItem<'_>> {
+            <[T]>::get(&self, index)
+        }
         fn len(&self) -> usize {
             self[..].len()
         }

--- a/differential-dataflow/src/trace/implementations/ord_neu.rs
+++ b/differential-dataflow/src/trace/implementations/ord_neu.rs
@@ -493,6 +493,9 @@ mod val_batch {
 
         type Storage = OrdValBatch<L>;
 
+        fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { storage.storage.keys.get(self.key_cursor) }
+        fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> { if self.val_valid(storage) { Some(self.val(storage)) } else { None } }
+
         fn key<'a>(&self, storage: &'a OrdValBatch<L>) -> Self::Key<'a> { storage.storage.keys.index(self.key_cursor) }
         fn val<'a>(&self, storage: &'a OrdValBatch<L>) -> Self::Val<'a> { storage.storage.vals.index(self.val_cursor) }
         fn map_times<L2: FnMut(Self::TimeGat<'_>, Self::DiffGat<'_>)>(&mut self, storage: &OrdValBatch<L>, mut logic: L2) {
@@ -996,6 +999,9 @@ mod key_batch {
         type DiffGat<'a> = <L::DiffContainer as BatchContainer>::ReadItem<'a>;
 
         type Storage = OrdKeyBatch<L>;
+
+        fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { storage.storage.keys.get(self.key_cursor) }
+        fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<&'a ()> { if self.val_valid(storage) { Some(&()) } else { None } }
 
         fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { storage.storage.keys.index(self.key_cursor) }
         fn val<'a>(&self, _storage: &'a Self::Storage) -> &'a () { &() }

--- a/differential-dataflow/src/trace/implementations/rhh.rs
+++ b/differential-dataflow/src/trace/implementations/rhh.rs
@@ -666,9 +666,9 @@ mod val_batch {
 
         type Storage = RhhValBatch<L>;
 
-        fn key<'a>(&self, storage: &'a RhhValBatch<L>) -> Self::Key<'a> { 
-            storage.storage.keys.index(self.key_cursor) 
-        }
+        fn get_key<'a>(&self, storage: &'a RhhValBatch<L>) -> Option<Self::Key<'a>> { storage.storage.keys.get(self.key_cursor) }
+        fn get_val<'a>(&self, storage: &'a RhhValBatch<L>) -> Option<Self::Val<'a>> { if self.val_valid(storage) { storage.storage.vals.get(self.val_cursor) } else { None } }
+        fn key<'a>(&self, storage: &'a RhhValBatch<L>) -> Self::Key<'a> { storage.storage.keys.index(self.key_cursor) }
         fn val<'a>(&self, storage: &'a RhhValBatch<L>) -> Self::Val<'a> { storage.storage.vals.index(self.val_cursor) }
         fn map_times<L2: FnMut(Self::TimeGat<'_>, Self::DiffGat<'_>)>(&mut self, storage: &RhhValBatch<L>, mut logic: L2) {
             let (lower, upper) = storage.storage.updates_for_value(self.val_cursor);

--- a/differential-dataflow/src/trace/mod.rs
+++ b/differential-dataflow/src/trace/mod.rs
@@ -403,6 +403,9 @@ pub mod rc_blanket_impls {
         #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(storage) }
         #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
+        #[inline] fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { self.cursor.get_key(storage) }
+        #[inline] fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> { self.cursor.get_val(storage) }
+
         #[inline]
         fn map_times<L: FnMut(Self::TimeGat<'_>, Self::DiffGat<'_>)>(&mut self, storage: &Self::Storage, logic: L) {
             self.cursor.map_times(storage, logic)

--- a/differential-dataflow/src/trace/wrappers/enter.rs
+++ b/differential-dataflow/src/trace/wrappers/enter.rs
@@ -184,6 +184,9 @@ where
     #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(storage) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
+    #[inline] fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { self.cursor.get_key(storage) }
+    #[inline] fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> { self.cursor.get_val(storage) }
+
     #[inline]
     fn map_times<L: FnMut(&TInner, Self::DiffGat<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
         use crate::IntoOwned;
@@ -237,6 +240,9 @@ where
 
     #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(&storage.batch) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
+
+    #[inline] fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { self.cursor.get_key(&storage.batch) }
+    #[inline] fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> { self.cursor.get_val(&storage.batch) }
 
     #[inline]
     fn map_times<L: FnMut(&TInner, Self::DiffGat<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {

--- a/differential-dataflow/src/trace/wrappers/enter_at.rs
+++ b/differential-dataflow/src/trace/wrappers/enter_at.rs
@@ -211,6 +211,9 @@ where
     #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(storage) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
+    #[inline] fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { self.cursor.get_key(storage) }
+    #[inline] fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> { self.cursor.get_val(storage) }
+
     #[inline]
     fn map_times<L: FnMut(&TInner, Self::DiffGat<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let key = self.key(storage);
@@ -269,6 +272,9 @@ where
 
     #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(&storage.batch) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
+
+    #[inline] fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { self.cursor.get_key(&storage.batch) }
+    #[inline] fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> { self.cursor.get_val(&storage.batch) }
 
     #[inline]
     fn map_times<L: FnMut(&TInner, Self::DiffGat<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {

--- a/differential-dataflow/src/trace/wrappers/filter.rs
+++ b/differential-dataflow/src/trace/wrappers/filter.rs
@@ -148,6 +148,9 @@ where
     #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(storage) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
+    #[inline] fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { self.cursor.get_key(storage) }
+    #[inline] fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> { self.cursor.get_val(storage) }
+
     #[inline]
     fn map_times<L: FnMut(Self::TimeGat<'_>, Self::DiffGat<'_>)>(&mut self, storage: &Self::Storage, logic: L) {
         let key = self.key(storage);
@@ -202,6 +205,9 @@ where
 
     #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(&storage.batch) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
+
+    #[inline] fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> { self.cursor.get_val(&storage.batch) }
+    #[inline] fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { self.cursor.get_key(&storage.batch) }
 
     #[inline]
     fn map_times<L: FnMut(Self::TimeGat<'_>, Self::DiffGat<'_>)>(&mut self, storage: &Self::Storage, logic: L) {

--- a/differential-dataflow/src/trace/wrappers/freeze.rs
+++ b/differential-dataflow/src/trace/wrappers/freeze.rs
@@ -199,6 +199,9 @@ where
     #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(storage) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
+    #[inline] fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { self.cursor.get_key(storage) }
+    #[inline] fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> { self.cursor.get_val(storage) }
+
     #[inline] fn map_times<L: FnMut(Self::TimeGat<'_>, Self::DiffGat<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let func = &self.func;
         self.cursor.map_times(storage, |time, diff| {
@@ -250,6 +253,9 @@ where
 
     #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(&storage.batch) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
+
+    #[inline] fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { self.cursor.get_key(&storage.batch) }
+    #[inline] fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> { self.cursor.get_val(&storage.batch) }
 
     #[inline] fn map_times<L: FnMut(Self::TimeGat<'_>, Self::DiffGat<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let func = &self.func;

--- a/differential-dataflow/src/trace/wrappers/frontier.rs
+++ b/differential-dataflow/src/trace/wrappers/frontier.rs
@@ -143,6 +143,9 @@ impl<C: Cursor> Cursor for CursorFrontier<C, C::Time> {
     #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(storage) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(storage) }
 
+    #[inline] fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { self.cursor.get_key(storage) }
+    #[inline] fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> { self.cursor.get_val(storage) }
+
     #[inline]
     fn map_times<L: FnMut(Self::TimeGat<'_>, Self::DiffGat<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
         let since = self.since.borrow();
@@ -205,6 +208,9 @@ where
 
     #[inline] fn key<'a>(&self, storage: &'a Self::Storage) -> Self::Key<'a> { self.cursor.key(&storage.batch) }
     #[inline] fn val<'a>(&self, storage: &'a Self::Storage) -> Self::Val<'a> { self.cursor.val(&storage.batch) }
+
+    #[inline] fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { self.cursor.get_key(&storage.batch) }
+    #[inline] fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Val<'a>> { self.cursor.get_val(&storage.batch) }
 
     #[inline]
     fn map_times<L: FnMut(Self::TimeGat<'_>, Self::DiffGat<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {


### PR DESCRIPTION
The `Cursor` API has historically relied on functions `foo_valid` and `foo`, so that one could independently validate a thing and without validation access it. In practice this results in two expensive calls, rather than one `get_foo` call that returns an option. Mostly, we see this when there are more complex containers that need to track down the destination of a reference, as opposed to a simple slice access.

The PR encourages more use of `get_foo` by removing their default implementations, adds `BatchContainer::get`, and .. somewhat unrelatedly updates the `CursorList` internals, following and extended #595.

Potentially we should add in default implementations of `foo` and `foo_valid`, but no need to do so at the moment, and seemingly all of our cursor implementations would like the manual implementation of these as well (there are moments where it helps to call them directly, and so it's hard to deprecate them completely).