### PR TITLE
Remove use of `borrow_as` from trace wrappers

### DIFF
--- a/differential-dataflow/src/trace/wrappers/freeze.rs
+++ b/differential-dataflow/src/trace/wrappers/freeze.rs
@@ -26,7 +26,6 @@ use timely::progress::frontier::AntichainRef;
 use crate::operators::arrange::Arranged;
 use crate::trace::{TraceReader, BatchReader, Description};
 use crate::trace::cursor::Cursor;
-use crate::IntoOwned;
 
 /// Freezes updates to an arrangement using a supplied function.
 ///
@@ -79,7 +78,7 @@ where
     type Key<'a> = Tr::Key<'a>;
     type Val<'a> = Tr::Val<'a>;
     type Time = Tr::Time;
-    type TimeGat<'a> = Tr::TimeGat<'a>;
+    type TimeGat<'a> = &'a Tr::Time;
     type Diff = Tr::Diff;
     type DiffGat<'a> = Tr::DiffGat<'a>;
 
@@ -143,7 +142,7 @@ where
     type Key<'a> = B::Key<'a>;
     type Val<'a> = B::Val<'a>;
     type Time = B::Time;
-    type TimeGat<'a> = B::TimeGat<'a>;
+    type TimeGat<'a> = &'a B::Time;
     type Diff = B::Diff;
     type DiffGat<'a> = B::DiffGat<'a>;
 
@@ -187,7 +186,7 @@ where
     type Key<'a> = C::Key<'a>;
     type Val<'a> = C::Val<'a>;
     type Time = C::Time;
-    type TimeGat<'a> = C::TimeGat<'a>;
+    type TimeGat<'a> = &'a C::Time;
     type Diff = C::Diff;
     type DiffGat<'a> = C::DiffGat<'a>;
 
@@ -206,7 +205,7 @@ where
         let func = &self.func;
         self.cursor.map_times(storage, |time, diff| {
             if let Some(time) = func(time) {
-                logic(<Self::TimeGat<'_> as IntoOwned>::borrow_as(&time), diff);
+                logic(&time, diff);
             }
         })
     }
@@ -242,7 +241,7 @@ where
     type Key<'a> = C::Key<'a>;
     type Val<'a> = C::Val<'a>;
     type Time = C::Time;
-    type TimeGat<'a> = C::TimeGat<'a>;
+    type TimeGat<'a> = &'a C::Time;
     type Diff = C::Diff;
     type DiffGat<'a> = C::DiffGat<'a>;
 
@@ -261,7 +260,7 @@ where
         let func = &self.func;
         self.cursor.map_times(&storage.batch, |time, diff| {
             if let Some(time) = func(time) {
-                logic(<Self::TimeGat<'_> as IntoOwned>::borrow_as(&time), diff);
+                logic(&time, diff);
             }
         })
     }

--- a/differential-dataflow/src/trace/wrappers/frontier.rs
+++ b/differential-dataflow/src/trace/wrappers/frontier.rs
@@ -35,7 +35,7 @@ impl<Tr: TraceReader> TraceReader for TraceFrontier<Tr> {
     type Key<'a> = Tr::Key<'a>;
     type Val<'a> = Tr::Val<'a>;
     type Time = Tr::Time;
-    type TimeGat<'a> = Tr::TimeGat<'a>;
+    type TimeGat<'a> = &'a Tr::Time;
     type Diff = Tr::Diff;
     type DiffGat<'a> = Tr::DiffGat<'a>;
 
@@ -86,7 +86,7 @@ impl<B: BatchReader> BatchReader for BatchFrontier<B> {
     type Key<'a> = B::Key<'a>;
     type Val<'a> = B::Val<'a>;
     type Time = B::Time;
-    type TimeGat<'a> = B::TimeGat<'a>;
+    type TimeGat<'a> = &'a B::Time;
     type Diff = B::Diff;
     type DiffGat<'a> = B::DiffGat<'a>;
 
@@ -131,7 +131,7 @@ impl<C: Cursor> Cursor for CursorFrontier<C, C::Time> {
     type Key<'a> = C::Key<'a>;
     type Val<'a> = C::Val<'a>;
     type Time = C::Time;
-    type TimeGat<'a> = C::TimeGat<'a>;
+    type TimeGat<'a> = &'a C::Time;
     type Diff = C::Diff;
     type DiffGat<'a> = C::DiffGat<'a>;
 
@@ -156,7 +156,7 @@ impl<C: Cursor> Cursor for CursorFrontier<C, C::Time> {
             time.clone_onto(&mut temp);
             temp.advance_by(since);
             if !until.less_equal(&temp) {
-                logic(<Self::TimeGat<'_> as IntoOwned>::borrow_as(&temp), diff);
+                logic(&temp, diff);
             }
         })
     }
@@ -197,7 +197,7 @@ where
     type Key<'a> = C::Key<'a>;
     type Val<'a> = C::Val<'a>;
     type Time = C::Time;
-    type TimeGat<'a> = C::TimeGat<'a>;
+    type TimeGat<'a> = &'a C::Time;
     type Diff = C::Diff;
     type DiffGat<'a> = C::DiffGat<'a>;
 
@@ -222,7 +222,7 @@ where
             time.clone_onto(&mut temp);
             temp.advance_by(since);
             if !until.less_equal(&temp) {
-                logic(<Self::TimeGat<'_> as IntoOwned>::borrow_as(&temp), diff);
+                logic(&temp, diff);
             }
         })
     }


### PR DESCRIPTION
Two trace wrappers relied on `IntoOwned::borrow_as` to convert from `&Time` to `TimeGat<'_>`, in order to support closures against their advertised time reference type. This PR changes the advertisement to be `&Time` instead, and the callers can rely on `borrow_as` themselves if they have a problem with that.

I think the `freeze.rs` changes likely have zero impact (and perhaps the file should be deprecated). The `frontier.rs` changes likely affect Materialize, which uses it, but it could/should be a pretty easy fix, if the types aren't already aligned (I half guess that they are already `&Time` as the GAT type).