### PR TITLE
Extract inner function from half-join

### DIFF
--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -104,7 +104,9 @@ where
         .as_collection()
 }
 
-/// Utility type for a session in scope `G` with a container builder `CB`.
+/// A session with lifetime `'a` in a scope `G` with a container builder `CB`.
+///
+/// This is a shorthand primarily for the reson of readability.
 type SessionFor<'a, G, CB> =
     Session<'a,
         <G as ScopeParent>::Timestamp,
@@ -291,14 +293,15 @@ where
     })
 }
 
-/// Process proposals one at a time, yielding if necessary.
+/// Outlined inner loop for `half_join_internal_unsafe` for reasons of performance.
+///
+/// Gives Rust/LLVM the opportunity to inline the loop body instead of inlining the loop and
+/// leaving all calls in the loop body outlined.
 ///
 /// Consumes proposals until the yield function returns `true` or all proposals are processed.
 /// Leaves a zero diff in place for all proposals that were processed.
 ///
 /// Returns `true` if the operator should yield.
-///
-/// Utility function for `half_join_internal_unsafe`.
 fn process_proposals<G, Tr, CF, Y, S, CB, K, V, R>(
     comparison: &CF,
     yield_function: &Y,

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -36,21 +36,21 @@ use std::ops::Mul;
 use std::time::Instant;
 
 use timely::container::{CapacityContainerBuilder, ContainerBuilder};
+use timely::dataflow::{Scope, ScopeParent, StreamCore};
 use timely::dataflow::channels::pact::{Pipeline, Exchange};
 use timely::dataflow::channels::pushers::buffer::Session;
 use timely::dataflow::channels::pushers::{Counter as PushCounter, Tee};
 use timely::dataflow::operators::Operator;
-use timely::dataflow::{Scope, ScopeParent, StreamCore};
 use timely::progress::Antichain;
 use timely::progress::frontier::AntichainRef;
 
-use differential_dataflow::consolidation::{consolidate, consolidate_updates};
+use differential_dataflow::{ExchangeData, Collection, AsCollection, Hashable};
 use differential_dataflow::difference::{Monoid, Semigroup};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
-use differential_dataflow::trace::cursor::IntoOwned;
 use differential_dataflow::trace::{Cursor, TraceReader};
-use differential_dataflow::{ExchangeData, Collection, AsCollection, Hashable};
+use differential_dataflow::consolidation::{consolidate, consolidate_updates};
+use differential_dataflow::trace::cursor::IntoOwned;
 
 /// A binary equijoin that responds to updates on only its first input.
 ///


### PR DESCRIPTION
Extract the inner loop of half-join into a separate function.

This change extracts the inner loop across `proposals` in half-join into a separate function. The idea is that the inner loop is hot, but by embedding it in the closure, the optimizer has a hard time inlining functions called from within the loop on account of the size of the closure itself. Help the optimizer by extracting the hot loop in the hope that this enables better inlining.

Also some changes around the return type of the `half_join_internal_unsafe` function. Instead of forcing a stream of vectors, allow the caller to provide a container builder, and return a stream instead. (We could return a collection, but the caller can do that themselves easily enough.)
