### PR TITLE
Remove `IntoOwned`

### DIFF
--- a/differential-dataflow/examples/columnar.rs
+++ b/differential-dataflow/examples/columnar.rs
@@ -585,7 +585,7 @@ pub mod dd_builder {
     use differential_dataflow::trace::Builder;
     use differential_dataflow::trace::Description;
     use differential_dataflow::trace::implementations::Layout;
-    use differential_dataflow::trace::implementations::Update;
+    use differential_dataflow::trace::implementations::layout;
     use differential_dataflow::trace::implementations::BatchContainer;
     use differential_dataflow::trace::implementations::ord_neu::{OrdValBatch, val_batch::OrdValStorage, OrdKeyBatch, Vals, Upds, layers::UpdsBuilder};
     use differential_dataflow::trace::implementations::ord_neu::key_batch::OrdKeyStorage;
@@ -618,11 +618,11 @@ pub mod dd_builder {
         // These two constraints seem .. like we could potentially replace by `Columnar::Ref<'a>`.
         for<'a> L::KeyContainer: PushInto<&'a <L::KeyContainer as BatchContainer>::Owned>,
         for<'a> L::ValContainer: PushInto<&'a <L::ValContainer as BatchContainer>::Owned>,
-        for<'a> <L::TimeContainer as BatchContainer>::ReadItem<'a> : IntoOwned<'a, Owned = <L::Target as Update>::Time>,
-        for<'a> <L::DiffContainer as BatchContainer>::ReadItem<'a> : IntoOwned<'a, Owned = <L::Target as Update>::Diff>,
+        for<'a> <L::TimeContainer as BatchContainer>::ReadItem<'a> : IntoOwned<'a, Owned = layout::Time<L>>,
+        for<'a> <L::DiffContainer as BatchContainer>::ReadItem<'a> : IntoOwned<'a, Owned = layout::Diff<L>>,
     {
         type Input = Column<((<L::KeyContainer as BatchContainer>::Owned,<L::ValContainer as BatchContainer>::Owned),<L::TimeContainer as BatchContainer>::Owned,<L::DiffContainer as BatchContainer>::Owned)>;
-        type Time = <L::Target as Update>::Time;
+        type Time = layout::Time<L>;
         type Output = OrdValBatch<L>;
 
         fn with_capacity(keys: usize, vals: usize, upds: usize) -> Self {
@@ -725,11 +725,11 @@ pub mod dd_builder {
     // These two constraints seem .. like we could potentially replace by `Columnar::Ref<'a>`.
         for<'a> L::KeyContainer: PushInto<&'a <L::KeyContainer as BatchContainer>::Owned>,
         for<'a> L::ValContainer: PushInto<&'a <L::ValContainer as BatchContainer>::Owned>,
-        for<'a> <L::TimeContainer as BatchContainer>::ReadItem<'a> : IntoOwned<'a, Owned = <L::Target as Update>::Time>,
-        for<'a> <L::DiffContainer as BatchContainer>::ReadItem<'a> : IntoOwned<'a, Owned = <L::Target as Update>::Diff>,
+        for<'a> <L::TimeContainer as BatchContainer>::ReadItem<'a> : IntoOwned<'a, Owned = layout::Time<L>>,
+        for<'a> <L::DiffContainer as BatchContainer>::ReadItem<'a> : IntoOwned<'a, Owned = layout::Diff<L>>,
     {
         type Input = Column<((<L::KeyContainer as BatchContainer>::Owned,<L::ValContainer as BatchContainer>::Owned),<L::TimeContainer as BatchContainer>::Owned,<L::DiffContainer as BatchContainer>::Owned)>;
-        type Time = <L::Target as Update>::Time;
+        type Time = layout::Time<L>;
         type Output = OrdKeyBatch<L>;
 
         fn with_capacity(keys: usize, _vals: usize, upds: usize) -> Self {

--- a/differential-dataflow/examples/columnar.rs
+++ b/differential-dataflow/examples/columnar.rs
@@ -618,8 +618,6 @@ pub mod dd_builder {
         // These two constraints seem .. like we could potentially replace by `Columnar::Ref<'a>`.
         for<'a> L::KeyContainer: PushInto<&'a <L::KeyContainer as BatchContainer>::Owned>,
         for<'a> L::ValContainer: PushInto<&'a <L::ValContainer as BatchContainer>::Owned>,
-        for<'a> <L::TimeContainer as BatchContainer>::ReadItem<'a> : IntoOwned<'a, Owned = layout::Time<L>>,
-        for<'a> <L::DiffContainer as BatchContainer>::ReadItem<'a> : IntoOwned<'a, Owned = layout::Diff<L>>,
     {
         type Input = Column<((<L::KeyContainer as BatchContainer>::Owned,<L::ValContainer as BatchContainer>::Owned),<L::TimeContainer as BatchContainer>::Owned,<L::DiffContainer as BatchContainer>::Owned)>;
         type Time = layout::Time<L>;
@@ -725,8 +723,6 @@ pub mod dd_builder {
     // These two constraints seem .. like we could potentially replace by `Columnar::Ref<'a>`.
         for<'a> L::KeyContainer: PushInto<&'a <L::KeyContainer as BatchContainer>::Owned>,
         for<'a> L::ValContainer: PushInto<&'a <L::ValContainer as BatchContainer>::Owned>,
-        for<'a> <L::TimeContainer as BatchContainer>::ReadItem<'a> : IntoOwned<'a, Owned = layout::Time<L>>,
-        for<'a> <L::DiffContainer as BatchContainer>::ReadItem<'a> : IntoOwned<'a, Owned = layout::Diff<L>>,
     {
         type Input = Column<((<L::KeyContainer as BatchContainer>::Owned,<L::ValContainer as BatchContainer>::Owned),<L::TimeContainer as BatchContainer>::Owned,<L::DiffContainer as BatchContainer>::Owned)>;
         type Time = layout::Time<L>;

--- a/differential-dataflow/examples/spines.rs
+++ b/differential-dataflow/examples/spines.rs
@@ -48,22 +48,6 @@ fn main() {
                     keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
                         .probe_with(&mut probe);
                 },
-                "slc" => {
-
-                    use differential_dataflow::trace::implementations::ord_neu::{PreferredBatcher, PreferredBuilder, PreferredSpine};
-
-                    let data =
-                    data.map(|x| (x.clone().into_bytes(), x.into_bytes()))
-                        .arrange::<PreferredBatcher<[u8],[u8],_,_>, PreferredBuilder<[u8],[u8],_,_>, PreferredSpine<[u8],[u8],_,_>>()
-                        .reduce_abelian::<_, _, _, PreferredBuilder<[u8],(),_,_>, PreferredSpine<[u8],(),_,_>>("distinct", |_,_,output| output.push(((), 1)));
-                    let keys =
-                    keys.map(|x| (x.clone().into_bytes(), 7))
-                        .arrange::<PreferredBatcher<[u8],u8,_,_>, PreferredBuilder<[u8],u8,_,_>, PreferredSpine<[u8],u8,_,_>>()
-                        .reduce_abelian::<_, _, _, PreferredBuilder<[u8],(),_,_>,PreferredSpine<[u8],(),_,_>>("distinct", |_,_,output| output.push(((), 1)));
-
-                    keys.join_core(&data, |_k, &(), &()| Option::<()>::None)
-                        .probe_with(&mut probe);
-                },
                 _ => {
                     println!("unrecognized mode: {:?}", mode)
                 }

--- a/differential-dataflow/src/operators/arrange/arrangement.rs
+++ b/differential-dataflow/src/operators/arrange/arrangement.rs
@@ -215,7 +215,7 @@ where
                         while let Some(val) = cursor.get_val(batch) {
                             for datum in logic(key, val) {
                                 cursor.map_times(batch, |time, diff| {
-                                    session.give((datum.clone(), time.into_owned(), diff.into_owned()));
+                                    session.give((datum.clone(), Tr::owned_time(time), Tr::owned_diff(diff)));
                                 });
                             }
                             cursor.step_val(batch);

--- a/differential-dataflow/src/operators/arrange/upsert.rs
+++ b/differential-dataflow/src/operators/arrange/upsert.rs
@@ -244,7 +244,7 @@ where
                                         // Determine the prior value associated with the key.
                                         while let Some(val) = trace_cursor.get_val(&trace_storage) {
                                             let mut count = 0;
-                                            trace_cursor.map_times(&trace_storage, |_time, diff| count += diff.into_owned());
+                                            trace_cursor.map_times(&trace_storage, |_time, diff| count += Tr::owned_diff(diff));
                                             assert!(count == 0 || count == 1);
                                             if count == 1 {
                                                 assert!(prev_value.is_none());

--- a/differential-dataflow/src/operators/count.rs
+++ b/differential-dataflow/src/operators/count.rs
@@ -109,7 +109,7 @@ where
                         if trace_cursor.get_key(&trace_storage) == Some(key) {
                             trace_cursor.map_times(&trace_storage, |_, diff| {
                                 count.as_mut().map(|c| c.plus_equals(&diff));
-                                if count.is_none() { count = Some(diff.into_owned()); }
+                                if count.is_none() { count = Some(T1::owned_diff(diff)); }
                             });
                         }
 
@@ -117,14 +117,14 @@ where
 
                             if let Some(count) = count.as_ref() {
                                 if !count.is_zero() {
-                                    session.give(((key.into_owned(), count.clone()), time.into_owned(), R2::from(-1i8)));
+                                    session.give(((key.into_owned(), count.clone()), T1::owned_time(time), R2::from(-1i8)));
                                 }
                             }
                             count.as_mut().map(|c| c.plus_equals(&diff));
-                            if count.is_none() { count = Some(diff.into_owned()); }
+                            if count.is_none() { count = Some(T1::owned_diff(diff)); }
                             if let Some(count) = count.as_ref() {
                                 if !count.is_zero() {
-                                    session.give(((key.into_owned(), count.clone()), time.into_owned(), R2::from(1i8)));
+                                    session.give(((key.into_owned(), count.clone()), T1::owned_time(time), R2::from(1i8)));
                                 }
                             }
                         });

--- a/differential-dataflow/src/operators/join.rs
+++ b/differential-dataflow/src/operators/join.rs
@@ -171,7 +171,7 @@ where
     V: Data + 'static,
 {
     fn join_map<V2: ExchangeData, R2: ExchangeData+Semigroup, D: Data, L>(&self, other: &Collection<G, (K, V2), R2>, mut logic: L) -> Collection<G, D, <Tr::Diff as Multiply<R2>>::Output>
-    where 
+    where
         Tr::Diff: Multiply<R2, Output: Semigroup+'static>,
         L: for<'a> FnMut(Tr::Key<'a>, Tr::Val<'a>, &V2)->D+'static,
     {
@@ -660,14 +660,12 @@ where
                 Ordering::Greater => batch.seek_key(batch_storage, trace_key),
                 Ordering::Equal => {
 
-                    use crate::IntoOwned;
-                    
                     thinker.history1.edits.load(trace, trace_storage, |time| {
-                        let mut time = time.into_owned();
+                        let mut time = C1::owned_time(time);
                         time.join_assign(meet);
                         time
                     });
-                    thinker.history2.edits.load(batch, batch_storage, |time| time.into_owned());
+                    thinker.history2.edits.load(batch, batch_storage, |time| C2::owned_time(time));
 
                     // populate `temp` with the results in the best way we know how.
                     thinker.think(|v1,v2,t,r1,r2| {

--- a/differential-dataflow/src/operators/mod.rs
+++ b/differential-dataflow/src/operators/mod.rs
@@ -22,7 +22,6 @@ pub mod threshold;
 
 use crate::lattice::Lattice;
 use crate::trace::Cursor;
-use crate::IntoOwned;
 
 /// An accumulation of (value, time, diff) updates.
 struct EditList<'a, C: Cursor> {
@@ -46,7 +45,7 @@ impl<'a, C: Cursor> EditList<'a, C> {
     {
         self.clear();
         while let Some(val) = cursor.get_val(storage) {
-            cursor.map_times(storage, |time1, diff1| self.push(logic(time1), diff1.into_owned()));
+            cursor.map_times(storage, |time1, diff1| self.push(logic(time1), C::owned_diff(diff1)));
             self.seal(val);
             cursor.step_val(storage);
         }

--- a/differential-dataflow/src/operators/reduce.rs
+++ b/differential-dataflow/src/operators/reduce.rs
@@ -739,7 +739,7 @@ mod history_replay {
             // loaded times by performing the lattice `join` with this value.
 
             // Load the batch contents.
-            let mut batch_replay = self.batch_history.replay_key(batch_cursor, batch_storage, key, |time| time.into_owned());
+            let mut batch_replay = self.batch_history.replay_key(batch_cursor, batch_storage, key, |time| C3::owned_time(time));
 
             // We determine the meet of times we must reconsider (those from `batch` and `times`). This meet
             // can be used to advance other historical times, which may consolidate their representation. As
@@ -776,23 +776,23 @@ mod history_replay {
             // Load the input and output histories.
             let mut input_replay = if let Some(meet) = meet.as_ref() {
                 self.input_history.replay_key(source_cursor, source_storage, key, |time| {
-                    let mut time = time.into_owned();
+                    let mut time = C1::owned_time(time);
                     time.join_assign(meet);
                     time
                 })
             }
             else {
-                self.input_history.replay_key(source_cursor, source_storage, key, |time| time.into_owned())
+                self.input_history.replay_key(source_cursor, source_storage, key, |time| C1::owned_time(time))
             };
             let mut output_replay = if let Some(meet) = meet.as_ref() {
                 self.output_history.replay_key(output_cursor, output_storage, key, |time| {
-                    let mut time = time.into_owned();
+                    let mut time = C2::owned_time(time);
                     time.join_assign(meet);
                     time
                 })
             }
             else {
-                self.output_history.replay_key(output_cursor, output_storage, key, |time| time.into_owned())
+                self.output_history.replay_key(output_cursor, output_storage, key, |time| C2::owned_time(time))
             };
 
             self.synth_times.clear();

--- a/differential-dataflow/src/trace/cursor/mod.rs
+++ b/differential-dataflow/src/trace/cursor/mod.rs
@@ -32,6 +32,11 @@ pub trait Cursor {
     /// Borrowed form of update difference.
     type DiffGat<'a> : Copy + IntoOwned<'a, Owned = Self::Diff>;
 
+    /// An owned copy of a reference to a time.
+    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { time.into_owned() }
+    /// An owned copy of a reference to a diff.
+    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { diff.into_owned() }
+
     /// Storage required by the cursor.
     type Storage;
 
@@ -75,7 +80,7 @@ pub trait Cursor {
 
     /// Rewinds the cursor and outputs its contents to a Vec
     fn to_vec<K, V>(&mut self, storage: &Self::Storage) -> Vec<((K, V), Vec<(Self::Time, Self::Diff)>)>
-    where 
+    where
         for<'a> Self::Key<'a> : IntoOwned<'a, Owned = K>,
         for<'a> Self::Val<'a> : IntoOwned<'a, Owned = V>,
     {

--- a/differential-dataflow/src/trace/implementations/huffman_container.rs
+++ b/differential-dataflow/src/trace/implementations/huffman_container.rs
@@ -38,8 +38,8 @@ impl<B: Ord + Clone + 'static> PushInto<Vec<B>> for HuffmanContainer<B> {
                 bytes.extend(huffman.encode(item.iter()));
                 self.offsets.push(bytes.len());
             },
-            Err(raw) => { 
-                raw.extend(item); 
+            Err(raw) => {
+                raw.extend(item);
                 self.offsets.push(raw.len());
             }
         }
@@ -81,6 +81,21 @@ impl<'a, B: Ord + Clone + 'static> PushInto<Wrapped<'a, B>> for HuffmanContainer
 impl<B: Ord + Clone + 'static> BatchContainer for HuffmanContainer<B> {
     type Owned = Vec<B>;
     type ReadItem<'a> = Wrapped<'a, B>;
+
+    fn into_owned<'a>(item: Self::ReadItem<'a>) -> Self::Owned {
+        match item.decode() {
+            Ok(decode) => decode.cloned().collect(),
+            Err(bytes) => bytes.to_vec(),
+        }
+    }
+    fn clone_onto<'a>(item: Self::ReadItem<'a>, other: &mut Self::Owned) {
+        other.clear();
+        match item.decode() {
+            Ok(decode) => other.extend(decode.cloned()),
+            Err(bytes) => other.extend_from_slice(bytes),
+        }
+    }
+    fn borrow_as<'a>(owned: &'a Self::Owned) -> Self::ReadItem<'a> { Self::ReadItem { inner: Err(&owned[..]) } }
 
     fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b> { item }
 
@@ -151,7 +166,7 @@ mod wrapper {
     use super::Encoded;
 
     pub struct Wrapped<'a, B: Ord> {
-        inner: Result<Encoded<'a, B>, &'a [B]>,
+        pub(crate) inner: Result<Encoded<'a, B>, &'a [B]>,
     }
 
     impl<'a, B: Ord> Wrapped<'a, B> {
@@ -254,7 +269,7 @@ mod huffman {
 
     use std::collections::BTreeMap;
     use std::convert::TryInto;
-    
+
     use self::decoder::Decoder;
     use self::encoder::Encoder;
 
@@ -281,7 +296,7 @@ mod huffman {
         }
 
         /// Decodes the provided bytes as a sequence of symbols.
-        pub fn decode<I>(&self, bytes: I) -> Decoder<'_, T, I::IntoIter> 
+        pub fn decode<I>(&self, bytes: I) -> Decoder<'_, T, I::IntoIter>
         where
             I: IntoIterator<Item=u8>
         {
@@ -317,7 +332,7 @@ mod huffman {
             while let Some((node, level)) = todo.pop() {
                 match node {
                     Node::Leaf(sym) => { levels.push((level, sym)); },
-                    Node::Fork(l,r) => { 
+                    Node::Fork(l,r) => {
                         todo.push((&tree[*l], level + 1));
                         todo.push((&tree[*r], level + 1));
                     },
@@ -345,13 +360,13 @@ mod huffman {
                 }
             }
 
-            Huffman { 
+            Huffman {
                 encode,
                 decode,
             }
         }
 
-        /// Inserts a symbol, and 
+        /// Inserts a symbol, and
         fn insert_decode(map: &mut [Decode<T>; 256], symbol: &T, bits: usize, code: u64) where T: Clone {
             let byte: u8 = (code >> 56).try_into().unwrap();
             if bits <= 8 {
@@ -376,7 +391,7 @@ mod huffman {
         Fork(usize, usize),
     }
 
-    /// Decoder 
+    /// Decoder
     #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Default)]
     pub enum Decode<T> {
         /// An as-yet unfilled slot.
@@ -392,7 +407,7 @@ mod huffman {
         /// Tests to see if the map contains any invalid values.
         ///
         /// A correctly initialized map will have no invalid values.
-        /// A map with invalid values will be unable to decode some 
+        /// A map with invalid values will be unable to decode some
         /// input byte sequences.
         fn any_void(&self) -> bool {
             match self {

--- a/differential-dataflow/src/trace/implementations/mod.rs
+++ b/differential-dataflow/src/trace/implementations/mod.rs
@@ -98,9 +98,9 @@ pub trait Layout {
     type Target: Update + ?Sized;
     /// Container for update keys.
     // NB: The `PushInto` constraint is only required by `rhh.rs` to push default values.
-    type KeyContainer: BatchContainer + PushInto<<Self::Target as Update>::Key>;
+    type KeyContainer: BatchContainer<Owned = <Self::Target as Update>::Key> + PushInto<<Self::Target as Update>::Key>;
     /// Container for update vals.
-    type ValContainer: BatchContainer;
+    type ValContainer: BatchContainer<Owned = <Self::Target as Update>::Val>;
     /// Container for times.
     type TimeContainer: BatchContainer<Owned = <Self::Target as Update>::Time> + PushInto<<Self::Target as Update>::Time>;
     /// Container for diffs.
@@ -150,7 +150,7 @@ where
 /// Examples include types that implement `Clone` who prefer
 pub trait PreferredContainer : ToOwned {
     /// The preferred container for the type.
-    type Container: BatchContainer + PushInto<Self::Owned>;
+    type Container: BatchContainer<Owned = Self::Owned> + PushInto<Self::Owned>;
 }
 
 impl<T: Ord + Clone + 'static> PreferredContainer for T {

--- a/differential-dataflow/src/trace/implementations/mod.rs
+++ b/differential-dataflow/src/trace/implementations/mod.rs
@@ -268,9 +268,11 @@ impl BatchContainer for OffsetList {
     type Owned = usize;
     type ReadItem<'a> = usize;
 
+    #[inline(always)]
     fn into_owned<'a>(item: Self::ReadItem<'a>) -> Self::Owned { item }
+    #[inline(always)]
     fn borrow_as<'a>(owned: &'a Self::Owned) -> Self::ReadItem<'a> { *owned }
-
+    #[inline(always)]
     fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b> { item }
 
     fn with_capacity(size: usize) -> Self {
@@ -446,6 +448,7 @@ pub mod containers {
         #[must_use]
         fn into_owned<'a>(item: Self::ReadItem<'a>) -> Self::Owned;
         /// Clones `self` onto an existing instance of the owned type.
+        #[inline(always)]
         fn clone_onto<'a>(item: Self::ReadItem<'a>, other: &mut Self::Owned) {
             *other = Self::into_owned(item);
         }
@@ -542,9 +545,9 @@ pub mod containers {
         type Owned = T;
         type ReadItem<'a> = &'a T;
 
-        fn into_owned<'a>(item: Self::ReadItem<'a>) -> Self::Owned { item.clone() }
-        fn clone_onto<'a>(item: Self::ReadItem<'a>, other: &mut Self::Owned) { other.clone_from(item); }
-        fn borrow_as<'a>(owned: &'a Self::Owned) -> Self::ReadItem<'a> { owned }
+        #[inline(always)] fn into_owned<'a>(item: Self::ReadItem<'a>) -> Self::Owned { item.clone() }
+        #[inline(always)] fn clone_onto<'a>(item: Self::ReadItem<'a>, other: &mut Self::Owned) { other.clone_from(item); }
+        #[inline(always)] fn borrow_as<'a>(owned: &'a Self::Owned) -> Self::ReadItem<'a> { owned }
 
         fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b> { item }
 
@@ -571,9 +574,9 @@ pub mod containers {
         type Owned = T;
         type ReadItem<'a> = &'a T;
 
-        fn into_owned<'a>(item: Self::ReadItem<'a>) -> Self::Owned { item.clone() }
-        fn clone_onto<'a>(item: Self::ReadItem<'a>, other: &mut Self::Owned) { other.clone_from(item); }
-        fn borrow_as<'a>(owned: &'a Self::Owned) -> Self::ReadItem<'a> { owned }
+        #[inline(always)] fn into_owned<'a>(item: Self::ReadItem<'a>) -> Self::Owned { item.clone() }
+        #[inline(always)] fn clone_onto<'a>(item: Self::ReadItem<'a>, other: &mut Self::Owned) { other.clone_from(item); }
+        #[inline(always)] fn borrow_as<'a>(owned: &'a Self::Owned) -> Self::ReadItem<'a> { owned }
 
         fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b> { item }
 
@@ -635,9 +638,9 @@ pub mod containers {
         type Owned = Vec<B>;
         type ReadItem<'a> = &'a [B];
 
-        fn into_owned<'a>(item: Self::ReadItem<'a>) -> Self::Owned { item.to_vec() }
-        fn clone_onto<'a>(item: Self::ReadItem<'a>, other: &mut Self::Owned) { other.clone_from_slice(item); }
-        fn borrow_as<'a>(owned: &'a Self::Owned) -> Self::ReadItem<'a> { &owned[..] }
+        #[inline(always)] fn into_owned<'a>(item: Self::ReadItem<'a>) -> Self::Owned { item.to_vec() }
+        #[inline(always)] fn clone_onto<'a>(item: Self::ReadItem<'a>, other: &mut Self::Owned) { other.clone_from_slice(item); }
+        #[inline(always)] fn borrow_as<'a>(owned: &'a Self::Owned) -> Self::ReadItem<'a> { &owned[..] }
 
         fn reborrow<'b, 'a: 'b>(item: Self::ReadItem<'a>) -> Self::ReadItem<'b> { item }
 

--- a/differential-dataflow/src/trace/implementations/ord_neu.rs
+++ b/differential-dataflow/src/trace/implementations/ord_neu.rs
@@ -236,9 +236,8 @@ pub mod layers {
                 // we push nothing and report an unincremented offset to encode this case.
                 let time_diff = upds.times.last().zip(upds.diffs.last());
                 let last_eq = self.stash.last().zip(time_diff).map(|((t1, d1), (t2, d2))| {
-                    use crate::IntoOwned;
-                    let t1 = <<T as BatchContainer>::ReadItem<'_> as IntoOwned>::borrow_as(t1);
-                    let d1 = <<D as BatchContainer>::ReadItem<'_> as IntoOwned>::borrow_as(d1);
+                    let t1 = T::borrow_as(t1);
+                    let d1 = D::borrow_as(d1);
                     t1.eq(&t2) && d1.eq(&d2)
                 });
                 if self.stash.len() == 1 && last_eq.unwrap_or(false) {
@@ -278,7 +277,6 @@ pub mod val_batch {
     use crate::trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
     use crate::trace::implementations::{BatchContainer, BuilderInput};
     use crate::trace::implementations::layout;
-    use crate::IntoOwned;
 
     use super::{Layout, Vals, Upds, layers::UpdsBuilder};
 
@@ -580,9 +578,9 @@ pub mod val_batch {
                 // NB: Here is where we would need to look back if `lower == upper`.
                 let (time, diff) = source.upds.get_abs(i);
                 use crate::lattice::Lattice;
-                let mut new_time: layout::Time<L> = time.into_owned();
+                let mut new_time: layout::Time<L> = L::TimeContainer::into_owned(time);
                 new_time.advance_by(self.description.since().borrow());
-                self.staging.push(new_time, diff.into_owned());
+                self.staging.push(new_time, L::DiffContainer::into_owned(diff));
             }
         }
     }
@@ -759,8 +757,6 @@ pub mod key_batch {
     use crate::trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
     use crate::trace::implementations::{BatchContainer, BuilderInput};
     use crate::trace::implementations::layout;
-
-    use crate::IntoOwned;
 
     use super::{Layout, Upds, layers::UpdsBuilder};
 
@@ -978,9 +974,9 @@ pub mod key_batch {
                 // NB: Here is where we would need to look back if `lower == upper`.
                 let (time, diff) = source.upds.get_abs(i);
                 use crate::lattice::Lattice;
-                let mut new_time = time.into_owned();
+                let mut new_time = L::TimeContainer::into_owned(time);
                 new_time.advance_by(self.description.since().borrow());
-                self.staging.push(new_time, diff.into_owned());
+                self.staging.push(new_time, L::DiffContainer::into_owned(diff));
             }
         }
     }

--- a/differential-dataflow/src/trace/implementations/rhh.rs
+++ b/differential-dataflow/src/trace/implementations/rhh.rs
@@ -1,7 +1,7 @@
 //! Batch implementation based on Robin Hood Hashing.
-//! 
+//!
 //! Items are ordered by `(hash(Key), Key)` rather than `Key`, which means
-//! that these implementations should only be used with each other, under 
+//! that these implementations should only be used with each other, under
 //! the same `hash` function, or for types that also order by `(hash(X), X)`,
 //! for example wrapped types that implement `Ord` that way.
 
@@ -17,7 +17,7 @@ use crate::trace::implementations::merge_batcher::{MergeBatcher, VecMerger, ColM
 use crate::trace::implementations::spine_fueled::Spine;
 use crate::trace::rc_blanket_impls::RcBuilder;
 
-use super::{Update, Layout, Vector, TStack};
+use super::{Layout, Vector, TStack};
 
 use self::val_batch::{RhhValBatch, RhhValBuilder};
 
@@ -92,28 +92,30 @@ mod val_batch {
     use crate::hashable::Hashable;
     use crate::trace::{Batch, BatchReader, Builder, Cursor, Description, Merger};
     use crate::trace::implementations::{BatchContainer, BuilderInput};
+    use crate::trace::implementations::layout;
+
     use crate::IntoOwned;
 
-    use super::{Layout, Update, HashOrdered};
+    use super::{Layout, HashOrdered};
 
     /// Update tuples organized as a Robin Hood Hash map, ordered by `(hash(Key), Key, Val, Time)`.
     ///
-    /// Specifically, this means that we attempt to place any `Key` at `alloc_len * (hash(Key) / 2^64)`, 
-    /// and spill onward if the slot is occupied. The cleverness of RHH is that you may instead evict 
-    /// someone else, in order to maintain the ordering up above. In fact, that is basically the rule: 
+    /// Specifically, this means that we attempt to place any `Key` at `alloc_len * (hash(Key) / 2^64)`,
+    /// and spill onward if the slot is occupied. The cleverness of RHH is that you may instead evict
+    /// someone else, in order to maintain the ordering up above. In fact, that is basically the rule:
     /// when there is a conflict, evict the greater of the two and attempt to place it in the next slot.
     ///
     /// This RHH implementation uses a repeated `keys_offs` offset to indicate an absent element, as all
-    /// keys for valid updates must have some associated values with updates. This is the same type of 
+    /// keys for valid updates must have some associated values with updates. This is the same type of
     /// optimization made for repeated updates, and it rules out (here) using that trick for repeated values.
     ///
-    /// We will use the `Hashable` trait here, but any consistent hash function should work out ok. 
+    /// We will use the `Hashable` trait here, but any consistent hash function should work out ok.
     /// We specifically want to use the highest bits of the result (we will) because the low bits have
     /// likely been spent shuffling the data between workers (by key), and are likely low entropy.
     #[derive(Debug, Serialize, Deserialize)]
-    pub struct RhhValStorage<L: Layout> 
-    where 
-        <L::Target as Update>::Key: Default + HashOrdered,
+    pub struct RhhValStorage<L: Layout>
+    where
+        layout::Key<L>: Default + HashOrdered,
     {
 
         /// The requested capacity for `keys`. We use this when determining where a key with a certain hash
@@ -123,7 +125,7 @@ mod val_batch {
         /// A number large enough that when it divides any `u64` the result is at most `self.key_capacity`.
         /// When that capacity is zero or one, this is set to zero instead.
         pub divisor: u64,
-        /// The number of present keys, distinct from `keys.len()` which contains 
+        /// The number of present keys, distinct from `keys.len()` which contains
         pub key_count: usize,
 
         /// An ordered list of keys, corresponding to entries in `keys_offs`.
@@ -150,8 +152,8 @@ mod val_batch {
     }
 
     impl<L: Layout> RhhValStorage<L>
-    where 
-        <L::Target as Update>::Key: Default + HashOrdered,
+    where
+        layout::Key<L>: Default + HashOrdered,
         for<'a> <L::KeyContainer as BatchContainer>::ReadItem<'a>: HashOrdered,
     {
         /// Lower and upper bounds in `self.vals` corresponding to the key at `index`.
@@ -186,12 +188,12 @@ mod val_batch {
         /// not know the final offset at the moment of key insertion can prepare for receiving the offset.
         fn insert_key(&mut self, key: <L::KeyContainer as BatchContainer>::ReadItem<'_>, offset: Option<usize>) {
             let desired = self.desired_location(&key);
-            // Were we to push the key now, it would be at `self.keys.len()`, so while that is wrong, 
+            // Were we to push the key now, it would be at `self.keys.len()`, so while that is wrong,
             // push additional blank entries in.
             while self.keys.len() < desired {
                 // We insert a default (dummy) key and repeat the offset to indicate this.
                 let current_offset = self.keys_offs.index(self.keys.len());
-                self.keys.push(<<L::Target as Update>::Key as Default>::default());
+                self.keys.push(<layout::Key<L> as Default>::default());
                 self.keys_offs.push(current_offset);
             }
 
@@ -258,35 +260,35 @@ mod val_batch {
         L::DiffContainer: Serialize + for<'a> Deserialize<'a>,
     ")]
     pub struct RhhValBatch<L: Layout>
-    where 
-        <L::Target as Update>::Key: Default + HashOrdered,
+    where
+        layout::Key<L>: Default + HashOrdered,
     {
         /// The updates themselves.
         pub storage: RhhValStorage<L>,
         /// Description of the update times this layer represents.
-        pub description: Description<<L::Target as Update>::Time>,
+        pub description: Description<layout::Time<L>>,
         /// The number of updates reflected in the batch.
         ///
         /// We track this separately from `storage` because due to the singleton optimization,
-        /// we may have many more updates than `storage.updates.len()`. It should equal that 
+        /// we may have many more updates than `storage.updates.len()`. It should equal that
         /// length, plus the number of singleton optimizations employed.
         pub updates: usize,
     }
 
-    impl<L: Layout> BatchReader for RhhValBatch<L> 
-    where 
-        <L::Target as Update>::Key: Default + HashOrdered,
+    impl<L: Layout> BatchReader for RhhValBatch<L>
+    where
+        layout::Key<L>: Default + HashOrdered,
         for<'a> <L::KeyContainer as BatchContainer>::ReadItem<'a>: HashOrdered,
     {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
-        type Time = <L::Target as Update>::Time;
+        type Time = layout::Time<L>;
         type TimeGat<'a> = <L::TimeContainer as BatchContainer>::ReadItem<'a>;
-        type Diff = <L::Target as Update>::Diff;
+        type Diff = layout::Diff<L>;
         type DiffGat<'a> = <L::DiffContainer as BatchContainer>::ReadItem<'a>;
 
         type Cursor = RhhValCursor<L>;
-        fn cursor(&self) -> Self::Cursor { 
+        fn cursor(&self) -> Self::Cursor {
             let mut cursor = RhhValCursor {
                 key_cursor: 0,
                 val_cursor: 0,
@@ -295,22 +297,22 @@ mod val_batch {
             cursor.step_key(self);
             cursor
         }
-        fn len(&self) -> usize { 
+        fn len(&self) -> usize {
             // Normally this would be `self.updates.len()`, but we have a clever compact encoding.
             // Perhaps we should count such exceptions to the side, to provide a correct accounting.
             self.updates
         }
-        fn description(&self) -> &Description<<L::Target as Update>::Time> { &self.description }
+        fn description(&self) -> &Description<layout::Time<L>> { &self.description }
     }
 
-    impl<L: Layout> Batch for RhhValBatch<L> 
-    where 
-        <L::Target as Update>::Key: Default + HashOrdered,
+    impl<L: Layout> Batch for RhhValBatch<L>
+    where
+        layout::Key<L>: Default + HashOrdered,
         for<'a> <L::KeyContainer as BatchContainer>::ReadItem<'a>: HashOrdered,
     {
         type Merger = RhhValMerger<L>;
 
-        fn begin_merge(&self, other: &Self, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self::Merger {
+        fn begin_merge(&self, other: &Self, compaction_frontier: AntichainRef<layout::Time<L>>) -> Self::Merger {
             RhhValMerger::new(self, other, compaction_frontier)
         }
 
@@ -335,9 +337,9 @@ mod val_batch {
     }
 
     /// State for an in-progress merge.
-    pub struct RhhValMerger<L: Layout> 
-    where 
-        <L::Target as Update>::Key: Default + HashOrdered,
+    pub struct RhhValMerger<L: Layout>
+    where
+        layout::Key<L>: Default + HashOrdered,
     {
         /// Key position to merge next in the first batch.
         key_cursor1: usize,
@@ -346,24 +348,24 @@ mod val_batch {
         /// result that we are currently assembling.
         result: RhhValStorage<L>,
         /// description
-        description: Description<<L::Target as Update>::Time>,
+        description: Description<layout::Time<L>>,
 
         /// Local stash of updates, to use for consolidation.
         ///
         /// We could emulate a `ChangeBatch` here, with related compaction smarts.
         /// A `ChangeBatch` itself needs an `i64` diff type, which we have not.
-        update_stash: Vec<(<L::Target as Update>::Time, <L::Target as Update>::Diff)>,
+        update_stash: Vec<(layout::Time<L>, layout::Diff<L>)>,
         /// Counts the number of singleton-optimized entries, that we may correctly count the updates.
         singletons: usize,
     }
 
     impl<L: Layout> Merger<RhhValBatch<L>> for RhhValMerger<L>
     where
-        <L::Target as Update>::Key: Default + HashOrdered,
-        RhhValBatch<L>: Batch<Time=<L::Target as Update>::Time>,
+        layout::Key<L>: Default + HashOrdered,
+        RhhValBatch<L>: Batch<Time=layout::Time<L>>,
         for<'a> <L::KeyContainer as BatchContainer>::ReadItem<'a>: HashOrdered,
     {
-        fn new(batch1: &RhhValBatch<L>, batch2: &RhhValBatch<L>, compaction_frontier: AntichainRef<<L::Target as Update>::Time>) -> Self {
+        fn new(batch1: &RhhValBatch<L>, batch2: &RhhValBatch<L>, compaction_frontier: AntichainRef<layout::Time<L>>) -> Self {
 
             assert!(batch1.upper() == batch2.lower());
             use crate::lattice::Lattice;
@@ -432,7 +434,7 @@ mod val_batch {
                 effort = (self.result.times.len() - starting_updates) as isize;
             }
 
-            // Merging is complete, and only copying remains. 
+            // Merging is complete, and only copying remains.
             // Key-by-key copying allows effort interruption, and compaction.
             while self.key_cursor1 < source1.storage.keys.len() && effort < *fuel {
                 self.copy_key(&source1.storage, self.key_cursor1);
@@ -452,17 +454,17 @@ mod val_batch {
     }
 
     // Helper methods in support of merging batches.
-    impl<L: Layout> RhhValMerger<L> 
-    where 
-        <L::Target as Update>::Key: Default + HashOrdered,
+    impl<L: Layout> RhhValMerger<L>
+    where
+        layout::Key<L>: Default + HashOrdered,
         for<'a> <L::KeyContainer as BatchContainer>::ReadItem<'a>: HashOrdered,
     {
         /// Copy the next key in `source`.
         ///
         /// The method extracts the key in `source` at `cursor`, and merges it in to `self`.
         /// If the result does not wholly cancel, they key will be present in `self` with the
-        /// compacted values and updates. 
-        /// 
+        /// compacted values and updates.
+        ///
         /// The caller should be certain to update the cursor, as this method does not do this.
         fn copy_key(&mut self, source: &RhhValStorage<L>, cursor: usize) {
             // Capture the initial number of values to determine if the merge was ultimately non-empty.
@@ -475,12 +477,12 @@ mod val_batch {
                     self.result.vals.push(source.vals.index(lower));
                 }
                 lower += 1;
-            }            
+            }
 
             // If we have pushed any values, copy the key as well.
             if self.result.vals.len() > init_vals {
                 self.result.insert_key(source.keys.index(cursor), Some(self.result.vals.len()));
-            }           
+            }
         }
         /// Merge the next key in each of `source1` and `source2` into `self`, updating the appropriate cursors.
         ///
@@ -490,7 +492,7 @@ mod val_batch {
 
             use ::std::cmp::Ordering;
             match source1.keys.index(self.key_cursor1).cmp(&source2.keys.index(self.key_cursor2)) {
-                Ordering::Less => { 
+                Ordering::Less => {
                     self.copy_key(source1, self.key_cursor1);
                     self.key_cursor1 += 1;
                 },
@@ -516,8 +518,8 @@ mod val_batch {
         /// If the compacted result contains values with non-empty updates, the function returns
         /// an offset that should be recorded to indicate the upper extent of the result values.
         fn merge_vals(
-            &mut self, 
-            (source1, mut lower1, upper1): (&RhhValStorage<L>, usize, usize), 
+            &mut self,
+            (source1, mut lower1, upper1): (&RhhValStorage<L>, usize, usize),
             (source2, mut lower2, upper2): (&RhhValStorage<L>, usize, usize),
         ) -> Option<usize> {
             // Capture the initial number of values to determine if the merge was ultimately non-empty.
@@ -528,7 +530,7 @@ mod val_batch {
                 // We could multi-way merge and it wouldn't be very complicated.
                 use ::std::cmp::Ordering;
                 match source1.vals.index(lower1).cmp(&source2.vals.index(lower2)) {
-                    Ordering::Less => { 
+                    Ordering::Less => {
                         // Extend stash by updates, with logical compaction applied.
                         self.stash_updates_for_val(source1, lower1);
                         if let Some(off) = self.consolidate_updates() {
@@ -547,7 +549,7 @@ mod val_batch {
                         lower1 += 1;
                         lower2 += 1;
                     },
-                    Ordering::Greater => { 
+                    Ordering::Greater => {
                         // Extend stash by updates, with logical compaction applied.
                         self.stash_updates_for_val(source2, lower2);
                         if let Some(off) = self.consolidate_updates() {
@@ -638,9 +640,9 @@ mod val_batch {
     /// Importantly, we should skip over invalid keys, rather than report them as
     /// invalid through `key_valid`: that method is meant to indicate the end of
     /// the cursor, rather than internal state.
-    pub struct RhhValCursor<L: Layout> 
-    where 
-        <L::Target as Update>::Key: Default + HashOrdered,
+    pub struct RhhValCursor<L: Layout>
+    where
+        layout::Key<L>: Default + HashOrdered,
     {
         /// Absolute position of the current key.
         key_cursor: usize,
@@ -650,16 +652,16 @@ mod val_batch {
         phantom: PhantomData<L>,
     }
 
-    impl<L: Layout> Cursor for RhhValCursor<L> 
-    where 
-        <L::Target as Update>::Key: Default + HashOrdered,
+    impl<L: Layout> Cursor for RhhValCursor<L>
+    where
+        layout::Key<L>: Default + HashOrdered,
         for<'a> <L::KeyContainer as BatchContainer>::ReadItem<'a>: HashOrdered,
     {
         type Key<'a> = <L::KeyContainer as BatchContainer>::ReadItem<'a>;
         type Val<'a> = <L::ValContainer as BatchContainer>::ReadItem<'a>;
-        type Time = <L::Target as Update>::Time;
+        type Time = layout::Time<L>;
         type TimeGat<'a> = <L::TimeContainer as BatchContainer>::ReadItem<'a>;
-        type Diff = <L::Target as Update>::Diff;
+        type Diff = layout::Diff<L>;
         type DiffGat<'a> = <L::DiffContainer as BatchContainer>::ReadItem<'a>;
 
         type Storage = RhhValBatch<L>;
@@ -711,7 +713,7 @@ mod val_batch {
             }
         }
         fn step_val(&mut self, storage: &RhhValBatch<L>) {
-            self.val_cursor += 1; 
+            self.val_cursor += 1;
             if !self.val_valid(storage) {
                 self.val_cursor = storage.storage.values_for_key(self.key_cursor).1;
             }
@@ -734,11 +736,11 @@ mod val_batch {
 
     /// A builder for creating layers from unsorted update tuples.
     pub struct RhhValBuilder<L: Layout, CI>
-    where 
-        <L::Target as Update>::Key: Default + HashOrdered,
+    where
+        layout::Key<L>: Default + HashOrdered,
     {
         result: RhhValStorage<L>,
-        singleton: Option<(<L::Target as Update>::Time, <L::Target as Update>::Diff)>,
+        singleton: Option<(layout::Time<L>, layout::Diff<L>)>,
         /// Counts the number of singleton optimizations we performed.
         ///
         /// This number allows us to correctly gauge the total number of updates reflected in a batch,
@@ -748,8 +750,8 @@ mod val_batch {
     }
 
     impl<L: Layout, CI> RhhValBuilder<L, CI>
-    where 
-        <L::Target as Update>::Key: Default + HashOrdered,
+    where
+        layout::Key<L>: Default + HashOrdered,
     {
         /// Pushes a single update, which may set `self.singleton` rather than push.
         ///
@@ -762,7 +764,7 @@ mod val_batch {
         /// previously pushed update exactly. In that case, we do not push the update into `updates`.
         /// The update tuple is retained in `self.singleton` in case we see another update and need
         /// to recover the singleton to push it into `updates` to join the second update.
-        fn push_update(&mut self, time: <L::Target as Update>::Time, diff: <L::Target as Update>::Diff) {
+        fn push_update(&mut self, time: layout::Time<L>, diff: layout::Diff<L>) {
             // If a just-pushed update exactly equals `(time, diff)` we can avoid pushing it.
             let t1 = <<L::TimeContainer as BatchContainer>::ReadItem<'_> as IntoOwned>::borrow_as(&time);
             let d1 = <<L::DiffContainer as BatchContainer>::ReadItem<'_> as IntoOwned>::borrow_as(&diff);
@@ -784,27 +786,27 @@ mod val_batch {
 
     impl<L: Layout, CI> Builder for RhhValBuilder<L, CI>
     where
-        <L::Target as Update>::Key: Default + HashOrdered,
-        CI: for<'a> BuilderInput<L::KeyContainer, L::ValContainer, Key<'a> = <L::Target as Update>::Key, Time=<L::Target as Update>::Time, Diff=<L::Target as Update>::Diff>,
+        layout::Key<L>: Default + HashOrdered,
+        CI: for<'a> BuilderInput<L::KeyContainer, L::ValContainer, Key<'a> = layout::Key<L>, Time=layout::Time<L>, Diff=layout::Diff<L>>,
         for<'a> L::ValContainer: PushInto<CI::Val<'a>>,
-        for<'a> <L::KeyContainer as BatchContainer>::ReadItem<'a>: HashOrdered + IntoOwned<'a, Owned = <L::Target as Update>::Key>,
+        for<'a> <L::KeyContainer as BatchContainer>::ReadItem<'a>: HashOrdered + IntoOwned<'a, Owned = layout::Key<L>>,
     {
         type Input = CI;
-        type Time = <L::Target as Update>::Time;
+        type Time = layout::Time<L>;
         type Output = RhhValBatch<L>;
 
         fn with_capacity(keys: usize, vals: usize, upds: usize) -> Self {
 
             // Double the capacity for RHH; probably excessive.
             let rhh_capacity = 2 * keys;
-            let divisor = RhhValStorage::<L>::divisor_for_capacity(rhh_capacity);                        
+            let divisor = RhhValStorage::<L>::divisor_for_capacity(rhh_capacity);
             // We want some additive slop, in case we spill over.
             // This number magically chosen based on nothing in particular.
             // Worst case, we will re-alloc and copy if we spill beyond this.
             let keys = rhh_capacity + 10;
 
             // We don't introduce zero offsets as they will be introduced by the first `push` call.
-            Self { 
+            Self {
                 result: RhhValStorage {
                     keys: L::KeyContainer::with_capacity(keys),
                     keys_offs: L::OffsetContainer::with_capacity(keys + 1),

--- a/differential-dataflow/src/trace/implementations/rhh.rs
+++ b/differential-dataflow/src/trace/implementations/rhh.rs
@@ -593,10 +593,10 @@ mod val_batch {
                 // NB: Here is where we would need to look back if `lower == upper`.
                 let time = source.times.index(i);
                 let diff = source.diffs.index(i);
-                let mut new_time = time.into_owned();
+                let mut new_time = L::TimeContainer::into_owned(time);
                 use crate::lattice::Lattice;
                 new_time.advance_by(self.description.since().borrow());
-                self.update_stash.push((new_time, diff.into_owned()));
+                self.update_stash.push((new_time, L::DiffContainer::into_owned(diff)));
             }
         }
 
@@ -609,8 +609,8 @@ mod val_batch {
                 // we push nothing and report an unincremented offset to encode this case.
                 let time_diff = self.result.times.last().zip(self.result.diffs.last());
                 let last_eq = self.update_stash.last().zip(time_diff).map(|((t1, d1), (t2, d2))| {
-                    let t1 = <<L::TimeContainer as BatchContainer>::ReadItem<'_> as IntoOwned>::borrow_as(t1);
-                    let d1 = <<L::DiffContainer as BatchContainer>::ReadItem<'_> as IntoOwned>::borrow_as(d1);
+                    let t1 = L::TimeContainer::borrow_as(t1);
+                    let d1 = L::DiffContainer::borrow_as(d1);
                     t1.eq(&t2) && d1.eq(&d2)
                 });
                 if self.update_stash.len() == 1 && last_eq.unwrap_or(false) {
@@ -766,8 +766,8 @@ mod val_batch {
         /// to recover the singleton to push it into `updates` to join the second update.
         fn push_update(&mut self, time: layout::Time<L>, diff: layout::Diff<L>) {
             // If a just-pushed update exactly equals `(time, diff)` we can avoid pushing it.
-            let t1 = <<L::TimeContainer as BatchContainer>::ReadItem<'_> as IntoOwned>::borrow_as(&time);
-            let d1 = <<L::DiffContainer as BatchContainer>::ReadItem<'_> as IntoOwned>::borrow_as(&diff);
+            let t1 = L::TimeContainer::borrow_as(&time);
+            let d1 = L::DiffContainer::borrow_as(&diff);
             if self.result.times.last().map(|t| t == t1).unwrap_or(false) && self.result.diffs.last().map(|d| d == d1).unwrap_or(false) {
                 assert!(self.singleton.is_none());
                 self.singleton = Some((time, diff));

--- a/differential-dataflow/src/trace/mod.rs
+++ b/differential-dataflow/src/trace/mod.rs
@@ -60,6 +60,11 @@ pub trait TraceReader {
     /// Borrowed form of update difference.
     type DiffGat<'a> : Copy + IntoOwned<'a, Owned = Self::Diff>;
 
+    /// An owned copy of a reference to a time.
+    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { Self::Cursor::owned_time(time) }
+    /// An owned copy of a reference to a diff.
+    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { Self::Cursor::owned_diff(diff) }
+
     /// The type of an immutable collection of updates.
     type Batch: for<'a> BatchReader<Key<'a> = Self::Key<'a>, Val<'a> = Self::Val<'a>, Time = Self::Time, TimeGat<'a> = Self::TimeGat<'a>, Diff = Self::Diff, DiffGat<'a> = Self::DiffGat<'a>>+Clone+'static;
 
@@ -194,7 +199,7 @@ pub trait Trace : TraceReader<Batch: Batch> {
     /// Sets the logic for exertion in the absence of updates.
     ///
     /// The function receives an iterator over batch levels, from large to small, as triples `(level, count, length)`,
-    /// indicating the level, the number of batches, and their total length in updates. It should return a number of 
+    /// indicating the level, the number of batches, and their total length in updates. It should return a number of
     /// updates to perform, or `None` if no work is required.
     fn set_exert_logic(&mut self, logic: ExertionLogic);
 
@@ -234,6 +239,11 @@ pub trait BatchReader : Sized {
     type Diff: Semigroup + 'static;
     /// Borrowed form of update difference.
     type DiffGat<'a> : Copy + IntoOwned<'a, Owned = Self::Diff>;
+
+    /// An owned copy of a reference to a time.
+    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { Self::Cursor::owned_time(time) }
+    /// An owned copy of a reference to a diff.
+    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { Self::Cursor::owned_diff(diff) }
 
     /// The type used to enumerate the batch's contents.
     type Cursor: for<'a> Cursor<Storage=Self, Key<'a> = Self::Key<'a>, Val<'a> = Self::Val<'a>, Time = Self::Time, TimeGat<'a> = Self::TimeGat<'a>, Diff = Self::Diff, DiffGat<'a> = Self::DiffGat<'a>>;

--- a/differential-dataflow/src/trace/wrappers/enter.rs
+++ b/differential-dataflow/src/trace/wrappers/enter.rs
@@ -188,9 +188,8 @@ where
 
     #[inline]
     fn map_times<L: FnMut(&TInner, Self::DiffGat<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
-        use crate::IntoOwned;
         self.cursor.map_times(storage, |time, diff| {
-            logic(&TInner::to_inner(time.into_owned()), diff)
+            logic(&TInner::to_inner(C::owned_time(time)), diff)
         })
     }
 
@@ -245,9 +244,8 @@ where
 
     #[inline]
     fn map_times<L: FnMut(&TInner, Self::DiffGat<'_>)>(&mut self, storage: &Self::Storage, mut logic: L) {
-        use crate::IntoOwned;
         self.cursor.map_times(&storage.batch, |time, diff| {
-            logic(&TInner::to_inner(time.into_owned()), diff)
+            logic(&TInner::to_inner(C::owned_time(time)), diff)
         })
     }
 

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -271,7 +271,7 @@ where
 
             // drop fully processed capabilities.
             stash.retain(|_,proposals| !proposals.is_empty());
-            
+
             for (capability, proposals) in stash_additions.into_iter() {
                 stash.entry(capability).or_insert(Vec::new()).extend(proposals);
             }


### PR DESCRIPTION
This PR moves the functionality of `IntoOwned` into the types that first provide access to the owned and borrowed types. The goal is to remove the freestanding requirement that a reference type should implement `IntoOwned`, as this is generally hard to introduce if it does not already exist. On the other hand, it is relatively easy for a container to provide this functionality, as it only needs to wrap existing logic (assuming it exists; if not there is a different problem). The main distinction is that we are happy to create new containers, or wrapper containers, etc. but much less happy to create new types that they contain.

There is a surprising amount of unmucking to do along the way, and this description will be updated with the narrative arcs if it is successful. For the moment, it is a draft PR revealing the work.