### PR TITLE
WIP: `Layout` extension trait

### DIFF
--- a/differential-dataflow/src/trace/cursor/cursor_list.rs
+++ b/differential-dataflow/src/trace/cursor/cursor_list.rs
@@ -94,6 +94,11 @@ impl<C: Cursor> CursorList<C> {
     }
 }
 
+use crate::trace::implementations::LaidOut;
+impl<C: Cursor> LaidOut for CursorList<C> {
+    type Layout = C::Layout;
+}
+
 impl<C: Cursor> Cursor for CursorList<C> {
     type Key<'a> = C::Key<'a>;
     type Val<'a> = C::Val<'a>;

--- a/differential-dataflow/src/trace/cursor/cursor_list.rs
+++ b/differential-dataflow/src/trace/cursor/cursor_list.rs
@@ -100,16 +100,6 @@ impl<C: Cursor> LaidOut for CursorList<C> {
 }
 
 impl<C: Cursor> Cursor for CursorList<C> {
-    type Key<'a> = C::Key<'a>;
-    type Val<'a> = C::Val<'a>;
-    type Time = C::Time;
-    type TimeGat<'a> = C::TimeGat<'a>;
-    type Diff = C::Diff;
-    type DiffGat<'a> = C::DiffGat<'a>;
-
-    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { C::owned_time(time) }
-    #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { C::clone_time_onto(time, onto) }
-    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { C::owned_diff(diff) }
 
     type Storage = Vec<C::Storage>;
 

--- a/differential-dataflow/src/trace/cursor/mod.rs
+++ b/differential-dataflow/src/trace/cursor/mod.rs
@@ -14,8 +14,10 @@ pub mod cursor_list;
 
 pub use self::cursor_list::CursorList;
 
+use crate::trace::implementations::LayoutExt;
+
 /// A cursor for navigating ordered `(key, val, time, diff)` updates.
-pub trait Cursor {
+pub trait Cursor : LayoutExt {
 
     /// Key by which updates are indexed.
     type Key<'a>: Copy + Clone + Ord;

--- a/differential-dataflow/src/trace/cursor/mod.rs
+++ b/differential-dataflow/src/trace/cursor/mod.rs
@@ -5,11 +5,6 @@
 //! both because it allows navigation on multiple levels (key and val), but also because it
 //! supports efficient seeking (via the `seek_key` and `seek_val` methods).
 
-use timely::progress::Timestamp;
-
-use crate::difference::Semigroup;
-use crate::lattice::Lattice;
-
 pub mod cursor_list;
 
 pub use self::cursor_list::CursorList;
@@ -18,26 +13,6 @@ use crate::trace::implementations::LayoutExt;
 
 /// A cursor for navigating ordered `(key, val, time, diff)` updates.
 pub trait Cursor : LayoutExt {
-
-    /// Key by which updates are indexed.
-    type Key<'a>: Copy + Clone + Ord;
-    /// Values associated with keys.
-    type Val<'a>: Copy + Clone + Ord;
-    /// Timestamps associated with updates
-    type Time: Timestamp + Lattice + Ord + Clone;
-    /// Borrowed form of timestamp.
-    type TimeGat<'a>: Copy;
-    /// Owned form of update difference.
-    type Diff: Semigroup + 'static;
-    /// Borrowed form of update difference.
-    type DiffGat<'a> : Copy;
-
-    /// An owned copy of a reference to a time.
-    fn owned_time(time: Self::TimeGat<'_>) -> Self::Time;
-    /// Clones a reference time onto an owned time.
-    fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time);
-    /// An owned copy of a reference to a diff.
-    fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff;
 
     /// Storage required by the cursor.
     type Storage;

--- a/differential-dataflow/src/trace/implementations/mod.rs
+++ b/differential-dataflow/src/trace/implementations/mod.rs
@@ -116,58 +116,63 @@ pub trait LayoutExt : LaidOut<Layout: Layout<KeyContainer = Self::KeyContainer, 
     /// Alias for an owned key of a layout.
     type KeyOwn;
     /// Alias for an borrowed key of a layout.
-    type KeyRef<'a>: Copy + Ord;
+    type Key<'a>: Copy + Ord;
     /// Alias for an owned val of a layout.
     type ValOwn;
     /// Alias for an borrowed val of a layout.
-    type ValRef<'a>: Copy + Ord;
+    type Val<'a>: Copy + Ord;
     /// Alias for an owned time of a layout.
-    type TimeOwn: Lattice + timely::progress::Timestamp;
+    type Time: Lattice + timely::progress::Timestamp;
     /// Alias for an borrowed time of a layout.
-    type TimeRef<'a>: Copy + Ord;
+    type TimeGat<'a>: Copy + Ord;
     /// Alias for an owned diff of a layout.
-    type DiffOwn: Semigroup;
+    type Diff: Semigroup;
     /// Alias for an borrowed diff of a layout.
-    type DiffRef<'a>: Copy + Ord;
+    type DiffGat<'a>: Copy + Ord;
 
     /// Container for update keys.
-    type KeyContainer: for<'a> BatchContainer<ReadItem<'a> = Self::KeyRef<'a>, Owned = Self::KeyOwn>;
+    type KeyContainer: for<'a> BatchContainer<ReadItem<'a> = Self::Key<'a>, Owned = Self::KeyOwn>;
     /// Container for update vals.
-    type ValContainer: for<'a> BatchContainer<ReadItem<'a> = Self::ValRef<'a>, Owned = Self::ValOwn>;
+    type ValContainer: for<'a> BatchContainer<ReadItem<'a> = Self::Val<'a>, Owned = Self::ValOwn>;
     /// Container for times.
-    type TimeContainer: for<'a> BatchContainer<ReadItem<'a> = Self::TimeRef<'a>, Owned = Self::TimeOwn>;
+    type TimeContainer: for<'a> BatchContainer<ReadItem<'a> = Self::TimeGat<'a>, Owned = Self::Time>;
     /// Container for diffs.
-    type DiffContainer: for<'a> BatchContainer<ReadItem<'a> = Self::DiffRef<'a>, Owned = Self::DiffOwn>;
+    type DiffContainer: for<'a> BatchContainer<ReadItem<'a> = Self::DiffGat<'a>, Owned = Self::Diff>;
 
     /// Construct an owned key from a reference.
-    fn owned_key(key: Self::KeyRef<'_>) -> Self::KeyOwn;
+    fn owned_key(key: Self::Key<'_>) -> Self::KeyOwn;
     /// Construct an owned val from a reference.
-    fn owned_val(val: Self::ValRef<'_>) -> Self::ValOwn;
+    fn owned_val(val: Self::Val<'_>) -> Self::ValOwn;
     /// Construct an owned time from a reference.
-    fn owned_time2(time: Self::TimeRef<'_>) -> Self::TimeOwn;
+    fn owned_time(time: Self::TimeGat<'_>) -> Self::Time;
     /// Construct an owned diff from a reference.
-    fn owned_diff2(diff: Self::DiffRef<'_>) -> Self::DiffOwn;
+    fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff;
+
+    /// Clones a reference time onto an owned time.
+    fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time);
 }
 
 impl<L: LaidOut> LayoutExt for L {
     type KeyOwn = <<L::Layout as Layout>::KeyContainer as BatchContainer>::Owned;
-    type KeyRef<'a> = <<L::Layout as Layout>::KeyContainer as BatchContainer>::ReadItem<'a>;
+    type Key<'a> = <<L::Layout as Layout>::KeyContainer as BatchContainer>::ReadItem<'a>;
     type ValOwn = <<L::Layout as Layout>::ValContainer as BatchContainer>::Owned;
-    type ValRef<'a> = <<L::Layout as Layout>::ValContainer as BatchContainer>::ReadItem<'a>;
-    type TimeOwn = <<L::Layout as Layout>::TimeContainer as BatchContainer>::Owned;
-    type TimeRef<'a> = <<L::Layout as Layout>::TimeContainer as BatchContainer>::ReadItem<'a>;
-    type DiffOwn = <<L::Layout as Layout>::DiffContainer as BatchContainer>::Owned;
-    type DiffRef<'a> = <<L::Layout as Layout>::DiffContainer as BatchContainer>::ReadItem<'a>;
+    type Val<'a> = <<L::Layout as Layout>::ValContainer as BatchContainer>::ReadItem<'a>;
+    type Time = <<L::Layout as Layout>::TimeContainer as BatchContainer>::Owned;
+    type TimeGat<'a> = <<L::Layout as Layout>::TimeContainer as BatchContainer>::ReadItem<'a>;
+    type Diff = <<L::Layout as Layout>::DiffContainer as BatchContainer>::Owned;
+    type DiffGat<'a> = <<L::Layout as Layout>::DiffContainer as BatchContainer>::ReadItem<'a>;
 
     type KeyContainer = <L::Layout as Layout>::KeyContainer;
     type ValContainer = <L::Layout as Layout>::ValContainer;
     type TimeContainer = <L::Layout as Layout>::TimeContainer;
     type DiffContainer = <L::Layout as Layout>::DiffContainer;
 
-    #[inline(always)] fn owned_key(key: Self::KeyRef<'_>) -> Self::KeyOwn { <Self::Layout as Layout>::KeyContainer::into_owned(key) }
-    #[inline(always)] fn owned_val(val: Self::ValRef<'_>) -> Self::ValOwn { <Self::Layout as Layout>::ValContainer::into_owned(val) }
-    #[inline(always)] fn owned_time2(time: Self::TimeRef<'_>) -> Self::TimeOwn { <Self::Layout as Layout>::TimeContainer::into_owned(time) }
-    #[inline(always)] fn owned_diff2(diff: Self::DiffRef<'_>) -> Self::DiffOwn { <Self::Layout as Layout>::DiffContainer::into_owned(diff) }
+    #[inline(always)] fn owned_key(key: Self::Key<'_>) -> Self::KeyOwn { <Self::Layout as Layout>::KeyContainer::into_owned(key) }
+    #[inline(always)] fn owned_val(val: Self::Val<'_>) -> Self::ValOwn { <Self::Layout as Layout>::ValContainer::into_owned(val) }
+    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { <Self::Layout as Layout>::TimeContainer::into_owned(time) }
+    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { <Self::Layout as Layout>::DiffContainer::into_owned(diff) }
+    #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { <Self::Layout as Layout>::TimeContainer::clone_onto(time, onto) }
+
 }
 
 // An easy way to provide an explicit layout: as a 5-tuple.

--- a/differential-dataflow/src/trace/implementations/ord_neu.rs
+++ b/differential-dataflow/src/trace/implementations/ord_neu.rs
@@ -601,17 +601,6 @@ pub mod val_batch {
 
     impl<L: Layout> Cursor for OrdValCursor<L> {
 
-        type Key<'a> = layout::KeyRef<'a, L>;
-        type Val<'a> = layout::ValRef<'a, L>;
-        type Time = layout::Time<L>;
-        type TimeGat<'a> = layout::TimeRef<'a, L>;
-        type Diff = layout::Diff<L>;
-        type DiffGat<'a> = layout::DiffRef<'a, L>;
-
-        #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { L::TimeContainer::into_owned(time) }
-        #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { L::TimeContainer::clone_onto(time, onto) }
-        #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { L::DiffContainer::into_owned(diff) }
-
         type Storage = OrdValBatch<L>;
 
         fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<Self::Key<'a>> { storage.storage.keys.get(self.key_cursor) }
@@ -807,7 +796,7 @@ pub mod key_batch {
         pub updates: usize,
     }
 
-    impl<L: Layout> BatchReader for OrdKeyBatch<L> {
+    impl<L: for<'a> Layout<ValContainer: BatchContainer<ReadItem<'a> = &'a ()>>> BatchReader for OrdKeyBatch<L> {
 
         type Key<'a> = layout::KeyRef<'a, L>;
         type Val<'a> = &'a ();
@@ -832,7 +821,7 @@ pub mod key_batch {
         fn description(&self) -> &Description<layout::Time<L>> { &self.description }
     }
 
-    impl<L: Layout> Batch for OrdKeyBatch<L> {
+    impl<L: for<'a> Layout<ValContainer: BatchContainer<ReadItem<'a> = &'a ()>>> Batch for OrdKeyBatch<L> {
         type Merger = OrdKeyMerger<L>;
 
         fn begin_merge(&self, other: &Self, compaction_frontier: AntichainRef<layout::Time<L>>) -> Self::Merger {
@@ -1000,21 +989,11 @@ pub mod key_batch {
     }
 
     use crate::trace::implementations::LaidOut;
-    impl<L: Layout> LaidOut for OrdKeyCursor<L> {
+    impl<L: for<'a> Layout<ValContainer: BatchContainer<ReadItem<'a> = &'a ()>>> LaidOut for OrdKeyCursor<L> {
         type Layout = L;
     }
 
-    impl<L: Layout> Cursor for OrdKeyCursor<L> {
-        type Key<'a> = layout::KeyRef<'a, L>;
-        type Val<'a> = &'a ();
-        type Time = layout::Time<L>;
-        type TimeGat<'a> = layout::TimeRef<'a, L>;
-        type Diff = layout::Diff<L>;
-        type DiffGat<'a> = layout::DiffRef<'a, L>;
-
-        #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { L::TimeContainer::into_owned(time) }
-        #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { L::TimeContainer::clone_onto(time, onto) }
-        #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { L::DiffContainer::into_owned(diff) }
+    impl<L: for<'a> Layout<ValContainer: BatchContainer<ReadItem<'a> = &'a ()>>> Cursor for OrdKeyCursor<L> {
 
         type Storage = OrdKeyBatch<L>;
 

--- a/differential-dataflow/src/trace/implementations/ord_neu.rs
+++ b/differential-dataflow/src/trace/implementations/ord_neu.rs
@@ -594,6 +594,11 @@ pub mod val_batch {
         phantom: PhantomData<L>,
     }
 
+    use crate::trace::implementations::LaidOut;
+    impl<L: Layout> LaidOut for OrdValCursor<L> {
+        type Layout = L;
+    }
+
     impl<L: Layout> Cursor for OrdValCursor<L> {
 
         type Key<'a> = layout::KeyRef<'a, L>;
@@ -992,6 +997,11 @@ pub mod key_batch {
         val_stepped: bool,
         /// Phantom marker for Rust happiness.
         phantom: PhantomData<L>,
+    }
+
+    use crate::trace::implementations::LaidOut;
+    impl<L: Layout> LaidOut for OrdKeyCursor<L> {
+        type Layout = L;
     }
 
     impl<L: Layout> Cursor for OrdKeyCursor<L> {

--- a/differential-dataflow/src/trace/implementations/rhh.rs
+++ b/differential-dataflow/src/trace/implementations/rhh.rs
@@ -650,6 +650,15 @@ mod val_batch {
         phantom: PhantomData<L>,
     }
 
+    use crate::trace::implementations::LaidOut;
+    impl<L: Layout> LaidOut for RhhValCursor<L>
+    where
+        layout::Key<L>: Default + HashOrdered,
+        for<'a> layout::KeyRef<'a, L>: HashOrdered,
+    {
+        type Layout = L;
+    }
+
     impl<L: Layout> Cursor for RhhValCursor<L>
     where
         layout::Key<L>: Default + HashOrdered,

--- a/differential-dataflow/src/trace/implementations/rhh.rs
+++ b/differential-dataflow/src/trace/implementations/rhh.rs
@@ -664,17 +664,6 @@ mod val_batch {
         layout::Key<L>: Default + HashOrdered,
         for<'a> layout::KeyRef<'a, L>: HashOrdered,
     {
-        type Key<'a> = layout::KeyRef<'a, L>;
-        type Val<'a> = layout::ValRef<'a, L>;
-        type Time = layout::Time<L>;
-        type TimeGat<'a> = layout::TimeRef<'a, L>;
-        type Diff = layout::Diff<L>;
-        type DiffGat<'a> = layout::DiffRef<'a, L>;
-
-        #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { L::TimeContainer::into_owned(time) }
-        #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { L::TimeContainer::clone_onto(time, onto) }
-        #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { L::DiffContainer::into_owned(diff) }
-
         type Storage = RhhValBatch<L>;
 
         fn get_key<'a>(&self, storage: &'a RhhValBatch<L>) -> Option<Self::Key<'a>> { storage.storage.keys.get(self.key_cursor) }

--- a/differential-dataflow/src/trace/mod.rs
+++ b/differential-dataflow/src/trace/mod.rs
@@ -383,6 +383,11 @@ pub mod rc_blanket_impls {
         cursor: C,
     }
 
+    use crate::trace::implementations::LaidOut;
+    impl<C: Cursor> LaidOut for RcBatchCursor<C> {
+        type Layout = C::Layout;
+    }
+
     impl<C> RcBatchCursor<C> {
         fn new(cursor: C) -> Self {
             RcBatchCursor {

--- a/differential-dataflow/src/trace/mod.rs
+++ b/differential-dataflow/src/trace/mod.rs
@@ -21,6 +21,8 @@ use crate::lattice::Lattice;
 pub use self::cursor::Cursor;
 pub use self::description::Description;
 
+use crate::trace::implementations::LayoutExt;
+
 /// A type used to express how much effort a trace should exert even in the absence of updates.
 pub type ExertionLogic = std::sync::Arc<dyn for<'a> Fn(&'a [(usize, usize, usize)])->Option<usize>+Send+Sync>;
 
@@ -397,17 +399,6 @@ pub mod rc_blanket_impls {
     }
 
     impl<C: Cursor> Cursor for RcBatchCursor<C> {
-
-        type Key<'a> = C::Key<'a>;
-        type Val<'a> = C::Val<'a>;
-        type Time = C::Time;
-        type TimeGat<'a> = C::TimeGat<'a>;
-        type Diff = C::Diff;
-        type DiffGat<'a> = C::DiffGat<'a>;
-
-        #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { C::owned_time(time) }
-        #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { C::clone_time_onto(time, onto) }
-        #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { C::owned_diff(diff) }
 
         type Storage = Rc<C::Storage>;
 

--- a/differential-dataflow/src/trace/wrappers/enter.rs
+++ b/differential-dataflow/src/trace/wrappers/enter.rs
@@ -183,17 +183,6 @@ where
     C: Cursor,
     TInner: Refines<C::Time>+Lattice,
 {
-    type Key<'a> = C::Key<'a>;
-    type Val<'a> = C::Val<'a>;
-    type Time = TInner;
-    type TimeGat<'a> = &'a TInner;
-    type Diff = C::Diff;
-    type DiffGat<'a> = C::DiffGat<'a>;
-
-    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { time.clone() }
-    #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { onto.clone_from(time) }
-    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { C::owned_diff(diff) }
-
     type Storage = C::Storage;
 
     #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
@@ -257,17 +246,6 @@ impl<TInner, C: Cursor> Cursor for BatchCursorEnter<C, TInner>
 where
     TInner: Refines<C::Time>+Lattice,
 {
-    type Key<'a> = C::Key<'a>;
-    type Val<'a> = C::Val<'a>;
-    type Time = TInner;
-    type TimeGat<'a> = &'a TInner;
-    type Diff = C::Diff;
-    type DiffGat<'a> = C::DiffGat<'a>;
-
-    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { time.clone() }
-    #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { onto.clone_from(time) }
-    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { C::owned_diff(diff) }
-
     type Storage = BatchEnter<C::Storage, TInner>;
 
     #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }

--- a/differential-dataflow/src/trace/wrappers/enter.rs
+++ b/differential-dataflow/src/trace/wrappers/enter.rs
@@ -154,6 +154,21 @@ pub struct CursorEnter<C, TInner> {
     cursor: C,
 }
 
+use crate::trace::implementations::{Layout, LaidOut};
+impl<C, TInner> LaidOut for CursorEnter<C, TInner>
+where
+    C: Cursor,
+    TInner: Refines<C::Time>+Lattice,
+{
+    type Layout = (
+        <C::Layout as Layout>::KeyContainer,
+        <C::Layout as Layout>::ValContainer,
+        Vec<TInner>,
+        <C::Layout as Layout>::DiffContainer,
+        <C::Layout as Layout>::OffsetContainer,
+    );
+}
+
 impl<C, TInner> CursorEnter<C, TInner> {
     fn new(cursor: C) -> Self {
         CursorEnter {
@@ -222,6 +237,20 @@ impl<C, TInner> BatchCursorEnter<C, TInner> {
             cursor,
         }
     }
+}
+
+impl<C, TInner> LaidOut for BatchCursorEnter<C, TInner>
+where
+    C: Cursor,
+    TInner: Refines<C::Time>+Lattice,
+{
+    type Layout = (
+        <C::Layout as Layout>::KeyContainer,
+        <C::Layout as Layout>::ValContainer,
+        Vec<TInner>,
+        <C::Layout as Layout>::DiffContainer,
+        <C::Layout as Layout>::OffsetContainer,
+    );
 }
 
 impl<TInner, C: Cursor> Cursor for BatchCursorEnter<C, TInner>

--- a/differential-dataflow/src/trace/wrappers/enter_at.rs
+++ b/differential-dataflow/src/trace/wrappers/enter_at.rs
@@ -179,6 +179,21 @@ pub struct CursorEnter<C, TInner, F> {
     logic: F,
 }
 
+use crate::trace::implementations::{Layout, LaidOut};
+impl<C, TInner, F> LaidOut for CursorEnter<C, TInner, F>
+where
+    C: Cursor,
+    TInner: Refines<C::Time>+Lattice,
+{
+    type Layout = (
+        <C::Layout as Layout>::KeyContainer,
+        <C::Layout as Layout>::ValContainer,
+        Vec<TInner>,
+        <C::Layout as Layout>::DiffContainer,
+        <C::Layout as Layout>::OffsetContainer,
+    );
+}
+
 impl<C, TInner, F> CursorEnter<C, TInner, F> {
     fn new(cursor: C, logic: F) -> Self {
         CursorEnter {
@@ -244,6 +259,20 @@ pub struct BatchCursorEnter<C, TInner, F> {
     phantom: ::std::marker::PhantomData<TInner>,
     cursor: C,
     logic: F,
+}
+
+impl<C, TInner, F> LaidOut for BatchCursorEnter<C, TInner, F>
+where
+    C: Cursor,
+    TInner: Refines<C::Time>+Lattice,
+{
+    type Layout = (
+        <C::Layout as Layout>::KeyContainer,
+        <C::Layout as Layout>::ValContainer,
+        Vec<TInner>,
+        <C::Layout as Layout>::DiffContainer,
+        <C::Layout as Layout>::OffsetContainer,
+    );
 }
 
 impl<C, TInner, F> BatchCursorEnter<C, TInner, F> {

--- a/differential-dataflow/src/trace/wrappers/enter_at.rs
+++ b/differential-dataflow/src/trace/wrappers/enter_at.rs
@@ -131,11 +131,12 @@ pub struct BatchEnter<B, TInner, F> {
     logic: F,
 }
 
+use crate::trace::implementations::LayoutExt;
 impl<B, TInner, F> BatchReader for BatchEnter<B, TInner, F>
 where
     B: BatchReader,
     TInner: Refines<B::Time>+Lattice,
-    F: FnMut(B::Key<'_>, <B::Cursor as Cursor>::Val<'_>, B::TimeGat<'_>)->TInner+Clone,
+    F: FnMut(B::Key<'_>, <B::Cursor as LayoutExt>::Val<'_>, B::TimeGat<'_>)->TInner+Clone,
 {
     type Key<'a> = B::Key<'a>;
     type Val<'a> = B::Val<'a>;
@@ -210,17 +211,6 @@ where
     TInner: Refines<C::Time>+Lattice,
     F: FnMut(C::Key<'_>, C::Val<'_>, C::TimeGat<'_>)->TInner,
 {
-    type Key<'a> = C::Key<'a>;
-    type Val<'a> = C::Val<'a>;
-    type Time = TInner;
-    type TimeGat<'a> = &'a TInner;
-    type Diff = C::Diff;
-    type DiffGat<'a> = C::DiffGat<'a>;
-
-    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { time.clone() }
-    #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { onto.clone_from(time) }
-    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { C::owned_diff(diff) }
-
     type Storage = C::Storage;
 
     #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
@@ -290,17 +280,6 @@ where
     TInner: Refines<C::Time>+Lattice,
     F: FnMut(C::Key<'_>, C::Val<'_>, C::TimeGat<'_>)->TInner,
 {
-    type Key<'a> = C::Key<'a>;
-    type Val<'a> = C::Val<'a>;
-    type Time = TInner;
-    type TimeGat<'a> = &'a TInner;
-    type Diff = C::Diff;
-    type DiffGat<'a> = C::DiffGat<'a>;
-
-    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { time.clone() }
-    #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { onto.clone_from(time) }
-    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { C::owned_diff(diff) }
-
     type Storage = BatchEnter<C::Storage, TInner, F>;
 
     #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }

--- a/differential-dataflow/src/trace/wrappers/filter.rs
+++ b/differential-dataflow/src/trace/wrappers/filter.rs
@@ -131,17 +131,6 @@ where
     C: Cursor,
     F: FnMut(C::Key<'_>, C::Val<'_>)->bool+'static
 {
-    type Key<'a> = C::Key<'a>;
-    type Val<'a> = C::Val<'a>;
-    type Time = C::Time;
-    type TimeGat<'a> = C::TimeGat<'a>;
-    type Diff = C::Diff;
-    type DiffGat<'a> = C::DiffGat<'a>;
-
-    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { C::owned_time(time) }
-    #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { C::clone_time_onto(time, onto) }
-    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { C::owned_diff(diff) }
-
     type Storage = C::Storage;
 
     #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
@@ -197,17 +186,6 @@ impl<C: Cursor, F> Cursor for BatchCursorFilter<C, F>
 where
     F: FnMut(C::Key<'_>, C::Val<'_>)->bool+'static,
 {
-    type Key<'a> = C::Key<'a>;
-    type Val<'a> = C::Val<'a>;
-    type Time = C::Time;
-    type TimeGat<'a> = C::TimeGat<'a>;
-    type Diff = C::Diff;
-    type DiffGat<'a> = C::DiffGat<'a>;
-
-    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { C::owned_time(time) }
-    #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { C::clone_time_onto(time, onto) }
-    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { C::owned_diff(diff) }
-
     type Storage = BatchFilter<C::Storage, F>;
 
     #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }

--- a/differential-dataflow/src/trace/wrappers/filter.rs
+++ b/differential-dataflow/src/trace/wrappers/filter.rs
@@ -112,6 +112,11 @@ pub struct CursorFilter<C, F> {
     logic: F,
 }
 
+use crate::trace::implementations::LaidOut;
+impl<C: Cursor, F> LaidOut for CursorFilter<C, F> {
+    type Layout = C::Layout;
+}
+
 impl<C, F> CursorFilter<C, F> {
     fn new(cursor: C, logic: F) -> Self {
         CursorFilter {
@@ -173,6 +178,10 @@ where
 pub struct BatchCursorFilter<C, F> {
     cursor: C,
     logic: F,
+}
+
+impl<C: Cursor, F> LaidOut for BatchCursorFilter<C, F> {
+    type Layout = C::Layout;
 }
 
 impl<C, F> BatchCursorFilter<C, F> {

--- a/differential-dataflow/src/trace/wrappers/freeze.rs
+++ b/differential-dataflow/src/trace/wrappers/freeze.rs
@@ -170,6 +170,17 @@ pub struct CursorFreeze<C, F> {
     func: Rc<F>,
 }
 
+use crate::trace::implementations::{Layout, LaidOut};
+impl<C: Cursor, F> LaidOut for CursorFreeze<C, F> {
+    type Layout = (
+        <C::Layout as Layout>::KeyContainer,
+        <C::Layout as Layout>::ValContainer,
+        Vec<C::Time>,
+        <C::Layout as Layout>::DiffContainer,
+        <C::Layout as Layout>::OffsetContainer,
+    );
+}
+
 impl<C, F> CursorFreeze<C, F> {
     fn new(cursor: C, func: Rc<F>) -> Self {
         Self { cursor, func }
@@ -227,6 +238,16 @@ where
 pub struct BatchCursorFreeze<C, F> {
     cursor: C,
     func: Rc<F>,
+}
+
+impl<C: Cursor, F> LaidOut for BatchCursorFreeze<C, F> {
+    type Layout = (
+        <C::Layout as Layout>::KeyContainer,
+        <C::Layout as Layout>::ValContainer,
+        Vec<C::Time>,
+        <C::Layout as Layout>::DiffContainer,
+        <C::Layout as Layout>::OffsetContainer,
+    );
 }
 
 impl<C, F> BatchCursorFreeze<C, F> {

--- a/differential-dataflow/src/trace/wrappers/freeze.rs
+++ b/differential-dataflow/src/trace/wrappers/freeze.rs
@@ -192,17 +192,6 @@ where
     C: Cursor,
     F: Fn(C::TimeGat<'_>)->Option<C::Time>,
 {
-    type Key<'a> = C::Key<'a>;
-    type Val<'a> = C::Val<'a>;
-    type Time = C::Time;
-    type TimeGat<'a> = &'a C::Time;
-    type Diff = C::Diff;
-    type DiffGat<'a> = C::DiffGat<'a>;
-
-    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { time.clone() }
-    #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { onto.clone_from(time) }
-    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { C::owned_diff(diff) }
-
     type Storage = C::Storage;
 
     #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(storage) }
@@ -261,17 +250,6 @@ impl<C: Cursor, F> Cursor for BatchCursorFreeze<C, F>
 where
     F: Fn(C::TimeGat<'_>)->Option<C::Time>,
 {
-    type Key<'a> = C::Key<'a>;
-    type Val<'a> = C::Val<'a>;
-    type Time = C::Time;
-    type TimeGat<'a> = &'a C::Time;
-    type Diff = C::Diff;
-    type DiffGat<'a> = C::DiffGat<'a>;
-
-    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { time.clone() }
-    #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { onto.clone_from(time) }
-    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { C::owned_diff(diff) }
-
     type Storage = BatchFreeze<C::Storage, F>;
 
     #[inline] fn key_valid(&self, storage: &Self::Storage) -> bool { self.cursor.key_valid(&storage.batch) }

--- a/differential-dataflow/src/trace/wrappers/frontier.rs
+++ b/differential-dataflow/src/trace/wrappers/frontier.rs
@@ -117,6 +117,17 @@ pub struct CursorFrontier<C, T> {
     until: Antichain<T>
 }
 
+use crate::trace::implementations::{Layout, LaidOut};
+impl<C: Cursor> LaidOut for CursorFrontier<C, C::Time> {
+    type Layout = (
+        <C::Layout as Layout>::KeyContainer,
+        <C::Layout as Layout>::ValContainer,
+        Vec<C::Time>,
+        <C::Layout as Layout>::DiffContainer,
+        <C::Layout as Layout>::OffsetContainer,
+    );
+}
+
 impl<C, T: Clone> CursorFrontier<C, T> {
     fn new(cursor: C, since: AntichainRef<T>, until: AntichainRef<T>) -> Self {
         CursorFrontier {
@@ -181,6 +192,16 @@ pub struct BatchCursorFrontier<C: Cursor> {
     cursor: C,
     since: Antichain<C::Time>,
     until: Antichain<C::Time>,
+}
+
+impl<C: Cursor> LaidOut for BatchCursorFrontier<C> {
+    type Layout = (
+        <C::Layout as Layout>::KeyContainer,
+        <C::Layout as Layout>::ValContainer,
+        Vec<C::Time>,
+        <C::Layout as Layout>::DiffContainer,
+        <C::Layout as Layout>::OffsetContainer,
+    );
 }
 
 impl<C: Cursor> BatchCursorFrontier<C> {

--- a/differential-dataflow/src/trace/wrappers/frontier.rs
+++ b/differential-dataflow/src/trace/wrappers/frontier.rs
@@ -139,16 +139,6 @@ impl<C, T: Clone> CursorFrontier<C, T> {
 }
 
 impl<C: Cursor> Cursor for CursorFrontier<C, C::Time> {
-    type Key<'a> = C::Key<'a>;
-    type Val<'a> = C::Val<'a>;
-    type Time = C::Time;
-    type TimeGat<'a> = &'a C::Time;
-    type Diff = C::Diff;
-    type DiffGat<'a> = C::DiffGat<'a>;
-
-    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { time.clone() }
-    #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { onto.clone_from(time) }
-    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { C::owned_diff(diff) }
 
     type Storage = C::Storage;
 
@@ -215,16 +205,6 @@ impl<C: Cursor> BatchCursorFrontier<C> {
 }
 
 impl<C: Cursor<Storage: BatchReader>> Cursor for BatchCursorFrontier<C> {
-    type Key<'a> = C::Key<'a>;
-    type Val<'a> = C::Val<'a>;
-    type Time = C::Time;
-    type TimeGat<'a> = &'a C::Time;
-    type Diff = C::Diff;
-    type DiffGat<'a> = C::DiffGat<'a>;
-
-    #[inline(always)] fn owned_time(time: Self::TimeGat<'_>) -> Self::Time { time.clone() }
-    #[inline(always)] fn clone_time_onto(time: Self::TimeGat<'_>, onto: &mut Self::Time) { onto.clone_from(time) }
-    #[inline(always)] fn owned_diff(diff: Self::DiffGat<'_>) -> Self::Diff { C::owned_diff(diff) }
 
     type Storage = BatchFrontier<C::Storage>;
 


### PR DESCRIPTION
The intent here is to provide a `LayoutExt` extension trait for types that have a `Layout` member, to provide them with type aliases and methods on them, e.g. "owned key", "borrowed key", "borrowed to owned function".