### PR TITLE
Inline consolidate fast-path

### DIFF
--- a/differential-dataflow/src/consolidation.rs
+++ b/differential-dataflow/src/consolidation.rs
@@ -115,7 +115,7 @@ pub fn consolidate_updates_slice<D: Ord, T: Ord, R: Semigroup>(slice: &mut [(D, 
 }
 
 /// Part of `consolidate_updates_slice` that handles slices of length greater than 1.
-pub fn consolidate_updates_slice_slow<D: Ord, T: Ord, R: Semigroup>(slice: &mut [(D, T, R)]) -> usize {
+fn consolidate_updates_slice_slow<D: Ord, T: Ord, R: Semigroup>(slice: &mut [(D, T, R)]) -> usize {
     // We could do an insertion-sort like initial scan which builds up sorted, consolidated runs.
     // In a world where there are not many results, we may never even need to call in to merge sort.
     slice.sort_unstable_by(|x,y| (&x.0, &x.1).cmp(&(&y.0, &y.1)));


### PR DESCRIPTION
Gives the compiler the opportunity to inline consolidate calls for small
amounts of data by separating the complex consolidate logic for more than
one update to a different function. We don't mark the function as cold or
inline never because we want to leave the decision to the compiler.

In local testing, this shaved a few percentages of the spines example. With
the patch:
```
Running ["new"] arrangement
5.682871841s    loading complete
14.032609636s   queries complete
14.037398497s   shut down
```

With current master:
```
Running ["new"] arrangement
6.010566878s    loading complete
14.673966926s   queries complete
14.678923984s   shut down
```

Signed-off-by: Moritz Hoffmann <antiguru@gmail.com>
