### PR TITLE
Simplify type arguments to reduce, make Upds fields pub

### DIFF
--- a/differential-dataflow/src/trace/implementations/ord_neu.rs
+++ b/differential-dataflow/src/trace/implementations/ord_neu.rs
@@ -135,11 +135,11 @@ pub mod layers {
     #[derive(Debug, Serialize, Deserialize)]
     pub struct Upds<O, T, D> {
         /// Offsets used to provide indexes from values to updates.
-        offs: O,
+        pub offs: O,
         /// Concatenated ordered lists of update times, bracketed by offsets in `offs`.
-        times: T,
+        pub times: T,
         /// Concatenated ordered lists of update diffs, bracketed by offsets in `offs`.
-        diffs: D,
+        pub diffs: D,
     }
 
     impl<O: for<'a> BatchContainer<ReadItem<'a> = usize>, T: BatchContainer, D: BatchContainer> Default for Upds<O, T, D> {

--- a/interactive/src/plan/mod.rs
+++ b/interactive/src/plan/mod.rs
@@ -170,7 +170,7 @@ impl<V: ExchangeData+Hash+Datum> Render for Plan<V> {
                         input_arrangement
                     };
 
-                    let output = input.reduce_abelian::<_,_,_,KeyBuilder<_,_,_>,KeySpine<_,_,_>>("Distinct", move |_,_,t| t.push(((), 1)));
+                    let output = input.reduce_abelian::<_,KeyBuilder<_,_,_>,KeySpine<_,_,_>>("Distinct", move |_,_,t| t.push(((), 1)));
 
                     arrangements.set_unkeyed(&self, &output.trace);
                     output.as_collection(|k,&()| k.clone())


### PR DESCRIPTION
The type arguments to reduce still listed K and V, although we have the same types as KeyOwn and ValOwn on the trace. Change it to use the types defined by the trace instead.

Make the Upds fields public, in line with Vals.
