### PR TITLE
Updates for timely 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ resolver = "2"
 
 [workspace.dependencies]
 differential-dataflow = { path = "differential-dataflow", default-features = false, version = "0.17.0" }
-timely = { version = "0.24", default-features = false }
+#timely = { version = "0.24", default-features = false }
 columnar = { version = "0.10", default-features = false }
-#timely = { path = "../timely-dataflow/timely/", default-features = false }
+timely = { path = "../timely-dataflow/timely/", default-features = false }
 
 [profile.release]
 opt-level = 3

--- a/differential-dataflow/examples/columnar.rs
+++ b/differential-dataflow/examples/columnar.rs
@@ -39,8 +39,10 @@ fn main() {
             let data = data_input.to_stream(scope);
             let keys = keys_input.to_stream(scope);
 
-            let data_pact = ExchangeCore::<ColumnBuilder<((String,()),u64,i64)>,_>::new_core(|x: &((&str,()),&u64,&i64)| (x.0).0.as_bytes().iter().map(|x| *x as u64).sum::<u64>() as u64);
-            let keys_pact = ExchangeCore::<ColumnBuilder<((String,()),u64,i64)>,_>::new_core(|x: &((&str,()),&u64,&i64)| (x.0).0.as_bytes().iter().map(|x| *x as u64).sum::<u64>() as u64);
+            use differential_dataflow::Hashable;
+            use timely::dataflow::channels::pact::DistributorPact;
+            let data_pact = DistributorPact(|peers| KeyDistributor::new(peers, |k: columnar::Ref<'_, Vec<u8>>| k.hashed()));
+            let keys_pact = DistributorPact(|peers| KeyDistributor::new(peers, |k: columnar::Ref<'_, Vec<u8>>| k.hashed()));
 
             let data = arrange_core::<_,_,Col2KeyBatcher<_,_,_>, ColKeyBuilder<_,_,_>, ColKeySpine<_,_,_>>(&data, data_pact, "Data");
             let keys = arrange_core::<_,_,Col2KeyBatcher<_,_,_>, ColKeyBuilder<_,_,_>, ColKeySpine<_,_,_>>(&keys, keys_pact, "Keys");
@@ -375,6 +377,475 @@ pub mod batcher {
 
     use differential_dataflow::trace::implementations::merge_batcher::MergeBatcher;
 
+    impl<K, V, T, R> ColumnarUpdate for (K, V, T, R)
+    where
+        K: Columnar<Container: OrdContainer + Debug + Default> + Debug + Ord + Clone + 'static,
+        V: Columnar<Container: OrdContainer + Debug + Default> + Debug + Ord + Clone + 'static,
+        T: Columnar<Container: OrdContainer + Debug + Default> + Debug + Ord + Default + Clone + Lattice + Timestamp,
+        R: Columnar<Container: OrdContainer + Debug + Default> + Debug + Ord + Default + Semigroup + 'static,
+    {
+        type Key = K;
+        type Val = V;
+        type Time = T;
+        type Diff = R;
+    }
+
+    impl<K, T, R> ColumnarUpdate for (K, T, R)
+    where
+        K: Columnar<Container: OrdContainer + Debug + Default> + Debug + Ord + Clone + 'static,
+        T: Columnar<Container: OrdContainer + Debug + Default> + Debug + Ord + Default + Clone + Lattice + Timestamp,
+        R: Columnar<Container: OrdContainer + Debug + Default> + Debug + Ord + Default + Semigroup + 'static,
+    {
+        type Key = K;
+        type Val = ();
+        type Time = T;
+        type Diff = R;
+    }
+
+
+    use crate::arrangement::Coltainer;
+    impl<U: ColumnarUpdate> Layout for ColumnarLayout<U> {
+        type KeyContainer    = Coltainer<U::Key>;
+        type ValContainer    = Coltainer<U::Val>;
+        type TimeContainer   = Coltainer<U::Time>;
+        type DiffContainer   = Coltainer<U::Diff>;
+        type OffsetContainer = OffsetList;
+    }
+
+    /// A type that names constituent update types.
+    ///
+    /// We will use their associated `Columnar::Container`
+    pub trait ColumnarUpdate : Debug + 'static {
+        type Key:  Columnar<Container: OrdContainer + Debug + Default> + Debug + Ord + Clone + 'static;
+        type Val:  Columnar<Container: OrdContainer + Debug + Default> + Debug + Ord + Clone + 'static;
+        type Time: Columnar<Container: OrdContainer + Debug + Default> + Debug + Ord + Default + Clone + Lattice + Timestamp;
+        type Diff: Columnar<Container: OrdContainer + Debug + Default> + Debug + Ord + Default + Semigroup + 'static;
+    }
+
+    /// A container whose references can be ordered.
+    pub trait OrdContainer : for<'a> columnar::Container<Ref<'a> : Ord> { }
+    impl<C: for<'a> columnar::Container<Ref<'a> : Ord>> OrdContainer for C { }
+
+}
+
+pub use storage::val::ValStorage;
+pub use storage::key::KeyStorage;
+pub mod storage {
+
+    pub mod val {
+
+        use std::fmt::Debug;
+        use columnar::{Container, ContainerOf, Index, Len, Push};
+        use columnar::Vecs;
+
+        use crate::layout::ColumnarUpdate as Update;
+
+        /// Trie-shaped update storage.
+        #[derive(Debug)]
+        pub struct ValStorage<U: Update> {
+            /// An ordered list of keys.
+            pub keys: ContainerOf<U::Key>,
+            /// For each key in `keys`, a list of values.
+            pub vals: Vecs<ContainerOf<U::Val>>,
+            /// For each val in `vals`, a list of (time, diff) updates.
+            pub upds: Vecs<(ContainerOf<U::Time>, ContainerOf<U::Diff>)>,
+        }
+
+        impl<U: Update> Default for ValStorage<U> { fn default() -> Self { Self { keys: Default::default(), vals: Default::default(), upds: Default::default(), } } }
+        impl<U: Update> Clone for ValStorage<U> { fn clone(&self) -> Self { Self { keys: self.keys.clone(), vals: self.vals.clone(), upds: self.upds.clone(), } } }
+
+        pub type Tuple<U> = (<U as Update>::Key, <U as Update>::Val, <U as Update>::Time, <U as Update>::Diff);
+
+        use std::ops::Range;
+        impl<U: Update> ValStorage<U> {
+
+            /// Forms `Self` from sorted update tuples.
+            pub fn form<'a>(sorted: impl Iterator<Item = columnar::Ref<'a, Tuple<U>>>) -> Self {
+
+                let mut output = Self::default();
+                let mut sorted = sorted.peekable();
+
+                if let Some((key,val,time,diff)) = sorted.next() {
+                    output.keys.push(key);
+                    output.vals.values.push(val);
+                    output.upds.values.push((time, diff));
+                    for (key,val,time,diff) in sorted {
+                        let mut differs = false;
+                        // We would now iterate over layers.
+                        // We'll do that manually, as the types are all different.
+                        // Keys first; non-standard logic because they are not (yet) a list of lists.
+                        let keys_len = output.keys.len();
+                        differs |= ContainerOf::<U::Key>::reborrow_ref(key) != output.keys.borrow().get(keys_len-1);
+                        if differs { output.keys.push(key); }
+                        // Vals next
+                        let vals_len = output.vals.values.len();
+                        if differs { output.vals.bounds.push(vals_len as u64); }
+                        differs |= ContainerOf::<U::Val>::reborrow_ref(val) != output.vals.values.borrow().get(vals_len-1);
+                        if differs { output.vals.values.push(val); }
+                        // Upds last
+                        let upds_len = output.upds.values.len();
+                        if differs { output.upds.bounds.push(upds_len as u64); }
+                        // differs |= ContainerOf::<(U::Time,U::Diff)>::reborrow_ref((time,diff)) != output.upds.values.borrow().get(upds_len-1);
+                        differs = true;
+                        if differs { output.upds.values.push((time,diff)); }
+                    }
+                    // output.keys.bounds.push(vals_len as u64);
+                    output.vals.bounds.push(output.vals.values.len() as u64);
+                    output.upds.bounds.push(output.upds.values.len() as u64);
+                }
+
+                assert_eq!(output.keys.len(), output.vals.len());
+                assert_eq!(output.vals.values.len(), output.upds.len());
+
+                output
+            }
+
+            pub fn vals_bounds(&self, range: Range<usize>) -> Range<usize> {
+                if !range.is_empty() {
+                    let lower = if range.start == 0 { 0 } else { Index::get(self.vals.bounds.borrow(), range.start-1) as usize };
+                    let upper = Index::get(self.vals.bounds.borrow(), range.end-1) as usize;
+                    lower .. upper
+                } else { range }
+            }
+
+            pub fn upds_bounds(&self, range: Range<usize>) -> Range<usize> {
+                if !range.is_empty() {
+                    let lower = if range.start == 0 { 0 } else { Index::get(self.upds.bounds.borrow(), range.start-1) as usize };
+                    let upper = Index::get(self.upds.bounds.borrow(), range.end-1) as usize;
+                    lower .. upper
+                } else { range }
+            }
+
+            /// Copies `other[range]` into self, keys and all.
+            pub fn extend_from_keys(&mut self, other: &Self, range: Range<usize>) {
+                self.keys.extend_from_self(other.keys.borrow(), range.clone());
+                self.vals.extend_from_self(other.vals.borrow(), range.clone());
+                self.upds.extend_from_self(other.upds.borrow(), other.vals_bounds(range));
+            }
+
+            pub fn extend_from_vals(&mut self, other: &Self, range: Range<usize>) {
+                self.vals.values.extend_from_self(other.vals.values.borrow(), range.clone());
+                self.upds.extend_from_self(other.upds.borrow(), range);
+            }
+        }
+
+        impl<U: Update> timely::Accountable for ValStorage<U> {
+            #[inline] fn record_count(&self) -> i64 { use columnar::Len; self.upds.values.len() as i64 }
+        }
+
+        use timely::dataflow::channels::ContainerBytes;
+        impl<U: Update> ContainerBytes for ValStorage<U> {
+            fn from_bytes(_bytes: timely::bytes::arc::Bytes) -> Self { unimplemented!() }
+            fn length_in_bytes(&self) -> usize { unimplemented!() }
+            fn into_bytes<W: ::std::io::Write>(&self, _writer: &mut W) { unimplemented!() }
+        }
+    }
+
+    pub mod key {
+
+        use std::fmt::Debug;
+        use columnar::{Container, ContainerOf, Index, Len, Push};
+        use columnar::Vecs;
+
+        use crate::layout::ColumnarUpdate as Update;
+
+        /// Trie-shaped update storage.
+        #[derive(Debug)]
+        pub struct KeyStorage<U: Update> {
+            /// An ordered list of keys.
+            pub keys: ContainerOf<U::Key>,
+            /// For each key in `keys`, a list of (time, diff) updates.
+            pub upds: Vecs<(ContainerOf<U::Time>, ContainerOf<U::Diff>)>,
+        }
+
+        impl<U: Update> Default for KeyStorage<U> { fn default() -> Self { Self { keys: Default::default(), upds: Default::default(), } } }
+        impl<U: Update> Clone for KeyStorage<U> { fn clone(&self) -> Self { Self { keys: self.keys.clone(), upds: self.upds.clone(), } } }
+
+        pub type Tuple<U> = (<U as Update>::Key, <U as Update>::Time, <U as Update>::Diff);
+
+        use std::ops::Range;
+        impl<U: Update> KeyStorage<U> {
+
+            /// Forms `Self` from sorted update tuples.
+            pub fn form<'a>(sorted: impl Iterator<Item = columnar::Ref<'a, Tuple<U>>>) -> Self {
+
+                let mut output = Self::default();
+                let mut sorted = sorted.peekable();
+
+                if let Some((key,time,diff)) = sorted.next() {
+                    output.keys.push(key);
+                    output.upds.values.push((time, diff));
+                    for (key,time,diff) in sorted {
+                        let mut differs = false;
+                        // We would now iterate over layers.
+                        // We'll do that manually, as the types are all different.
+                        // Keys first; non-standard logic because they are not (yet) a list of lists.
+                        let keys_len = output.keys.len();
+                        differs |= ContainerOf::<U::Key>::reborrow_ref(key) != output.keys.borrow().get(keys_len-1);
+                        if differs { output.keys.push(key); }
+                        // Upds last
+                        let upds_len = output.upds.values.len();
+                        if differs { output.upds.bounds.push(upds_len as u64); }
+                        // differs |= ContainerOf::<(U::Time,U::Diff)>::reborrow_ref((time,diff)) != output.upds.values.borrow().get(upds_len-1);
+                        differs = true;
+                        if differs { output.upds.values.push((time,diff)); }
+                    }
+                    output.upds.bounds.push(output.upds.values.len() as u64);
+                }
+
+                assert_eq!(output.keys.len(), output.upds.len());
+
+                output
+            }
+
+            pub fn upds_bounds(&self, range: Range<usize>) -> Range<usize> {
+                if !range.is_empty() {
+                    let lower = if range.start == 0 { 0 } else { Index::get(self.upds.bounds.borrow(), range.start-1) as usize };
+                    let upper = Index::get(self.upds.bounds.borrow(), range.end-1) as usize;
+                    lower .. upper
+                } else { range }
+            }
+
+            /// Copies `other[range]` into self, keys and all.
+            pub fn extend_from_keys(&mut self, other: &Self, range: Range<usize>) {
+                self.keys.extend_from_self(other.keys.borrow(), range.clone());
+                self.upds.extend_from_self(other.upds.borrow(), range.clone());
+            }
+        }
+
+        impl<U: Update> timely::Accountable for KeyStorage<U> {
+            #[inline] fn record_count(&self) -> i64 { use columnar::Len; self.upds.values.len() as i64 }
+        }
+
+        use timely::dataflow::channels::ContainerBytes;
+        impl<U: Update> ContainerBytes for KeyStorage<U> {
+            fn from_bytes(_bytes: timely::bytes::arc::Bytes) -> Self { unimplemented!() }
+            fn length_in_bytes(&self) -> usize { unimplemented!() }
+            fn into_bytes<W: ::std::io::Write>(&self, _writer: &mut W) { unimplemented!() }
+        }
+    }
+}
+
+pub use column_builder::{val::ValBuilder as ValColBuilder, key::KeyBuilder as KeyColBuilder};
+mod column_builder {
+
+    pub mod val {
+
+        use std::collections::VecDeque;
+        use columnar::{Columnar, Clear, Len, Push};
+
+        use crate::layout::ColumnarUpdate as Update;
+        use crate::ValStorage;
+
+        type TupleContainer<U> = <(<U as Update>::Key, <U as Update>::Val, <U as Update>::Time, <U as Update>::Diff) as Columnar>::Container;
+
+        /// A container builder for `Column<C>`.
+        pub struct ValBuilder<U: Update> {
+            /// Container that we're writing to.
+            current: TupleContainer<U>,
+            /// Empty allocation.
+            empty: Option<ValStorage<U>>,
+            /// Completed containers pending to be sent.
+            pending: VecDeque<ValStorage<U>>,
+        }
+
+        use timely::container::PushInto;
+        impl<T, U: Update> PushInto<T> for ValBuilder<U> where TupleContainer<U> : Push<T> {
+            #[inline]
+            fn push_into(&mut self, item: T) {
+                self.current.push(item);
+                if self.current.len() > 1024 {
+                    // TODO: Consolidate the batch?
+                    use columnar::{Container, Index};
+                    let mut refs = self.current.borrow().into_index_iter().collect::<Vec<_>>();
+                    refs.sort();
+                    let storage = ValStorage::form(refs.into_iter());
+                    self.pending.push_back(storage);
+                    self.current.clear();
+                }
+            }
+        }
+
+        impl<U: Update> Default for ValBuilder<U> {
+            fn default() -> Self {
+                ValBuilder {
+                    current: Default::default(),
+                    empty: None,
+                    pending: Default::default(),
+                }
+            }
+        }
+
+        use timely::container::{ContainerBuilder, LengthPreservingContainerBuilder};
+        impl<U: Update> ContainerBuilder for ValBuilder<U> {
+            type Container = ValStorage<U>;
+
+            #[inline]
+            fn extract(&mut self) -> Option<&mut Self::Container> {
+                if let Some(container) = self.pending.pop_front() {
+                    self.empty = Some(container);
+                    self.empty.as_mut()
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn finish(&mut self) -> Option<&mut Self::Container> {
+                if !self.current.is_empty() {
+                    // TODO: Consolidate the batch?
+                    use columnar::{Container, Index};
+                    let mut refs = self.current.borrow().into_index_iter().collect::<Vec<_>>();
+                    refs.sort();
+                    let storage = ValStorage::form(refs.into_iter());
+                    self.pending.push_back(storage);
+                    self.current.clear();
+                }
+                self.empty = self.pending.pop_front();
+                self.empty.as_mut()
+            }
+        }
+
+        impl<U: Update> LengthPreservingContainerBuilder for ValBuilder<U> { }
+    }
+
+    pub mod key {
+
+        use std::collections::VecDeque;
+        use columnar::{Columnar, Clear, Len, Push};
+
+        use crate::layout::ColumnarUpdate as Update;
+        use crate::KeyStorage;
+
+        type TupleContainer<U> = <(<U as Update>::Key, <U as Update>::Time, <U as Update>::Diff) as Columnar>::Container;
+
+        /// A container builder for `Column<C>`.
+        pub struct KeyBuilder<U: Update> {
+            /// Container that we're writing to.
+            current: TupleContainer<U>,
+            /// Empty allocation.
+            empty: Option<KeyStorage<U>>,
+            /// Completed containers pending to be sent.
+            pending: VecDeque<KeyStorage<U>>,
+        }
+
+        use timely::container::PushInto;
+        impl<T, U: Update> PushInto<T> for KeyBuilder<U> where TupleContainer<U> : Push<T> {
+            #[inline]
+            fn push_into(&mut self, item: T) {
+                self.current.push(item);
+                if self.current.len() > 1024 {
+                    // TODO: Consolidate the batch?
+                    use columnar::{Container, Index};
+                    let mut refs = self.current.borrow().into_index_iter().collect::<Vec<_>>();
+                    refs.sort();
+                    let storage = KeyStorage::form(refs.into_iter());
+                    self.pending.push_back(storage);
+                    self.current.clear();
+                }
+            }
+        }
+
+        impl<U: Update> Default for KeyBuilder<U> { fn default() -> Self { KeyBuilder { current: Default::default(), empty: None, pending: Default::default(), } } }
+
+        use timely::container::{ContainerBuilder, LengthPreservingContainerBuilder};
+        impl<U: Update> ContainerBuilder for KeyBuilder<U> {
+            type Container = KeyStorage<U>;
+
+            #[inline]
+            fn extract(&mut self) -> Option<&mut Self::Container> {
+                if let Some(container) = self.pending.pop_front() {
+                    self.empty = Some(container);
+                    self.empty.as_mut()
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn finish(&mut self) -> Option<&mut Self::Container> {
+                if !self.current.is_empty() {
+                    // TODO: Consolidate the batch?
+                    use columnar::{Container, Index};
+                    let mut refs = self.current.borrow().into_index_iter().collect::<Vec<_>>();
+                    refs.sort();
+                    let storage = KeyStorage::form(refs.into_iter());
+                    self.pending.push_back(storage);
+                    self.current.clear();
+                }
+                self.empty = self.pending.pop_front();
+                self.empty.as_mut()
+            }
+        }
+
+        impl<U: Update> LengthPreservingContainerBuilder for KeyBuilder<U> { }
+    }
+}
+
+use distributor::key::KeyDistributor;
+mod distributor {
+
+    pub mod key {
+
+        use columnar::{Container, Index, Len};
+        use timely::container::{ContainerBuilder, PushInto};
+        use timely::dataflow::channels::{Message, pushers::exchange::Distributor};
+
+        use crate::layout::ColumnarUpdate as Update;
+        use crate::{KeyColBuilder, KeyStorage};
+
+        pub struct KeyDistributor<U: Update, H> {
+            builders: Vec<KeyColBuilder<U>>,
+            hashfunc: H,
+        }
+
+        impl<U: Update, H: for<'a> FnMut(columnar::Ref<'a, U::Key>)->u64> Distributor<KeyStorage<U>> for KeyDistributor<U, H> {
+            fn partition<T: Clone, P: timely::communication::Push<Message<T, KeyStorage<U>>>>(&mut self, container: &mut KeyStorage<U>, time: &T, pushers: &mut [P]) {
+                // For each key, partition and copy (key, time, diff) into the appropriate self.builder.
+                for index in 0 .. container.keys.len() {
+                    let key = container.keys.borrow().get(index);
+                    let idx = ((self.hashfunc)(key) as usize) % self.builders.len();
+                    for (t, diff) in container.upds.borrow().get(index).into_index_iter() {
+                        self.builders[idx].push_into((key, t, diff));
+                    }
+                    while let Some(produced) = self.builders[idx].extract() {
+                        Message::push_at(produced, time.clone(), &mut pushers[idx]);
+                    }
+                }
+            }
+            fn flush<T: Clone, P: timely::communication::Push<Message<T, KeyStorage<U>>>>(&mut self, time: &T, pushers: &mut [P]) {
+                for (builder, pusher) in self.builders.iter_mut().zip(pushers.iter_mut()) {
+                    while let Some(container) = builder.finish() {
+                        Message::push_at(container, time.clone(), pusher);
+                    }
+                }
+            }
+            fn relax(&mut self) { }
+        }
+
+        impl<U: Update, H> KeyDistributor<U, H> {
+            pub fn new(peers: usize, hashfunc: H) -> Self {
+                Self {
+                    builders: std::iter::repeat_with(Default::default).take(peers).collect(),
+                    hashfunc,
+                }
+            }
+        }
+    }
+}
+
+pub use arrangement::{ValBatcher, ValBuilder, ValSpine, KeyBatcher, KeyBuilder, KeySpine};
+pub mod arrangement {
+
+    use std::rc::Rc;
+    use differential_dataflow::trace::implementations::ord_neu::{OrdValBatch, OrdKeyBatch};
+    use differential_dataflow::trace::rc_blanket_impls::RcBuilder;
+    use differential_dataflow::trace::implementations::spine_fueled::Spine;
+
+    use crate::layout::ColumnarLayout;
+
+    /// A trace implementation backed by columnar storage.
+    pub type ValSpine<K, V, T, R> = Spine<Rc<OrdValBatch<ColumnarLayout<(K,V,T,R)>>>>;
     /// A batcher for columnar storage.
     pub type Col2ValBatcher<K, V, T, R> = MergeBatcher<Column<((K,V),T,R)>, Chunker<Column<((K,V),T,R)>>, merger::ColumnMerger<(K,V),T,R>>;
     pub type Col2KeyBatcher<K, T, R> = Col2ValBatcher<K, (), T, R>;

--- a/differential-dataflow/examples/multitemporal.rs
+++ b/differential-dataflow/examples/multitemporal.rs
@@ -59,7 +59,8 @@ fn main() {
                             let time = Pair::new(arguments[1], arguments[2]);
                             if capability.time().less_equal(&time) {
                                 input
-                                    .session(capability.clone())
+                                    .activate()
+                                    .session(&capability)
                                     .give((arguments[0], time, arguments[3]));
                             } else {
                                 println!("Requested time {:?} no longer open (input from {:?})", time, capability.time());

--- a/differential-dataflow/examples/progress.rs
+++ b/differential-dataflow/examples/progress.rs
@@ -121,7 +121,7 @@ fn frontier<G, T>(
 ) -> Collection<G, (Location, T)>
 where
     G: Scope<Timestamp: Lattice+Ord>,
-    T: Timestamp<Summary: differential_dataflow::ExchangeData>,
+    T: Timestamp<Summary: differential_dataflow::ExchangeData>+std::hash::Hash,
 {
     // Translate node and edge transitions into a common Location to Location edge with an associated Summary.
     let nodes = nodes.map(|(target, source, summary)| (Location::from(target), (Location::from(source), summary)));

--- a/differential-dataflow/src/algorithms/graphs/propagate.rs
+++ b/differential-dataflow/src/algorithms/graphs/propagate.rs
@@ -16,7 +16,7 @@ use crate::operators::arrange::arrangement::ArrangeByKey;
 /// method to limit the introduction of labels.
 pub fn propagate<G, N, L, R>(edges: &Collection<G, (N,N), R>, nodes: &Collection<G,(N,L),R>) -> Collection<G,(N,L),R>
 where
-    G: Scope<Timestamp: Lattice+Ord>,
+    G: Scope<Timestamp: Lattice+Ord+Hash>,
     N: ExchangeData+Hash,
     R: ExchangeData+Abelian,
     R: Multiply<R, Output=R>,
@@ -33,7 +33,7 @@ where
 /// method to limit the introduction of labels.
 pub fn propagate_at<G, N, L, F, R>(edges: &Collection<G, (N,N), R>, nodes: &Collection<G,(N,L),R>, logic: F) -> Collection<G,(N,L),R>
 where
-    G: Scope<Timestamp: Lattice+Ord>,
+    G: Scope<Timestamp: Lattice+Ord+Hash>,
     N: ExchangeData+Hash,
     R: ExchangeData+Abelian,
     R: Multiply<R, Output=R>,
@@ -60,7 +60,7 @@ where
     R: Multiply<R, Output=R>,
     R: From<i8>,
     L: ExchangeData,
-    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Diff=R>+Clone+'static,
+    Tr: for<'a> TraceReader<Key<'a>=&'a N, Val<'a>=&'a N, Time:Hash, Diff=R>+Clone+'static,
     F: Fn(&L)->u64+Clone+'static,
 {
     // Morally the code performs the following iterative computation. However, in the interest of a simplified

--- a/differential-dataflow/src/algorithms/graphs/scc.rs
+++ b/differential-dataflow/src/algorithms/graphs/scc.rs
@@ -35,7 +35,7 @@ where
 /// Returns the subset of edges in the same strongly connected component.
 pub fn strongly_connected<G, N, R>(graph: &Collection<G, (N,N), R>) -> Collection<G, (N,N), R>
 where
-    G: Scope<Timestamp: Lattice + Ord>,
+    G: Scope<Timestamp: Lattice+Ord+Hash>,
     N: ExchangeData + Hash,
     R: ExchangeData + Abelian,
     R: Multiply<R, Output=R>,
@@ -51,7 +51,7 @@ where
 fn trim_edges<G, N, R>(cycle: &Collection<G, (N,N), R>, edges: &Collection<G, (N,N), R>)
     -> Collection<G, (N,N), R>
 where
-    G: Scope<Timestamp: Lattice+Ord>,
+    G: Scope<Timestamp: Lattice+Ord+Hash>,
     N: ExchangeData + Hash,
     R: ExchangeData + Abelian,
     R: Multiply<R, Output=R>,

--- a/differential-dataflow/src/algorithms/graphs/sequential.rs
+++ b/differential-dataflow/src/algorithms/graphs/sequential.rs
@@ -11,7 +11,7 @@ use crate::hashable::Hashable;
 
 fn _color<G, N>(edges: &Collection<G, (N,N)>) -> Collection<G,(N,Option<u32>)>
 where
-    G: Scope<Timestamp: Lattice+Ord>,
+    G: Scope<Timestamp: Lattice+Ord+Hash>,
     N: ExchangeData+Hash,
 {
     // need some bogus initial values.

--- a/differential-dataflow/src/collection.rs
+++ b/differential-dataflow/src/collection.rs
@@ -207,7 +207,7 @@ impl<G: Scope, D, R, C: Container> Collection<G, D, R, C> {
     // TODO: Removing this function is possible, but breaks existing callers of `negate` who expect
     //       an inherent method on `Collection`.
     pub fn negate(&self) -> Collection<G, D, R, C>
-    where 
+    where
         StreamCore<G, C>: crate::operators::Negate<G, C>
     {
         crate::operators::Negate::negate(&self.inner).as_collection()
@@ -455,6 +455,7 @@ impl<G: Scope, D: Clone+'static, R: Clone+'static> Collection<G, D, R> {
     /// to all of the data timestamps).
     pub fn delay<F>(&self, func: F) -> Collection<G, D, R>
     where
+        G::Timestamp: Hash,
         F: FnMut(&G::Timestamp) -> G::Timestamp + Clone + 'static,
     {
         let mut func1 = func.clone();

--- a/differential-dataflow/src/containers.rs
+++ b/differential-dataflow/src/containers.rs
@@ -268,8 +268,6 @@ impl<T: Columnation> PushInto<&&T> for TimelyStack<T> {
 }
 
 mod container {
-    use std::ops::Deref;
-
     use columnation::Columnation;
 
     use crate::containers::TimelyStack;
@@ -277,11 +275,6 @@ mod container {
     impl<T: Columnation> timely::container::Accountable for TimelyStack<T> {
         #[inline] fn record_count(&self) -> i64 { i64::try_from(self.local.len()).unwrap() }
         #[inline] fn is_empty(&self) -> bool { self.local.is_empty() }
-    }
-    impl<T: Columnation> timely::container::IterContainer for TimelyStack<T> {
-        type ItemRef<'a> = &'a T where Self: 'a;
-        type Iter<'a> = std::slice::Iter<'a, T> where Self: 'a;
-        #[inline] fn iter(&self) -> Self::Iter<'_> { self.deref().iter() }
     }
     impl<T: Columnation> timely::container::DrainContainer for TimelyStack<T> {
         type Item<'a> = &'a T where Self: 'a;

--- a/differential-dataflow/src/dynamic/mod.rs
+++ b/differential-dataflow/src/dynamic/mod.rs
@@ -1,22 +1,22 @@
 //! Types and operators for dynamically scoped iterative dataflows.
-//! 
+//!
 //! Scopes in timely dataflow are expressed statically, as part of the type system.
 //! This affords many efficiencies, as well as type-driven reassurance of correctness.
 //! However, there are times you need scopes whose organization is discovered only at runtime.
 //! Naiad and Materialize are examples: the latter taking arbitrary SQL into iterative dataflows.
-//! 
-//! This module provides a timestamp type `Pointstamp` that can represent an update with an 
+//!
+//! This module provides a timestamp type `Pointstamp` that can represent an update with an
 //! unboundedly long sequence of some `T: Timestamp`, ordered by the product order by which times
-//! in iterative dataflows are ordered. The module also provides methods for manipulating these 
+//! in iterative dataflows are ordered. The module also provides methods for manipulating these
 //! timestamps to emulate the movement of update streams in to, within, and out of iterative scopes.
-//! 
+//!
 
 pub mod pointstamp;
 
 use timely::dataflow::Scope;
 use timely::order::Product;
 use timely::progress::Timestamp;
-use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
+use timely::dataflow::operators::generic::{OutputBuilder, builder_rc::OperatorBuilder};
 use timely::dataflow::channels::pact::Pipeline;
 use timely::progress::Antichain;
 
@@ -42,7 +42,8 @@ where
     pub fn leave_dynamic(&self, level: usize) -> Self {
         // Create a unary operator that will strip all but `level-1` timestamp coordinates.
         let mut builder = OperatorBuilder::new("LeaveDynamic".to_string(), self.scope());
-        let (mut output, stream) = builder.new_output();
+        let (output, stream) = builder.new_output();
+        let mut output = OutputBuilder::from(output);
         let mut input = builder.new_input_connection(&self.inner, Pipeline, [(0, Antichain::from_elem(Product { outer: Default::default(), inner: PointStampSummary { retain: Some(level - 1), actions: Vec::new() } }))]);
 
         builder.build(move |_capability| move |_frontier| {
@@ -67,7 +68,7 @@ where
 }
 
 /// Produces the summary for a feedback operator at `level`, applying `summary` to that coordinate.
-pub fn feedback_summary<T>(level: usize, summary: T::Summary) -> PointStampSummary<T::Summary> 
+pub fn feedback_summary<T>(level: usize, summary: T::Summary) -> PointStampSummary<T::Summary>
 where
     T: Timestamp+Default,
 {

--- a/differential-dataflow/src/operators/count.rs
+++ b/differential-dataflow/src/operators/count.rs
@@ -73,7 +73,7 @@ where
             let mut lower_limit = timely::progress::frontier::Antichain::from_elem(<G::Timestamp as timely::progress::Timestamp>::minimum());
             let mut upper_limit = timely::progress::frontier::Antichain::from_elem(<G::Timestamp as timely::progress::Timestamp>::minimum());
 
-            move |input, output| {
+            move |(input, _frontier), output| {
 
                 let mut batch_cursors = Vec::new();
                 let mut batch_storage = Vec::new();

--- a/differential-dataflow/src/operators/join.rs
+++ b/differential-dataflow/src/operators/join.rs
@@ -10,12 +10,9 @@ use timely::container::{ContainerBuilder, PushInto};
 use timely::order::PartialOrder;
 use timely::progress::Timestamp;
 use timely::dataflow::{Scope, StreamCore};
-use timely::dataflow::operators::generic::{Operator, OutputHandleCore};
+use timely::dataflow::operators::generic::{Operator, OutputBuilderSession, Session};
 use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::channels::pushers::buffer::Session;
-use timely::dataflow::channels::pushers::Counter;
 use timely::dataflow::operators::Capability;
-use timely::dataflow::channels::pushers::tee::Tee;
 
 use crate::hashable::Hashable;
 use crate::{Data, ExchangeData, Collection};
@@ -312,7 +309,7 @@ where
 }
 
 /// The session passed to join closures.
-pub type JoinSession<'a, T, CB, C> = Session<'a, T, EffortBuilder<CB>, Counter<T, C, Tee<T, C>>>;
+pub type JoinSession<'a, 'b, T, CB, CT> = Session<'a, 'b, T, EffortBuilder<CB>, CT>;
 
 /// A container builder that tracks the length of outputs to estimate the effort of join closures.
 #[derive(Default, Debug)]
@@ -361,7 +358,7 @@ where
     G: Scope<Timestamp=T1::Time>,
     T1: TraceReader+Clone+'static,
     T2: for<'a> TraceReader<Key<'a>=T1::Key<'a>, Time=T1::Time>+Clone+'static,
-    L: FnMut(T1::Key<'_>,T1::Val<'_>,T2::Val<'_>,&G::Timestamp,&T1::Diff,&T2::Diff,&mut JoinSession<T1::Time, CB, CB::Container>)+'static,
+    L: FnMut(T1::Key<'_>,T1::Val<'_>,T2::Val<'_>,&G::Timestamp,&T1::Diff,&T2::Diff,&mut JoinSession<T1::Time, CB, Capability<T1::Time>>)+'static,
     CB: ContainerBuilder,
 {
     // Rename traces for symmetry from here on out.
@@ -436,7 +433,7 @@ where
         let mut trace1_option = Some(trace1);
         let mut trace2_option = Some(trace2);
 
-        move |input1, input2, output| {
+        move |(input1, frontier1), (input2, frontier2), output| {
 
             // 1. Consuming input.
             //
@@ -561,12 +558,12 @@ where
 
             // Maintain `trace1`. Drop if `input2` is empty, or advance based on future needs.
             if let Some(trace1) = trace1_option.as_mut() {
-                if input2.frontier().is_empty() { trace1_option = None; }
+                if frontier2.is_empty() { trace1_option = None; }
                 else {
                     // Allow `trace1` to compact logically up to the frontier we may yet receive,
                     // in the opposing input (`input2`). All `input2` times will be beyond this
                     // frontier, and joined times only need to be accurate when advanced to it.
-                    trace1.set_logical_compaction(input2.frontier().frontier());
+                    trace1.set_logical_compaction(frontier2.frontier());
                     // Allow `trace1` to compact physically up to the upper bound of batches we
                     // have received in its input (`input1`). We will not require a cursor that
                     // is not beyond this bound.
@@ -576,12 +573,12 @@ where
 
             // Maintain `trace2`. Drop if `input1` is empty, or advance based on future needs.
             if let Some(trace2) = trace2_option.as_mut() {
-                if input1.frontier().is_empty() { trace2_option = None;}
+                if frontier1.is_empty() { trace2_option = None;}
                 else {
                     // Allow `trace2` to compact logically up to the frontier we may yet receive,
                     // in the opposing input (`input1`). All `input1` times will be beyond this
                     // frontier, and joined times only need to be accurate when advanced to it.
-                    trace2.set_logical_compaction(input1.frontier().frontier());
+                    trace2.set_logical_compaction(frontier1.frontier());
                     // Allow `trace2` to compact physically up to the upper bound of batches we
                     // have received in its input (`input2`). We will not require a cursor that
                     // is not beyond this bound.
@@ -635,9 +632,9 @@ where
 
     /// Process keys until at least `fuel` output tuples produced, or the work is exhausted.
     #[inline(never)]
-    fn work<L, CB: ContainerBuilder>(&mut self, output: &mut OutputHandleCore<T, EffortBuilder<CB>, Tee<T, CB::Container>>, mut logic: L, fuel: &mut usize)
+    fn work<L, CB: ContainerBuilder>(&mut self, output: &mut OutputBuilderSession<T, EffortBuilder<CB>>, mut logic: L, fuel: &mut usize)
     where
-        L: for<'a> FnMut(C1::Key<'a>, C1::Val<'a>, C2::Val<'a>, &T, &C1::Diff, &C2::Diff, &mut JoinSession<T, CB, CB::Container>),
+        L: for<'a> FnMut(C1::Key<'a>, C1::Val<'a>, C2::Val<'a>, &T, &C1::Diff, &C2::Diff, &mut JoinSession<T, CB, Capability<T>>),
     {
 
         let meet = self.capability.time();

--- a/differential-dataflow/src/operators/reduce.rs
+++ b/differential-dataflow/src/operators/reduce.rs
@@ -365,7 +365,7 @@ where
 
             let id = trace.stream.scope().index();
 
-            move |input, output| {
+            move |(input, _frontier), output| {
 
                 // The `reduce` operator receives fully formed batches, which each serve as an indication
                 // that the frontier has advanced to the upper bound of their description.

--- a/differential-dataflow/src/operators/threshold.rs
+++ b/differential-dataflow/src/operators/threshold.rs
@@ -123,7 +123,7 @@ where
             let mut lower_limit = timely::progress::frontier::Antichain::from_elem(<G::Timestamp as timely::progress::Timestamp>::minimum());
             let mut upper_limit = timely::progress::frontier::Antichain::from_elem(<G::Timestamp as timely::progress::Timestamp>::minimum());
 
-            move |input, output| {
+            move |(input, _frontier), output| {
 
                 let mut batch_cursors = Vec::new();
                 let mut batch_storage = Vec::new();

--- a/dogsdogsdogs/examples/delta_query2.rs
+++ b/dogsdogsdogs/examples/delta_query2.rs
@@ -36,8 +36,8 @@ fn main() {
                 use differential_dogs3::operators::half_join;
 
                 // pick a frontier that will not mislead TOTAL ORDER comparisons.
-                let closure = |time: &Product<usize, usize>, antichain: &mut timely::progress::Antichain<Product<usize, usize>>| { 
-                    antichain.insert(Product::new(time.outer.saturating_sub(1), time.inner.saturating_sub(1))); 
+                let closure = |time: &Product<usize, usize>, antichain: &mut timely::progress::Antichain<Product<usize, usize>>| {
+                    antichain.insert(Product::new(time.outer.saturating_sub(1), time.inner.saturating_sub(1)));
                 };
 
                 let path1 =
@@ -70,11 +70,13 @@ fn main() {
         });
 
         i1
-            .session(c1.clone())
+            .activate()
+            .session(&c1)
             .give(((5, 6), Product::new(0, 13), 1));
 
         i2
-            .session(c2.clone())
+            .activate()
+            .session(&c2)
             .give(((5, 7), Product::new(11, 0), 1));
 
     }).unwrap();

--- a/dogsdogsdogs/src/lib.rs
+++ b/dogsdogsdogs/src/lib.rs
@@ -181,7 +181,7 @@ where
 
 impl<G, K, V, R, P, F> PrefixExtender<G, R> for CollectionExtender<K, V, G::Timestamp, R, P, F>
 where
-    G: Scope<Timestamp: Lattice+ExchangeData>,
+    G: Scope<Timestamp: Lattice+ExchangeData+Hash>,
     K: ExchangeData+Hash+Default,
     V: ExchangeData+Hash+Default,
     P: ExchangeData,

--- a/dogsdogsdogs/src/operators/count.rs
+++ b/dogsdogsdogs/src/operators/count.rs
@@ -19,7 +19,7 @@ pub fn count<G, Tr, K, R, F, P>(
 ) -> Collection<G, (P, usize, usize), R>
 where
     G: Scope<Timestamp=Tr::Time>,
-    Tr: TraceReader<KeyOwn = K, Diff=isize>+Clone+'static,
+    Tr: TraceReader<KeyOwn = K, Time: std::hash::Hash, Diff=isize>+Clone+'static,
     for<'a> Tr::Diff : Semigroup<Tr::DiffGat<'a>>,
     K: Hashable + Ord + Default + 'static,
     R: Monoid+Multiply<Output = R>+ExchangeData,

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -38,9 +38,7 @@ use std::time::Instant;
 use timely::container::{CapacityContainerBuilder, ContainerBuilder};
 use timely::dataflow::{Scope, ScopeParent, StreamCore};
 use timely::dataflow::channels::pact::{Pipeline, Exchange};
-use timely::dataflow::channels::pushers::buffer::Session;
-use timely::dataflow::channels::pushers::{Counter as PushCounter, Tee};
-use timely::dataflow::operators::Operator;
+use timely::dataflow::operators::{Capability, Operator, generic::Session};
 use timely::progress::Antichain;
 use timely::progress::frontier::AntichainRef;
 
@@ -86,7 +84,7 @@ where
     K: Hashable + ExchangeData,
     V: ExchangeData,
     R: ExchangeData + Monoid,
-    Tr: TraceReader<KeyOwn = K>+Clone+'static,
+    Tr: TraceReader<KeyOwn = K, Time: std::hash::Hash>+Clone+'static,
     R: Mul<Tr::Diff, Output: Semigroup>,
     FF: Fn(&G::Timestamp, &mut Antichain<G::Timestamp>) + 'static,
     CF: Fn(Tr::TimeGat<'_>, &G::Timestamp) -> bool + 'static,
@@ -107,15 +105,11 @@ where
 /// A session with lifetime `'a` in a scope `G` with a container builder `CB`.
 ///
 /// This is a shorthand primarily for the reson of readability.
-type SessionFor<'a, G, CB> =
-    Session<'a,
+type SessionFor<'a, 'b, G, CB> =
+    Session<'a, 'b,
         <G as ScopeParent>::Timestamp,
         CB,
-        PushCounter<
-            <G as ScopeParent>::Timestamp,
-            <CB as ContainerBuilder>::Container,
-            Tee<<G as ScopeParent>::Timestamp, <CB as ContainerBuilder>::Container>
-        >
+        Capability<<G as ScopeParent>::Timestamp>,
     >;
 
 /// An unsafe variant of `half_join` where the `output_func` closure takes
@@ -156,7 +150,7 @@ where
     K: Hashable + ExchangeData,
     V: ExchangeData,
     R: ExchangeData + Monoid,
-    Tr: for<'a> TraceReader<KeyOwn = K>+Clone+'static,
+    Tr: for<'a> TraceReader<KeyOwn = K, Time: std::hash::Hash>+Clone+'static,
     FF: Fn(&G::Timestamp, &mut Antichain<G::Timestamp>) + 'static,
     CF: Fn(Tr::TimeGat<'_>, &Tr::Time) -> bool + 'static,
     Y: Fn(std::time::Instant, usize) -> bool + 'static,
@@ -180,7 +174,7 @@ where
         // Acquire an activator to reschedule the operator when it has unfinished work.
         let activator = stream.scope().activator_for(info.address);
 
-        move |input1, input2, output| {
+        move |(input1, frontier1), (input2, frontier2), output| {
 
             // drain the first input, stashing requests.
             input1.for_each(|capability, data| {
@@ -211,9 +205,9 @@ where
                     // Avoid computation if we should already yield.
                     // TODO: Verify this is correct for TOTAL ORDER.
                     yielded = yielded || yield_function(timer, work);
-                    if !yielded && !input2.frontier.less_equal(capability.time()) {
+                    if !yielded && !frontier2.less_equal(capability.time()) {
 
-                        let frontier = input2.frontier.frontier();
+                        let frontier = frontier2.frontier();
 
                         // Update yielded: We can only go from false to {false, true} as
                         // we're checking that `!yielded` holds before entering this block.
@@ -278,7 +272,7 @@ where
 
             // The logical merging frontier depends on both input1 and stash.
             let mut frontier = timely::progress::frontier::Antichain::new();
-            for time in input1.frontier().frontier().iter() {
+            for time in frontier1.frontier().iter() {
                 frontier_func(time, &mut frontier);
             }
             for time in stash.keys() {
@@ -286,7 +280,7 @@ where
             }
             arrangement_trace.as_mut().map(|trace| trace.set_logical_compaction(frontier.borrow()));
 
-            if input1.frontier().is_empty() && stash.is_empty() {
+            if frontier1.is_empty() && stash.is_empty() {
                 arrangement_trace = None;
             }
         }

--- a/dogsdogsdogs/src/operators/propose.rs
+++ b/dogsdogsdogs/src/operators/propose.rs
@@ -23,6 +23,7 @@ where
     Tr: for<'a> TraceReader<
         KeyOwn = K,
         ValOwn = V,
+        Time: std::hash::Hash,
         Diff: Monoid+Multiply<Output = Tr::Diff>+ExchangeData+Semigroup<Tr::DiffGat<'a>>,
     >+Clone+'static,
     K: Hashable + Default + Ord + 'static,
@@ -56,6 +57,7 @@ where
     Tr: for<'a> TraceReader<
         KeyOwn = K,
         ValOwn = V,
+        Time: std::hash::Hash,
         Diff : Semigroup<Tr::DiffGat<'a>>+Monoid+Multiply<Output = Tr::Diff>+ExchangeData,
     >+Clone+'static,
     K: Hashable + Default + Ord + 'static,

--- a/dogsdogsdogs/src/operators/validate.rs
+++ b/dogsdogsdogs/src/operators/validate.rs
@@ -21,6 +21,7 @@ where
     G: Scope<Timestamp=Tr::Time>,
     Tr: for<'a> TraceReader<
         KeyOwn = (K, V),
+        Time: std::hash::Hash,
         Diff : Semigroup<Tr::DiffGat<'a>>+Monoid+Multiply<Output = Tr::Diff>+ExchangeData,
     >+Clone+'static,
     K: Ord+Hash+Clone+Default + 'static,

--- a/experiments/src/bin/graphs-interactive-alt.rs
+++ b/experiments/src/bin/graphs-interactive-alt.rs
@@ -364,7 +364,7 @@ where G::Timestamp: Lattice+Ord {
 
 
 fn connected_components<G: Scope>(graph: &Arrange<G, Node, Node, isize>) -> Collection<G, (Node, Node)>
-where G::Timestamp: Lattice {
+where G::Timestamp: Lattice+std::hash::Hash {
 
     // each edge (x,y) means that we need at least a label for the min of x and y.
     let nodes =

--- a/experiments/src/bin/multitemporal.rs
+++ b/experiments/src/bin/multitemporal.rs
@@ -65,12 +65,14 @@ fn main() {
 
         // load initial root.
         root_input
-            .session(root_cap)
+            .activate()
+            .session(&root_cap)
             .give((0, Pair::new(0, 0), 1));
 
         // load initial edges
         edge_input
-            .session(edge_cap.clone())
+            .activate()
+            .session(&edge_cap)
             .give_iterator((0 .. worker_edges).map(|_|
                 ((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)),
                     Pair::new(0, 0), 1)
@@ -90,7 +92,8 @@ fn main() {
         for round in 1 .. rounds {
 
             edge_input
-                .session(edge_cap.clone())
+                .activate()
+                .session(&edge_cap)
                 .give_iterator((0 .. worker_batch).flat_map(|_| {
                     let insert = ((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), Pair::new(0, round), 1);
                     let remove = ((rng2.gen_range(0, nodes), rng2.gen_range(0, nodes)), Pair::new(0, round),-1);
@@ -112,7 +115,8 @@ fn main() {
         edge_cap = edge_cap_next;
 
         edge_input
-            .session(edge_cap.clone())
+            .activate()
+            .session(&edge_cap)
             .give_iterator((0 .. worker_batch).map(|_| {
                 ((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), Pair::new(1, 0), 1)
             }));
@@ -124,7 +128,8 @@ fn main() {
         }
 
         edge_input
-            .session(edge_cap.clone())
+            .activate()
+            .session(&edge_cap)
             .give_iterator((0 .. worker_batch).map(|_| {
                 ((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), Pair::new(2, 3), 1)
             }));
@@ -136,7 +141,8 @@ fn main() {
         }
 
         edge_input
-            .session(edge_cap.clone())
+            .activate()
+            .session(&edge_cap)
             .give_iterator((0 .. worker_batch).map(|_| {
                 ((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), Pair::new(3, 1), 1)
             }));
@@ -148,7 +154,8 @@ fn main() {
         }
 
         edge_input
-            .session(edge_cap0)
+            .activate()
+            .session(&edge_cap0)
             .give_iterator((0 .. worker_batch).map(|_| {
                 ((rng1.gen_range(0, nodes), rng1.gen_range(0, nodes)), Pair::new(0, 10), 1)
             }));

--- a/interactive/src/logging.rs
+++ b/interactive/src/logging.rs
@@ -7,6 +7,7 @@ use timely::communication::Allocate;
 use timely::worker::Worker;
 use timely::logging::TimelyEvent;
 use timely::dataflow::operators::capture::event::EventIterator;
+use timely::dataflow::operators::generic::OutputBuilder;
 
 use differential_dataflow::ExchangeData;
 use differential_dataflow::logging::DifferentialEvent;
@@ -47,13 +48,20 @@ where
         use timely::dataflow::channels::pact::Pipeline;
         let mut input = demux.new_input(&input_stream, Pipeline);
 
-        let (mut operates_out, operates) = demux.new_output();
-        let (mut channels_out, channels) = demux.new_output();
-        let (mut schedule_out, schedule) = demux.new_output();
-        let (mut messages_out, messages) = demux.new_output();
-        let (mut shutdown_out, shutdown) = demux.new_output();
-        let (mut park_out, park) = demux.new_output();
-        let (mut text_out, text) = demux.new_output();
+        let (operates_out, operates) = demux.new_output();
+        let mut operates_out = OutputBuilder::from(operates_out);
+        let (channels_out, channels) = demux.new_output();
+        let mut channels_out = OutputBuilder::from(channels_out);
+        let (schedule_out, schedule) = demux.new_output();
+        let mut schedule_out = OutputBuilder::from(schedule_out);
+        let (messages_out, messages) = demux.new_output();
+        let mut messages_out = OutputBuilder::from(messages_out);
+        let (shutdown_out, shutdown) = demux.new_output();
+        let mut shutdown_out = OutputBuilder::from(shutdown_out);
+        let (park_out, park) = demux.new_output();
+        let mut park_out = OutputBuilder::from(park_out);
+        let (text_out, text) = demux.new_output();
+        let mut text_out = OutputBuilder::from(text_out);
 
         demux.build(move |_capability| {
 
@@ -228,8 +236,10 @@ where
         use timely::dataflow::channels::pact::Pipeline;
         let mut input = demux.new_input(&input, Pipeline);
 
-        let (mut batch_out, batch) = demux.new_output();
-        let (mut merge_out, merge) = demux.new_output();
+        let (batch_out, batch) = demux.new_output();
+        let mut batch_out = OutputBuilder::from(batch_out);
+        let (merge_out, merge) = demux.new_output();
+        let mut merge_out = OutputBuilder::from(merge_out);
 
         demux.build(move |_capability| {
 


### PR DESCRIPTION
Updates necessary for recent changes to timely, mostly around input and output handles and sessions. A bit due to removing a `+Hash` constraint on `Timestamp`.