### PR TITLE
Extract `VecCollection` from `Collection`

### DIFF
--- a/advent_of_code_2017/src/bin/day_07.rs
+++ b/advent_of_code_2017/src/bin/day_07.rs
@@ -3,7 +3,7 @@ extern crate differential_dataflow;
 
 // taken from: https://adventofcode.com/2017/day/6
 
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::*;
 

--- a/advent_of_code_2017/src/bin/day_07.rs
+++ b/advent_of_code_2017/src/bin/day_07.rs
@@ -1074,7 +1074,7 @@ tvhftq (35)";
         let index = worker.index();
         let peers = worker.peers();
 
-        let worker_input = 
+        let worker_input =
         input
             .split('\n')
             .enumerate()
@@ -1102,7 +1102,7 @@ tvhftq (35)";
             let weights = input.explode(|(name,weight,_)| Some((name, weight as isize)));
             let parents = input.flat_map(|(name,_,links)| links.into_iter().map(move |link| (link,name.to_string())));
 
-            let total_weights: Collection<_,String> = weights
+            let total_weights: VecCollection<_,String> = weights
                 .iterate(|inner| {
                     parents.enter(&inner.scope())
                            .semijoin(&inner)

--- a/advent_of_code_2017/src/bin/day_08.rs
+++ b/advent_of_code_2017/src/bin/day_08.rs
@@ -3,7 +3,7 @@ extern crate differential_dataflow;
 
 // taken from: https://adventofcode.com/2017/day/8
 
-// use differential_dataflow::Collection;
+// use differential_dataflow::VecCollection;
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::*;
 use differential_dataflow::algorithms::prefix_sum::PrefixSum;
@@ -1068,7 +1068,7 @@ wui inc -120 if i > -2038";
             let edits = data.map(|(pos, line)| {
 
                 // Each line has a read location with a condition, and a write location with an operation.
-                // E.g., 
+                // E.g.,
                 //
                 //      kxm dec 986 if xbh <= -2515
                 //      obc inc 63 if wui >= 2800

--- a/advent_of_code_2017/src/bin/day_09.rs
+++ b/advent_of_code_2017/src/bin/day_09.rs
@@ -20,7 +20,7 @@ fn main() {
         let index = worker.index();
         let peers = worker.peers();
 
-        let worker_input = 
+        let worker_input =
         input
             .chars()
             .enumerate()
@@ -37,7 +37,7 @@ fn main() {
             //   { next_invalid, garbage }
             //
             // where the first bool indicates that the next character should be ignored,
-            // and the second bool indicates that we are in a garbage scope. We will 
+            // and the second bool indicates that we are in a garbage scope. We will
             // encode this as the values 0 .. 4, where
             //
             //  0: valid, non-garbage
@@ -48,7 +48,7 @@ fn main() {
             // Each character initially describes a substring of length one, but we will
             // build up the state transition for larger substrings, iteratively.
 
-            let transitions = 
+            let transitions =
             input
                 .map(|(pos, character)|
                     (pos, match character {
@@ -95,7 +95,7 @@ fn main() {
 }
 
 /// Accumulate data in `collection` into all powers-of-two intervals containing them.
-fn pp_aggregate<G, D, F>(collection: Collection<G, (usize, D)>, combine: F) -> Collection<G, ((usize, usize), D)>
+fn pp_aggregate<G, D, F>(collection: VecCollection<G, (usize, D)>, combine: F) -> VecCollection<G, ((usize, usize), D)>
 where
     G: Scope<Timestamp: Lattice>,
     D: Data,
@@ -105,7 +105,7 @@ where
     let unit_ranges = collection.map(|(index, data)| ((index, 0), data));
 
     unit_ranges
-        .iterate(|ranges| 
+        .iterate(|ranges|
 
             // Each available range, of size less than usize::max_value(), advertises itself as the range
             // twice as large, aligned to integer multiples of its size. Each range, which may contain at
@@ -126,10 +126,10 @@ where
 
 /// Produces the accumulated values at each of the `usize` locations in `aggregates` (and others).
 fn pp_broadcast<G, D, B, F>(
-    ranges: Collection<G, ((usize, usize), D)>, 
+    ranges: VecCollection<G, ((usize, usize), D)>,
     seed: B,
     zero: D,
-    combine: F) -> Collection<G, (usize, B)>
+    combine: F) -> VecCollection<G, (usize, B)>
 where
     G: Scope<Timestamp: Lattice+Ord+::std::fmt::Debug>,
     D: Data,
@@ -137,7 +137,7 @@ where
     F: Fn(&B, &D) -> B + 'static,
 {
     // Each range proposes an empty first child, to provide for its second child if it has no sibling.
-    // This is important if we want to reconstruct 
+    // This is important if we want to reconstruct
     let zero_ranges =
         ranges
             .map(move |((pos, log),_)| ((pos, if log > 0 { log - 1 } else { 0 }), zero.clone()))
@@ -145,7 +145,7 @@ where
 
     let aggregates = ranges.concat(&zero_ranges);
 
-    let init_state = 
+    let init_state =
     Some(((0, seed), Default::default(), 1))
         .to_stream(&mut aggregates.scope())
         .as_collection();

--- a/advent_of_code_2017/src/bin/day_10.rs
+++ b/advent_of_code_2017/src/bin/day_10.rs
@@ -3,7 +3,7 @@ extern crate differential_dataflow;
 
 // taken from: https://adventofcode.com/2017/day/8
 
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::*;
 

--- a/advent_of_code_2017/src/bin/day_14.rs
+++ b/advent_of_code_2017/src/bin/day_14.rs
@@ -3,7 +3,7 @@ extern crate differential_dataflow;
 
 // taken from: https://adventofcode.com/2017/day/8
 
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::*;
 
@@ -31,8 +31,8 @@ fn main() {
                     // println!("{:?}: \t{:?}", row, hash);
 
                     (0 .. 128)
-                        .map(move |col| 
-                            if hash[col/8] & (1 << (7-(col % 8))) != 0 { 
+                        .map(move |col|
+                            if hash[col/8] & (1 << (7-(col % 8))) != 0 {
                                 (row, col, '#')
                             }
                             else {

--- a/advent_of_code_2017/src/bin/day_15.rs
+++ b/advent_of_code_2017/src/bin/day_15.rs
@@ -3,7 +3,7 @@ extern crate differential_dataflow;
 
 // taken from: https://adventofcode.com/2017/day/8
 
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::*;
 

--- a/differential-dataflow/examples/bfs.rs
+++ b/differential-dataflow/examples/bfs.rs
@@ -4,7 +4,7 @@ use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 
@@ -91,9 +91,9 @@ fn main() {
 }
 
 // returns pairs (n, s) indicating node n can be reached from a root in s steps.
-fn bfs<G>(edges: &Collection<G, Edge>, roots: &Collection<G, Node>) -> Collection<G, (Node, u32)>
+fn bfs<G>(edges: &VecCollection<G, Edge>, roots: &VecCollection<G, Node>) -> VecCollection<G, (Node, u32)>
 where
-    G: Scope<Timestamp: Lattice+Ord>, 
+    G: Scope<Timestamp: Lattice+Ord>,
 {
     // initialize roots as reaching themselves at distance 0
     let nodes = roots.map(|x| (x, 0));

--- a/differential-dataflow/examples/dynamic.rs
+++ b/differential-dataflow/examples/dynamic.rs
@@ -4,7 +4,7 @@ use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 
@@ -91,9 +91,9 @@ fn main() {
 }
 
 // returns pairs (n, s) indicating node n can be reached from a root in s steps.
-fn bfs<G>(edges: &Collection<G, Edge>, roots: &Collection<G, Node>) -> Collection<G, (Node, u32)>
+fn bfs<G>(edges: &VecCollection<G, Edge>, roots: &VecCollection<G, Node>) -> VecCollection<G, (Node, u32)>
 where
-    G: Scope<Timestamp: Lattice+Ord>, 
+    G: Scope<Timestamp: Lattice+Ord>,
 {
     use timely::order::Product;
     use iterate::Variable;
@@ -115,7 +115,7 @@ where
         let inner = feedback_summary::<usize>(1, 1);
         let label = Variable::new_from(nodes.clone(), Product { outer: Default::default(), inner });
 
-        let next = 
+        let next =
         label
             .join_map(&edges, |_k,l,d| (*d, l+1))
             .concat(&nodes)

--- a/differential-dataflow/examples/graspan.rs
+++ b/differential-dataflow/examples/graspan.rs
@@ -8,11 +8,11 @@ use timely::order::Product;
 use timely::dataflow::Scope;
 use timely::dataflow::scopes::ScopeParent;
 
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::input::{Input, InputSession};
 use differential_dataflow::operators::arrange::{ArrangeByKey, ArrangeBySelf};
-use differential_dataflow::operators::iterate::VariableRow;
+use differential_dataflow::operators::iterate::VecVariable;
 use differential_dataflow::operators::Threshold;
 
 type Node = usize;
@@ -83,16 +83,16 @@ type Arrange<G,K,V,R> = Arranged<G, TraceValHandle<K, V, <G as ScopeParent>::Tim
 /// An edge variable provides arranged representations of its contents, even before they are
 /// completely defined, in support of recursively defined productions.
 pub struct EdgeVariable<G: Scope<Timestamp: Lattice>> {
-    variable: VariableRow<G, Edge, Diff>,
-    current: Collection<G, Edge, Diff>,
+    variable: VecVariable<G, Edge, Diff>,
+    current: VecCollection<G, Edge, Diff>,
     forward: Option<Arrange<G, Node, Node, Diff>>,
     reverse: Option<Arrange<G, Node, Node, Diff>>,
 }
 
 impl<G: Scope<Timestamp: Lattice>> EdgeVariable<G> {
     /// Creates a new variable initialized with `source`.
-    pub fn from(source: &Collection<G, Edge>, step: <G::Timestamp as Timestamp>::Summary) -> Self {
-        let variable = VariableRow::new(&mut source.scope(), step);
+    pub fn from(source: &VecCollection<G, Edge>, step: <G::Timestamp as Timestamp>::Summary) -> Self {
+        let variable = VecVariable::new(&mut source.scope(), step);
         EdgeVariable {
             variable: variable,
             current: source.clone(),
@@ -101,7 +101,7 @@ impl<G: Scope<Timestamp: Lattice>> EdgeVariable<G> {
         }
     }
     /// Concatenates `production` into the definition of the variable.
-    pub fn add_production(&mut self, production: &Collection<G, Edge, Diff>) {
+    pub fn add_production(&mut self, production: &VecCollection<G, Edge, Diff>) {
         self.current = self.current.concat(production);
     }
     /// Finalizes the variable, connecting its recursive definition.

--- a/differential-dataflow/examples/graspan.rs
+++ b/differential-dataflow/examples/graspan.rs
@@ -12,7 +12,7 @@ use differential_dataflow::Collection;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::input::{Input, InputSession};
 use differential_dataflow::operators::arrange::{ArrangeByKey, ArrangeBySelf};
-use differential_dataflow::operators::iterate::Variable;
+use differential_dataflow::operators::iterate::VariableRow;
 use differential_dataflow::operators::Threshold;
 
 type Node = usize;
@@ -83,7 +83,7 @@ type Arrange<G,K,V,R> = Arranged<G, TraceValHandle<K, V, <G as ScopeParent>::Tim
 /// An edge variable provides arranged representations of its contents, even before they are
 /// completely defined, in support of recursively defined productions.
 pub struct EdgeVariable<G: Scope<Timestamp: Lattice>> {
-    variable: Variable<G, Edge, Diff>,
+    variable: VariableRow<G, Edge, Diff>,
     current: Collection<G, Edge, Diff>,
     forward: Option<Arrange<G, Node, Node, Diff>>,
     reverse: Option<Arrange<G, Node, Node, Diff>>,
@@ -92,7 +92,7 @@ pub struct EdgeVariable<G: Scope<Timestamp: Lattice>> {
 impl<G: Scope<Timestamp: Lattice>> EdgeVariable<G> {
     /// Creates a new variable initialized with `source`.
     pub fn from(source: &Collection<G, Edge>, step: <G::Timestamp as Timestamp>::Summary) -> Self {
-        let variable = Variable::new(&mut source.scope(), step);
+        let variable = VariableRow::new(&mut source.scope(), step);
         EdgeVariable {
             variable: variable,
             current: source.clone(),
@@ -153,7 +153,7 @@ impl Query {
 
     /// Creates a dataflow implementing the query, and returns input and trace handles.
     pub fn render_in<G>(&self, scope: &mut G) -> IndexMap<String, RelationHandles<G::Timestamp>>
-    where 
+    where
         G: Scope<Timestamp: Lattice+::timely::order::TotalOrder>,
     {
         // Create new input (handle, stream) pairs

--- a/differential-dataflow/examples/interpreted.rs
+++ b/differential-dataflow/examples/interpreted.rs
@@ -2,7 +2,7 @@ use std::hash::Hash;
 use timely::dataflow::*;
 use timely::dataflow::operators::*;
 
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::*;
 
@@ -35,13 +35,13 @@ fn main() {
         println!("loaded {} nodes, {} edges", nodes, edges.len());
 
         worker.dataflow::<(),_,_>(|scope| {
-            interpret(&Collection::new(edges.to_stream(scope)), &[(0,2), (1,2)]);
+            interpret(&VecCollection::new(edges.to_stream(scope)), &[(0,2), (1,2)]);
         });
 
     }).unwrap();
 }
 
-fn interpret<G>(edges: &Collection<G, Edge>, relations: &[(usize, usize)]) -> Collection<G, Vec<Node>>
+fn interpret<G>(edges: &VecCollection<G, Edge>, relations: &[(usize, usize)]) -> VecCollection<G, Vec<Node>>
 where
     G: Scope<Timestamp: Lattice+Hash+Ord>,
 {

--- a/differential-dataflow/examples/iterate_container.rs
+++ b/differential-dataflow/examples/iterate_container.rs
@@ -5,7 +5,7 @@ use timely::dataflow::operators::Operator;
 use timely::order::Product;
 use timely::dataflow::{Scope, StreamCore};
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use differential_dataflow::{AsCollection, collection::CollectionCore};
+use differential_dataflow::{AsCollection, Collection};
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::iterate::Variable;
 use differential_dataflow::collection::containers::{Enter, Leave, Negate, ResultsIn};
@@ -52,12 +52,12 @@ fn main() {
     timely::example(|scope| {
 
         let numbers = scope.new_collection_from(1 .. 10u32).1;
-        let numbers: CollectionCore<_, _>  = wrap(&numbers.inner).as_collection();
+        let numbers: Collection<_, _>  = wrap(&numbers.inner).as_collection();
 
         scope.iterative::<u64,_,_>(|nested| {
             let summary = Product::new(Default::default(), 1);
             let variable = Variable::new_from(numbers.enter(nested), summary);
-            let mapped: CollectionCore<_, _> = variable.inner.unary(Pipeline, "Map", |_,_| {
+            let mapped: Collection<_, _> = variable.inner.unary(Pipeline, "Map", |_,_| {
                 |input, output| {
                     input.for_each(|time, data| {
                         let mut session = output.session(&time);

--- a/differential-dataflow/examples/iterate_container.rs
+++ b/differential-dataflow/examples/iterate_container.rs
@@ -5,7 +5,7 @@ use timely::dataflow::operators::Operator;
 use timely::order::Product;
 use timely::dataflow::{Scope, StreamCore};
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use differential_dataflow::{AsCollection, Collection};
+use differential_dataflow::{AsCollection, collection::CollectionCore};
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::iterate::Variable;
 use differential_dataflow::collection::containers::{Enter, Leave, Negate, ResultsIn};
@@ -52,12 +52,12 @@ fn main() {
     timely::example(|scope| {
 
         let numbers = scope.new_collection_from(1 .. 10u32).1;
-        let numbers: Collection<_, u32, isize, _>  = wrap(&numbers.inner).as_collection();
+        let numbers: CollectionCore<_, _>  = wrap(&numbers.inner).as_collection();
 
         scope.iterative::<u64,_,_>(|nested| {
             let summary = Product::new(Default::default(), 1);
             let variable = Variable::new_from(numbers.enter(nested), summary);
-            let mapped: Collection<_, u32, isize, _> = variable.inner.unary(Pipeline, "Map", |_,_| {
+            let mapped: CollectionCore<_, _> = variable.inner.unary(Pipeline, "Map", |_,_| {
                 |input, output| {
                     input.for_each(|time, data| {
                         let mut session = output.session(&time);

--- a/differential-dataflow/examples/monoid-bfs.rs
+++ b/differential-dataflow/examples/monoid-bfs.rs
@@ -5,7 +5,7 @@ use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 
@@ -123,7 +123,7 @@ fn main() {
 }
 
 // returns pairs (n, s) indicating node n can be reached from a root in s steps.
-fn bfs<G>(edges: &Collection<G, Edge, MinSum>, roots: &Collection<G, Node, MinSum>) -> Collection<G, Node, MinSum>
+fn bfs<G>(edges: &VecCollection<G, Edge, MinSum>, roots: &VecCollection<G, Node, MinSum>) -> VecCollection<G, Node, MinSum>
 where
     G: Scope<Timestamp: Lattice+Ord>,
 {

--- a/differential-dataflow/examples/pagerank.rs
+++ b/differential-dataflow/examples/pagerank.rs
@@ -1,7 +1,7 @@
 use timely::order::Product;
 use timely::dataflow::{*, operators::Filter};
 
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::{*, iterate::Variable};
 use differential_dataflow::input::InputSession;
@@ -77,7 +77,7 @@ fn main() {
 
 // Returns a weighted collection in which the weight of each node is proportional
 // to its PageRank in the input graph `edges`.
-fn pagerank<G>(iters: Iter, edges: &Collection<G, Edge, Diff>) -> Collection<G, Node, Diff>
+fn pagerank<G>(iters: Iter, edges: &VecCollection<G, Edge, Diff>) -> VecCollection<G, Node, Diff>
 where
     G: Scope<Timestamp: Lattice>,
 {

--- a/differential-dataflow/examples/stackoverflow.rs
+++ b/differential-dataflow/examples/stackoverflow.rs
@@ -5,7 +5,7 @@ use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle;
 
 use differential_dataflow::input::InputSession;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 
@@ -105,7 +105,7 @@ fn main() {
 }
 
 // returns pairs (n, s) indicating node n can be reached from a root in s steps.
-fn bfs<G>(edges: &Collection<G, Edge>, roots: &Collection<G, Node>) -> Collection<G, (Node, u32)>
+fn bfs<G>(edges: &VecCollection<G, Edge>, roots: &VecCollection<G, Node>) -> VecCollection<G, (Node, u32)>
 where
     G: Scope<Timestamp: Lattice+Ord>,
 {

--- a/differential-dataflow/src/algorithms/graphs/bfs.rs
+++ b/differential-dataflow/src/algorithms/graphs/bfs.rs
@@ -4,12 +4,12 @@ use std::hash::Hash;
 
 use timely::dataflow::*;
 
-use crate::{Collection, ExchangeData};
+use crate::{VecCollection, ExchangeData};
 use crate::operators::*;
 use crate::lattice::Lattice;
 
 /// Returns pairs (node, dist) indicating distance of each node from a root.
-pub fn bfs<G, N>(edges: &Collection<G, (N,N)>, roots: &Collection<G, N>) -> Collection<G, (N,u32)>
+pub fn bfs<G, N>(edges: &VecCollection<G, (N,N)>, roots: &VecCollection<G, N>) -> VecCollection<G, (N,u32)>
 where
     G: Scope<Timestamp: Lattice+Ord>,
     N: ExchangeData+Hash,
@@ -23,7 +23,7 @@ use crate::trace::TraceReader;
 use crate::operators::arrange::Arranged;
 
 /// Returns pairs (node, dist) indicating distance of each node from a root.
-pub fn bfs_arranged<G, N, Tr>(edges: &Arranged<G, Tr>, roots: &Collection<G, N>) -> Collection<G, (N, u32)>
+pub fn bfs_arranged<G, N, Tr>(edges: &Arranged<G, Tr>, roots: &VecCollection<G, N>) -> VecCollection<G, (N, u32)>
 where
     G: Scope<Timestamp=Tr::Time>,
     N: ExchangeData+Hash,

--- a/differential-dataflow/src/algorithms/graphs/bijkstra.rs
+++ b/differential-dataflow/src/algorithms/graphs/bijkstra.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 use timely::order::Product;
 use timely::dataflow::*;
 
-use crate::{Collection, ExchangeData};
+use crate::{VecCollection, ExchangeData};
 use crate::operators::*;
 use crate::lattice::Lattice;
 use crate::operators::iterate::Variable;
@@ -20,7 +20,7 @@ use crate::operators::iterate::Variable;
 /// Goals that cannot reach from the source to the target are relatively expensive, as
 /// the entire graph must be explored to confirm this. A graph connectivity pre-filter
 /// could be good insurance here.
-pub fn bidijkstra<G, N>(edges: &Collection<G, (N,N)>, goals: &Collection<G, (N,N)>) -> Collection<G, ((N,N), u32)>
+pub fn bidijkstra<G, N>(edges: &VecCollection<G, (N,N)>, goals: &VecCollection<G, (N,N)>) -> VecCollection<G, ((N,N), u32)>
 where
     G: Scope<Timestamp: Lattice+Ord>,
     N: ExchangeData+Hash,
@@ -38,8 +38,8 @@ use crate::operators::arrange::Arranged;
 pub fn bidijkstra_arranged<G, N, Tr>(
     forward: &Arranged<G, Tr>,
     reverse: &Arranged<G, Tr>,
-    goals: &Collection<G, (N,N)>
-) -> Collection<G, ((N,N), u32)>
+    goals: &VecCollection<G, (N,N)>
+) -> VecCollection<G, ((N,N), u32)>
 where
     G: Scope<Timestamp=Tr::Time>,
     N: ExchangeData+Hash,

--- a/differential-dataflow/src/algorithms/graphs/propagate.rs
+++ b/differential-dataflow/src/algorithms/graphs/propagate.rs
@@ -51,7 +51,7 @@ use crate::operators::arrange::arrangement::Arranged;
 ///
 /// This variant takes a pre-arranged edge collection, to facilitate re-use, and allows
 /// a method `logic` to specify the rounds in which we introduce various labels. The output
-/// of `logic should be a number in the interval [0,64],
+/// of `logic should be a number in the interval \[0,64\],
 pub fn propagate_core<G, N, L, Tr, F, R>(edges: &Arranged<G,Tr>, nodes: &VecCollection<G,(N,L),R>, logic: F) -> VecCollection<G,(N,L),R>
 where
     G: Scope<Timestamp=Tr::Time>,

--- a/differential-dataflow/src/algorithms/graphs/propagate.rs
+++ b/differential-dataflow/src/algorithms/graphs/propagate.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 
 use timely::dataflow::*;
 
-use crate::{Collection, ExchangeData};
+use crate::{VecCollection, ExchangeData};
 use crate::lattice::Lattice;
 use crate::difference::{Abelian, Multiply};
 use crate::operators::arrange::arrangement::ArrangeByKey;
@@ -14,7 +14,7 @@ use crate::operators::arrange::arrangement::ArrangeByKey;
 /// This algorithm naively propagates all labels at once, much like standard label propagation.
 /// To more carefully control the label propagation, consider `propagate_core` which supports a
 /// method to limit the introduction of labels.
-pub fn propagate<G, N, L, R>(edges: &Collection<G, (N,N), R>, nodes: &Collection<G,(N,L),R>) -> Collection<G,(N,L),R>
+pub fn propagate<G, N, L, R>(edges: &VecCollection<G, (N,N), R>, nodes: &VecCollection<G,(N,L),R>) -> VecCollection<G,(N,L),R>
 where
     G: Scope<Timestamp: Lattice+Ord>,
     N: ExchangeData+Hash,
@@ -31,7 +31,7 @@ where
 /// This algorithm naively propagates all labels at once, much like standard label propagation.
 /// To more carefully control the label propagation, consider `propagate_core` which supports a
 /// method to limit the introduction of labels.
-pub fn propagate_at<G, N, L, F, R>(edges: &Collection<G, (N,N), R>, nodes: &Collection<G,(N,L),R>, logic: F) -> Collection<G,(N,L),R>
+pub fn propagate_at<G, N, L, F, R>(edges: &VecCollection<G, (N,N), R>, nodes: &VecCollection<G,(N,L),R>, logic: F) -> VecCollection<G,(N,L),R>
 where
     G: Scope<Timestamp: Lattice+Ord>,
     N: ExchangeData+Hash,
@@ -52,7 +52,7 @@ use crate::operators::arrange::arrangement::Arranged;
 /// This variant takes a pre-arranged edge collection, to facilitate re-use, and allows
 /// a method `logic` to specify the rounds in which we introduce various labels. The output
 /// of `logic should be a number in the interval [0,64],
-pub fn propagate_core<G, N, L, Tr, F, R>(edges: &Arranged<G,Tr>, nodes: &Collection<G,(N,L),R>, logic: F) -> Collection<G,(N,L),R>
+pub fn propagate_core<G, N, L, Tr, F, R>(edges: &Arranged<G,Tr>, nodes: &VecCollection<G,(N,L),R>, logic: F) -> VecCollection<G,(N,L),R>
 where
     G: Scope<Timestamp=Tr::Time>,
     N: ExchangeData+Hash,
@@ -96,7 +96,7 @@ where
             .concat(&nodes)
             .reduce_abelian::<_,ValBuilder<_,_,_,_>,ValSpine<_,_,_,_>>("Propagate", |_, s, t| t.push((s[0].0.clone(), R::from(1_i8))));
 
-        let propagate: Collection<_, (N, L), R> =
+        let propagate: VecCollection<_, (N, L), R> =
         labels
             .join_core(&edges, |_k, l: &L, d| Some((d.clone(), l.clone())));
 

--- a/differential-dataflow/src/algorithms/graphs/scc.rs
+++ b/differential-dataflow/src/algorithms/graphs/scc.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 
 use timely::dataflow::*;
 
-use crate::{Collection, ExchangeData};
+use crate::{VecCollection, ExchangeData};
 use crate::operators::*;
 use crate::lattice::Lattice;
 use crate::difference::{Abelian, Multiply};
@@ -13,7 +13,7 @@ use crate::difference::{Abelian, Multiply};
 use super::propagate::propagate;
 
 /// Iteratively removes nodes with no in-edges.
-pub fn trim<G, N, R>(graph: &Collection<G, (N,N), R>) -> Collection<G, (N,N), R>
+pub fn trim<G, N, R>(graph: &VecCollection<G, (N,N), R>) -> VecCollection<G, (N,N), R>
 where
     G: Scope<Timestamp: Lattice+Ord>,
     N: ExchangeData + Hash,
@@ -33,7 +33,7 @@ where
 }
 
 /// Returns the subset of edges in the same strongly connected component.
-pub fn strongly_connected<G, N, R>(graph: &Collection<G, (N,N), R>) -> Collection<G, (N,N), R>
+pub fn strongly_connected<G, N, R>(graph: &VecCollection<G, (N,N), R>) -> VecCollection<G, (N,N), R>
 where
     G: Scope<Timestamp: Lattice + Ord>,
     N: ExchangeData + Hash,
@@ -48,8 +48,8 @@ where
     })
 }
 
-fn trim_edges<G, N, R>(cycle: &Collection<G, (N,N), R>, edges: &Collection<G, (N,N), R>)
-    -> Collection<G, (N,N), R>
+fn trim_edges<G, N, R>(cycle: &VecCollection<G, (N,N), R>, edges: &VecCollection<G, (N,N), R>)
+    -> VecCollection<G, (N,N), R>
 where
     G: Scope<Timestamp: Lattice+Ord>,
     N: ExchangeData + Hash,

--- a/differential-dataflow/src/algorithms/graphs/sequential.rs
+++ b/differential-dataflow/src/algorithms/graphs/sequential.rs
@@ -4,12 +4,12 @@ use std::hash::Hash;
 
 use timely::dataflow::*;
 
-use crate::{Collection, ExchangeData};
+use crate::{VecCollection, ExchangeData};
 use crate::lattice::Lattice;
 use crate::operators::*;
 use crate::hashable::Hashable;
 
-fn _color<G, N>(edges: &Collection<G, (N,N)>) -> Collection<G,(N,Option<u32>)>
+fn _color<G, N>(edges: &VecCollection<G, (N,N)>) -> VecCollection<G,(N,Option<u32>)>
 where
     G: Scope<Timestamp: Lattice+Ord>,
     N: ExchangeData+Hash,
@@ -40,9 +40,9 @@ where
 /// fired, and we apply `logic` to the new state of lower neighbors and
 /// the old state (input) of higher neighbors.
 pub fn sequence<G, N, V, F>(
-    state: &Collection<G, (N,V)>,
-    edges: &Collection<G, (N,N)>,
-    logic: F) -> Collection<G, (N,Option<V>)>
+    state: &VecCollection<G, (N,V)>,
+    edges: &VecCollection<G, (N,N)>,
+    logic: F) -> VecCollection<G, (N,Option<V>)>
 where
     G: Scope<Timestamp: Lattice+Hash+Ord>,
     N: ExchangeData+Hashable,

--- a/differential-dataflow/src/algorithms/identifiers.rs
+++ b/differential-dataflow/src/algorithms/identifiers.rs
@@ -2,7 +2,7 @@
 
 use timely::dataflow::Scope;
 
-use crate::{Collection, ExchangeData, Hashable};
+use crate::{VecCollection, ExchangeData, Hashable};
 use crate::lattice::Lattice;
 use crate::operators::*;
 use crate::difference::Abelian;
@@ -28,16 +28,16 @@ pub trait Identifiers<G: Scope, D: ExchangeData, R: ExchangeData+Abelian> {
     ///          .assert_empty();
     /// });
     /// ```
-    fn identifiers(&self) -> Collection<G, (D, u64), R>;
+    fn identifiers(&self) -> VecCollection<G, (D, u64), R>;
 }
 
-impl<G, D, R> Identifiers<G, D, R> for Collection<G, D, R>
+impl<G, D, R> Identifiers<G, D, R> for VecCollection<G, D, R>
 where
     G: Scope<Timestamp: Lattice>,
     D: ExchangeData + ::std::hash::Hash,
     R: ExchangeData + Abelian,
 {
-    fn identifiers(&self) -> Collection<G, (D, u64), R> {
+    fn identifiers(&self) -> VecCollection<G, (D, u64), R> {
 
         // The design here is that we iteratively develop a collection
         // of pairs (round, record), where each pair is a proposal that

--- a/differential-dataflow/src/collection.rs
+++ b/differential-dataflow/src/collection.rs
@@ -22,7 +22,7 @@ use crate::difference::{Semigroup, Abelian, Multiply};
 use crate::lattice::Lattice;
 use crate::hashable::Hashable;
 
-/// A mutable collection of values of type `D`
+/// An evolving collection of values of type `D`, backed by Rust `Vec` types as containers.
 ///
 /// The `Collection` type is the core abstraction in differential dataflow programs. As you write your
 /// differential dataflow computation, you write as if the collection is a static dataset to which you
@@ -31,15 +31,17 @@ use crate::hashable::Hashable;
 /// propagate changes through your functional computation and report the corresponding changes to the
 /// output collections.
 ///
-/// Each collection has three generic parameters. The parameter `G` is for the scope in which the
+/// Each vec collection has three generic parameters. The parameter `G` is for the scope in which the
 /// collection exists; as you write more complicated programs you may wish to introduce nested scopes
 /// (e.g. for iteration) and this parameter tracks the scope (for timely dataflow's benefit). The `D`
 /// parameter is the type of data in your collection, for example `String`, or `(u32, Vec<Option<()>>)`.
 /// The `R` parameter represents the types of changes that the data undergo, and is most commonly (and
 /// defaults to) `isize`, representing changes to the occurrence count of each record.
+///
+/// This type definition instantiates the [`Collection`] type with a `Vec<(D, G::Timestamp, R)>`.
 pub type VecCollection<G, D, R = isize> = Collection<G, Vec<(D, <G as ScopeParent>::Timestamp, R)>>;
 
-/// A collection represented by a stream of abstract containers.
+/// An evolving collection represented by a stream of abstract containers.
 ///
 /// The containers purport to reperesent changes to a collection, and they must implement various traits
 /// in order to expose some of this functionality (e.g. negation, timestamp manipulation). Other actions

--- a/differential-dataflow/src/dynamic/mod.rs
+++ b/differential-dataflow/src/dynamic/mod.rs
@@ -1,15 +1,15 @@
 //! Types and operators for dynamically scoped iterative dataflows.
-//! 
+//!
 //! Scopes in timely dataflow are expressed statically, as part of the type system.
 //! This affords many efficiencies, as well as type-driven reassurance of correctness.
 //! However, there are times you need scopes whose organization is discovered only at runtime.
 //! Naiad and Materialize are examples: the latter taking arbitrary SQL into iterative dataflows.
-//! 
-//! This module provides a timestamp type `Pointstamp` that can represent an update with an 
+//!
+//! This module provides a timestamp type `Pointstamp` that can represent an update with an
 //! unboundedly long sequence of some `T: Timestamp`, ordered by the product order by which times
-//! in iterative dataflows are ordered. The module also provides methods for manipulating these 
+//! in iterative dataflows are ordered. The module also provides methods for manipulating these
 //! timestamps to emulate the movement of update streams in to, within, and out of iterative scopes.
-//! 
+//!
 
 pub mod pointstamp;
 
@@ -21,12 +21,12 @@ use timely::dataflow::channels::pact::Pipeline;
 use timely::progress::Antichain;
 
 use crate::difference::Semigroup;
-use crate::{Collection, Data};
+use crate::{VecCollection, Data};
 use crate::collection::AsCollection;
 use crate::dynamic::pointstamp::PointStamp;
 use crate::dynamic::pointstamp::PointStampSummary;
 
-impl<G, D, R, T, TOuter> Collection<G, D, R>
+impl<G, D, R, T, TOuter> VecCollection<G, D, R>
 where
     G: Scope<Timestamp = Product<TOuter, PointStamp<T>>>,
     D: Data,
@@ -67,7 +67,7 @@ where
 }
 
 /// Produces the summary for a feedback operator at `level`, applying `summary` to that coordinate.
-pub fn feedback_summary<T>(level: usize, summary: T::Summary) -> PointStampSummary<T::Summary> 
+pub fn feedback_summary<T>(level: usize, summary: T::Summary) -> PointStampSummary<T::Summary>
 where
     T: Timestamp+Default,
 {

--- a/differential-dataflow/src/lib.rs
+++ b/differential-dataflow/src/lib.rs
@@ -76,7 +76,7 @@
 
 use std::fmt::Debug;
 
-pub use collection::{Collection, AsCollection};
+pub use collection::{AsCollection, Collection, VecCollection};
 pub use hashable::Hashable;
 pub use difference::Abelian as Diff;
 

--- a/differential-dataflow/src/operators/arrange/upsert.rs
+++ b/differential-dataflow/src/operators/arrange/upsert.rs
@@ -119,7 +119,7 @@ use super::TraceAgent;
 
 /// Arrange data from a stream of keyed upserts.
 ///
-/// The input should be a stream of timestamped pairs of Key and Option<Val>.
+/// The input should be a stream of timestamped pairs of `Key` and `Option<Val>`.
 /// The contents of the collection are defined key-by-key, where each optional
 /// value in sequence either replaces or removes the existing value, should it
 /// exist.

--- a/differential-dataflow/src/operators/consolidate.rs
+++ b/differential-dataflow/src/operators/consolidate.rs
@@ -8,7 +8,7 @@
 
 use timely::dataflow::Scope;
 
-use crate::{Collection, ExchangeData, Hashable};
+use crate::{VecCollection, ExchangeData, Hashable};
 use crate::consolidation::ConsolidatingContainerBuilder;
 use crate::difference::Semigroup;
 
@@ -17,7 +17,7 @@ use crate::lattice::Lattice;
 use crate::trace::{Batcher, Builder};
 
 /// Methods which require data be arrangeable.
-impl<G, D, R> Collection<G, D, R>
+impl<G, D, R> VecCollection<G, D, R>
 where
     G: Scope<Timestamp: Data+Lattice>,
     D: ExchangeData+Hashable,

--- a/differential-dataflow/src/operators/count.rs
+++ b/differential-dataflow/src/operators/count.rs
@@ -6,7 +6,7 @@ use timely::dataflow::operators::Operator;
 use timely::dataflow::channels::pact::Pipeline;
 
 use crate::lattice::Lattice;
-use crate::{ExchangeData, Collection};
+use crate::{ExchangeData, VecCollection};
 use crate::difference::{IsZero, Semigroup};
 use crate::hashable::Hashable;
 use crate::collection::AsCollection;
@@ -30,7 +30,7 @@ pub trait CountTotal<G: Scope<Timestamp: TotalOrder+Lattice+Ord>, K: ExchangeDat
     ///          .count_total();
     /// });
     /// ```
-    fn count_total(&self) -> Collection<G, (K, R), isize> {
+    fn count_total(&self) -> VecCollection<G, (K, R), isize> {
         self.count_total_core()
     }
 
@@ -39,14 +39,14 @@ pub trait CountTotal<G: Scope<Timestamp: TotalOrder+Lattice+Ord>, K: ExchangeDat
     /// This method allows `count_total` to produce collections whose difference
     /// type is something other than an `isize` integer, for example perhaps an
     /// `i32`.
-    fn count_total_core<R2: Semigroup + From<i8> + 'static>(&self) -> Collection<G, (K, R), R2>;
+    fn count_total_core<R2: Semigroup + From<i8> + 'static>(&self) -> VecCollection<G, (K, R), R2>;
 }
 
-impl<G, K: ExchangeData+Hashable, R: ExchangeData+Semigroup> CountTotal<G, K, R> for Collection<G, K, R>
+impl<G, K: ExchangeData+Hashable, R: ExchangeData+Semigroup> CountTotal<G, K, R> for VecCollection<G, K, R>
 where
     G: Scope<Timestamp: TotalOrder+Lattice+Ord>,
 {
-    fn count_total_core<R2: Semigroup + From<i8> + 'static>(&self) -> Collection<G, (K, R), R2> {
+    fn count_total_core<R2: Semigroup + From<i8> + 'static>(&self) -> VecCollection<G, (K, R), R2> {
         self.arrange_by_self_named("Arrange: CountTotal")
             .count_total_core()
     }
@@ -63,7 +63,7 @@ where
     >+Clone+'static,
     K: ExchangeData,
 {
-    fn count_total_core<R2: Semigroup + From<i8> + 'static>(&self) -> Collection<G, (K, T1::Diff), R2> {
+    fn count_total_core<R2: Semigroup + From<i8> + 'static>(&self) -> VecCollection<G, (K, T1::Diff), R2> {
 
         let mut trace = self.trace.clone();
 

--- a/differential-dataflow/src/trace/implementations/chainless_batcher.rs
+++ b/differential-dataflow/src/trace/implementations/chainless_batcher.rs
@@ -1,14 +1,4 @@
 //! A `Batcher` implementation based on merge sort.
-//!
-//! The `MergeBatcher` requires support from two types, a "chunker" and a "merger".
-//! The chunker receives input batches and consolidates them, producing sorted output
-//! "chunks" that are fully consolidated (no adjacent updates can be accumulated).
-//! The merger implements the [`Merger`] trait, and provides hooks for manipulating
-//! sorted "chains" of chunks as needed by the merge batcher: merging chunks and also
-//! splitting them apart based on time.
-//!
-//! Implementations of `MergeBatcher` can be instantiated through the choice of both
-//! the chunker and the merger, provided their respective output and input types align.
 
 use timely::progress::frontier::AntichainRef;
 use timely::progress::{frontier::Antichain, Timestamp};

--- a/differential-dataflow/src/trace/implementations/merge_batcher.rs
+++ b/differential-dataflow/src/trace/implementations/merge_batcher.rs
@@ -292,7 +292,7 @@ pub mod container {
 
     /// A merger for arbitrary containers.
     ///
-    /// `MC` is a [`Container`] that implements [`MergerChunk`].
+    /// `MC` is a `Container` that implements [`MergerChunk`].
     /// `CQ` is a [`ContainerQueue`] supporting `MC`.
     pub struct ContainerMerger<MC, CQ> {
         _marker: PhantomData<(MC, CQ)>,

--- a/differential-dataflow/tests/bfs.rs
+++ b/differential-dataflow/tests/bfs.rs
@@ -9,7 +9,7 @@ use timely::dataflow::operators::Capture;
 use timely::dataflow::operators::capture::Extract;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
@@ -202,7 +202,7 @@ fn bfs_differential(
 }
 
 // returns pairs (n, s) indicating node n can be reached from a root in s steps.
-fn bfs<G>(edges: &Collection<G, Edge>, roots: &Collection<G, Node>) -> Collection<G, (Node, usize)>
+fn bfs<G>(edges: &VecCollection<G, Edge>, roots: &VecCollection<G, Node>) -> VecCollection<G, (Node, usize)>
 where
     G: Scope<Timestamp: Lattice+Ord>,
 {

--- a/differential-dataflow/tests/scc.rs
+++ b/differential-dataflow/tests/scc.rs
@@ -12,7 +12,7 @@ use timely::dataflow::operators::Capture;
 use timely::dataflow::operators::capture::Extract;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
@@ -215,7 +215,7 @@ fn scc_differential(
         .collect()
 }
 
-fn _strongly_connected<G>(graph: &Collection<G, Edge>) -> Collection<G, Edge>
+fn _strongly_connected<G>(graph: &VecCollection<G, Edge>) -> VecCollection<G, Edge>
 where
     G: Scope<Timestamp: Lattice+Ord+Hash>,
 {
@@ -226,7 +226,7 @@ where
     })
 }
 
-fn _trim_edges<G>(cycle: &Collection<G, Edge>, edges: &Collection<G, Edge>) -> Collection<G, Edge>
+fn _trim_edges<G>(cycle: &VecCollection<G, Edge>, edges: &VecCollection<G, Edge>) -> VecCollection<G, Edge>
 where
     G: Scope<Timestamp: Lattice+Ord+Hash>,
 {
@@ -243,7 +243,7 @@ where
          .map(|((x1,x2),_)| (x2,x1))
 }
 
-fn _reachability<G>(edges: &Collection<G, Edge>, nodes: &Collection<G, (Node, Node)>) -> Collection<G, Edge>
+fn _reachability<G>(edges: &VecCollection<G, Edge>, nodes: &VecCollection<G, (Node, Node)>) -> VecCollection<G, Edge>
 where
     G: Scope<Timestamp: Lattice+Ord+Hash>,
 {

--- a/dogsdogsdogs/examples/ngo.rs
+++ b/dogsdogsdogs/examples/ngo.rs
@@ -2,7 +2,7 @@ use std::hash::Hash;
 use timely::dataflow::*;
 use timely::dataflow::operators::*;
 
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::*;
 
@@ -35,13 +35,13 @@ fn main() {
         println!("loaded {} nodes, {} edges", nodes, edges.len());
 
         worker.dataflow::<(),_,_>(|scope| {
-            triangles(&Collection::new(edges.to_stream(scope))).inner.count().inspect(|x| println!("{:?}", x));
+            triangles(&VecCollection::new(edges.to_stream(scope))).inner.count().inspect(|x| println!("{:?}", x));
         });
 
     }).unwrap();
 }
 
-fn triangles<G: Scope>(edges: &Collection<G, Edge>) -> Collection<G, (Node, Node, Node)>
+fn triangles<G: Scope>(edges: &VecCollection<G, Edge>) -> VecCollection<G, (Node, Node, Node)>
 where
     G: Scope<Timestamp: Lattice+Hash+Ord>,
 {

--- a/dogsdogsdogs/src/operators/count.rs
+++ b/dogsdogsdogs/src/operators/count.rs
@@ -1,6 +1,6 @@
 use timely::dataflow::Scope;
 
-use differential_dataflow::{ExchangeData, Collection, Hashable};
+use differential_dataflow::{ExchangeData, VecCollection, Hashable};
 use differential_dataflow::difference::{Semigroup, Monoid, Multiply};
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::TraceReader;
@@ -12,11 +12,11 @@ use differential_dataflow::trace::TraceReader;
 /// associated count in `arrangement`. If the found count is less than `count`,
 /// the `count` and `index` fields are overwritten with their new values.
 pub fn count<G, Tr, K, R, F, P>(
-    prefixes: &Collection<G, (P, usize, usize), R>,
+    prefixes: &VecCollection<G, (P, usize, usize), R>,
     arrangement: Arranged<G, Tr>,
     key_selector: F,
     index: usize,
-) -> Collection<G, (P, usize, usize), R>
+) -> VecCollection<G, (P, usize, usize), R>
 where
     G: Scope<Timestamp=Tr::Time>,
     Tr: TraceReader<KeyOwn = K, Diff=isize>+Clone+'static,

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -44,7 +44,7 @@ use timely::dataflow::operators::Operator;
 use timely::progress::Antichain;
 use timely::progress::frontier::AntichainRef;
 
-use differential_dataflow::{ExchangeData, Collection, AsCollection, Hashable};
+use differential_dataflow::{ExchangeData, VecCollection, AsCollection, Hashable};
 use differential_dataflow::difference::{Monoid, Semigroup};
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
@@ -75,12 +75,12 @@ use differential_dataflow::trace::implementations::BatchContainer;
 /// once out of the "delta flow region", the updates will be `delay`d to the
 /// times specified in the payloads.
 pub fn half_join<G, K, V, R, Tr, FF, CF, DOut, S>(
-    stream: &Collection<G, (K, V, G::Timestamp), R>,
+    stream: &VecCollection<G, (K, V, G::Timestamp), R>,
     arrangement: Arranged<G, Tr>,
     frontier_func: FF,
     comparison: CF,
     mut output_func: S,
-) -> Collection<G, (DOut, G::Timestamp), <R as Mul<Tr::Diff>>::Output>
+) -> VecCollection<G, (DOut, G::Timestamp), <R as Mul<Tr::Diff>>::Output>
 where
     G: Scope<Timestamp = Tr::Time>,
     K: Hashable + ExchangeData,
@@ -144,7 +144,7 @@ type SessionFor<'a, G, CB> =
 /// records. Note this is not the number of *output* records, owing mainly to
 /// the number of matched records being easiest to record with low overhead.
 pub fn half_join_internal_unsafe<G, K, V, R, Tr, FF, CF, Y, S, CB>(
-    stream: &Collection<G, (K, V, G::Timestamp), R>,
+    stream: &VecCollection<G, (K, V, G::Timestamp), R>,
     mut arrangement: Arranged<G, Tr>,
     frontier_func: FF,
     comparison: CF,

--- a/dogsdogsdogs/src/operators/lookup_map.rs
+++ b/dogsdogsdogs/src/operators/lookup_map.rs
@@ -6,7 +6,7 @@ use timely::dataflow::channels::pact::{Pipeline, Exchange};
 use timely::dataflow::operators::Operator;
 use timely::progress::Antichain;
 
-use differential_dataflow::{ExchangeData, Collection, AsCollection, Hashable};
+use differential_dataflow::{ExchangeData, VecCollection, AsCollection, Hashable};
 use differential_dataflow::difference::{IsZero, Semigroup, Monoid};
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::{Cursor, TraceReader};
@@ -18,14 +18,14 @@ use differential_dataflow::trace::implementations::BatchContainer;
 /// key with `key_selector` and then proposes all pair af the prefix
 /// and values associated with the key in `arrangement`.
 pub fn lookup_map<G, D, K, R, Tr, F, DOut, ROut, S>(
-    prefixes: &Collection<G, D, R>,
+    prefixes: &VecCollection<G, D, R>,
     mut arrangement: Arranged<G, Tr>,
     key_selector: F,
     mut output_func: S,
     supplied_key0: K,
     supplied_key1: K,
     supplied_key2: K,
-) -> Collection<G, DOut, ROut>
+) -> VecCollection<G, DOut, ROut>
 where
     G: Scope<Timestamp=Tr::Time>,
     Tr: for<'a> TraceReader<

--- a/dogsdogsdogs/src/operators/propose.rs
+++ b/dogsdogsdogs/src/operators/propose.rs
@@ -1,6 +1,6 @@
 use timely::dataflow::Scope;
 
-use differential_dataflow::{ExchangeData, Collection, Hashable};
+use differential_dataflow::{ExchangeData, VecCollection, Hashable};
 use differential_dataflow::difference::{Semigroup, Monoid, Multiply};
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::TraceReader;
@@ -14,10 +14,10 @@ use differential_dataflow::trace::TraceReader;
 /// `arrangement` undergoes. More complicated patterns are also appropriate, as in the case
 /// of delta queries.
 pub fn propose<G, Tr, K, F, P, V>(
-    prefixes: &Collection<G, P, Tr::Diff>,
+    prefixes: &VecCollection<G, P, Tr::Diff>,
     arrangement: Arranged<G, Tr>,
     key_selector: F,
-) -> Collection<G, (P, V), Tr::Diff>
+) -> VecCollection<G, (P, V), Tr::Diff>
 where
     G: Scope<Timestamp=Tr::Time>,
     Tr: for<'a> TraceReader<
@@ -47,10 +47,10 @@ where
 /// prefixes by the number of matches in `arrangement`. This can be useful to
 /// avoid the need to prepare an arrangement of distinct extensions.
 pub fn propose_distinct<G, Tr, K, F, P, V>(
-    prefixes: &Collection<G, P, Tr::Diff>,
+    prefixes: &VecCollection<G, P, Tr::Diff>,
     arrangement: Arranged<G, Tr>,
     key_selector: F,
-) -> Collection<G, (P, V), Tr::Diff>
+) -> VecCollection<G, (P, V), Tr::Diff>
 where
     G: Scope<Timestamp=Tr::Time>,
     Tr: for<'a> TraceReader<

--- a/dogsdogsdogs/src/operators/validate.rs
+++ b/dogsdogsdogs/src/operators/validate.rs
@@ -2,7 +2,7 @@ use std::hash::Hash;
 
 use timely::dataflow::Scope;
 
-use differential_dataflow::{ExchangeData, Collection};
+use differential_dataflow::{ExchangeData, VecCollection};
 use differential_dataflow::difference::{Semigroup, Monoid, Multiply};
 use differential_dataflow::operators::arrange::Arranged;
 use differential_dataflow::trace::TraceReader;
@@ -13,10 +13,10 @@ use differential_dataflow::trace::TraceReader;
 /// key with `key_selector` and then proposes all pair af the prefix
 /// and values associated with the key in `arrangement`.
 pub fn validate<G, K, V, Tr, F, P>(
-    extensions: &Collection<G, (P, V), Tr::Diff>,
+    extensions: &VecCollection<G, (P, V), Tr::Diff>,
     arrangement: Arranged<G, Tr>,
     key_selector: F,
-) -> Collection<G, (P, V), Tr::Diff>
+) -> VecCollection<G, (P, V), Tr::Diff>
 where
     G: Scope<Timestamp=Tr::Time>,
     Tr: for<'a> TraceReader<

--- a/doop/src/main.rs
+++ b/doop/src/main.rs
@@ -7,11 +7,11 @@ use std::cell::RefCell;
 use timely::dataflow::{Scope, ProbeHandle};
 use timely::dataflow::scopes::child::Iterative as Child;
 
-use differential_dataflow::{AsCollection, Collection, Hashable};
+use differential_dataflow::{AsCollection, VecCollection, Hashable};
 use differential_dataflow::ExchangeData as Data;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::input::Input;
-use differential_dataflow::operators::iterate::VariableRow;
+use differential_dataflow::operators::iterate::VecVariable;
 use differential_dataflow::operators::{Threshold, Join, JoinCore};
 use differential_dataflow::operators::arrange::ArrangeByKey;
 
@@ -56,8 +56,8 @@ type MethodInvocation = Instruction;
 
 /// Set-valued collection.
 pub struct Relation<'a, G: Scope, D: Data+Hashable> where G::Timestamp : Lattice {
-    variable: VariableRow<Child<'a, G, Iter>, D, Diff>,
-    current: Collection<Child<'a, G, Iter>, D, Diff>,
+    variable: VecVariable<Child<'a, G, Iter>, D, Diff>,
+    current: VecCollection<Child<'a, G, Iter>, D, Diff>,
 }
 
 impl<'a, G: Scope, D: Data+Hashable> Relation<'a, G, D> where G::Timestamp : Lattice {
@@ -66,16 +66,16 @@ impl<'a, G: Scope, D: Data+Hashable> Relation<'a, G, D> where G::Timestamp : Lat
         Self::new_from(&::timely::dataflow::operators::generic::operator::empty(scope).as_collection())
     }
     /// Creates a new variable initialized with `source`.
-    pub fn new_from(source: &Collection<Child<'a, G, Iter>, D, Diff>) -> Self {
+    pub fn new_from(source: &VecCollection<Child<'a, G, Iter>, D, Diff>) -> Self {
         use ::timely::order::Product;
-        let variable = VariableRow::new_from(source.clone(), Product::new(Default::default(), 1));
+        let variable = VecVariable::new_from(source.clone(), Product::new(Default::default(), 1));
         Relation {
             variable: variable,
             current: source.clone(),
         }
     }
     /// Concatenates `production` into the definition of the variable.
-    pub fn add_production(&mut self, production: &Collection<Child<'a, G, Iter>, D, Diff>) {
+    pub fn add_production(&mut self, production: &VecCollection<Child<'a, G, Iter>, D, Diff>) {
         self.current = self.current.concat(production);
     }
     /// Finalizes the variable, connecting its recursive definition.
@@ -89,8 +89,8 @@ impl<'a, G: Scope, D: Data+Hashable> Relation<'a, G, D> where G::Timestamp : Lat
 
 impl<'a, G: Scope, D: Data+Hashable> ::std::ops::Deref for Relation<'a, G, D>
 where G::Timestamp : Lattice {
-    type Target = Collection<Child<'a, G, Iter>, D, Diff>;
-    fn deref(&self) -> &Collection<Child<'a, G, Iter>, D, Diff> {
+    type Target = VecCollection<Child<'a, G, Iter>, D, Diff>;
+    fn deref(&self) -> &VecCollection<Child<'a, G, Iter>, D, Diff> {
         &self.variable
     }
 }
@@ -283,7 +283,7 @@ fn main() {
             let (input1, ClassType) = scope.new_collection_from_raw(load1(index, &prefix, "ClassType.facts", interner.clone())); inputs.0.push(input1);
             let (input2, ArrayType) = scope.new_collection_from_raw(load1(index, &prefix, "ArrayType.facts", interner.clone())); inputs.0.push(input2);
             let (input3, InterfaceType) = scope.new_collection_from_raw(load1(index, &prefix, "InterfaceType.facts", interner.clone())); inputs.0.push(input3);
-            // let Var_DeclaringMethod: Collection<_,(Symbol, Symbol)> = scope.new_collection_from_raw(load2(index, &prefix, "Var-DeclaringMethod.facts", interner.clone())).1;
+            // let Var_DeclaringMethod: VecCollection<_,(Symbol, Symbol)> = scope.new_collection_from_raw(load2(index, &prefix, "Var-DeclaringMethod.facts", interner.clone())).1;
             let (input4, ApplicationClass) = scope.new_collection_from_raw(load1(index, &prefix, "ApplicationClass.facts", interner.clone())); inputs.0.push(input4);
             let (input5, ThisVar) = scope.new_collection_from_raw(load2(index, &prefix, "ThisVar.facts", interner.clone())); inputs.1.push(input5);
 
@@ -317,14 +317,14 @@ fn main() {
             let (input31, ActualParam) = scope.new_collection_from_raw(load3(index, &prefix, "ActualParam.facts", interner.clone())); inputs.2.push(input31);
 
             // Main schema
-            let isType: Collection<_,Type> =
+            let isType: VecCollection<_,Type> =
             ClassType
                 .concat(&ArrayType)
                 .concat(&InterfaceType)
                 .concat(&ApplicationClass)
                 .concat(&_NormalHeap.map(|(_id,ty)| ty));
 
-            let isReferenceType: Collection<_,ReferenceType> =
+            let isReferenceType: VecCollection<_,ReferenceType> =
             ClassType
                 .concat(&ArrayType)
                 .concat(&InterfaceType)
@@ -350,11 +350,11 @@ fn main() {
                 .concat(&scope.new_collection_from_raw(Some(((temp2.clone(), temp1b.clone()), 0, 1))).1);
 
             // NOTE: Unused
-            // let MainMethodArgArray: Collection<_,HeapAllocation> = scope.new_collection_from_raw(Some(temp3.clone())).1;
+            // let MainMethodArgArray: VecCollection<_,HeapAllocation> = scope.new_collection_from_raw(Some(temp3.clone())).1;
             // NOTE: Unused
-            // let MainMethodArgArrayContent: Collection<_,HeapAllocation> = scope.new_collection_from_raw(Some(temp2.clone())).1;
+            // let MainMethodArgArrayContent: VecCollection<_,HeapAllocation> = scope.new_collection_from_raw(Some(temp2.clone())).1;
 
-            let Instruction_Method = //: Collection<_,(Instruction, Method)> =
+            let Instruction_Method = //: VecCollection<_,(Instruction, Method)> =
             _AssignHeapAllocation.map(|x| (x.0, x.4))
                 .concat(&_AssignLocal.map(|x| (x.0, x.4)))
                 .concat(&_AssignCast.map(|x| (x.0, x.5)))
@@ -374,7 +374,7 @@ fn main() {
             let isVirtualMethodInvocation_Insn = _VirtualMethodInvocation.map(|x| x.0);
             let isStaticMethodInvocation_Insn = _StaticMethodInvocation.map(|x| x.0);
 
-            let FieldInstruction_Signature: Collection<_,(FieldInstruction, Field)> =
+            let FieldInstruction_Signature: VecCollection<_,(FieldInstruction, Field)> =
             _StoreInstanceField.map(|x| (x.0, x.4))
                 .concat(&_LoadInstanceField.map(|x| (x.0, x.4)))
                 .concat(&_StoreStaticField.map(|x| (x.0, x.3)))
@@ -392,7 +392,7 @@ fn main() {
             let StoreArrayIndex_From = _StoreArrayIndex.map(|x| (x.0, x.2));
             let StoreArrayIndex_Base = _StoreArrayIndex.map(|x| (x.0, x.3));
 
-            let AssignInstruction_To: Collection<_,(AssignInstruction, Var)> =
+            let AssignInstruction_To: VecCollection<_,(AssignInstruction, Var)> =
             _AssignHeapAllocation.map(|x| (x.0, x.3))
                 .concat(&_AssignLocal.map(|x| (x.0, x.3)))
                 .concat(&_AssignCast.map(|x| (x.0, x.3)));
@@ -403,7 +403,7 @@ fn main() {
             let AssignHeapAllocation_Heap = _AssignHeapAllocation.map(|x| (x.0, x.2));
 
             let ReturnNonvoid_Var = _Return.map(|x| (x.0, x.2));
-            let MethodInvocation_Method: Collection<_,(MethodInvocation, Method)> =
+            let MethodInvocation_Method: VecCollection<_,(MethodInvocation, Method)> =
             _StaticMethodInvocation.map(|x| (x.0, x.2))
                 .concat(&_SpecialMethodInvocation.map(|x| (x.0, x.2)))
                 .concat(&_VirtualMethodInvocation.map(|x| (x.0, x.2)));
@@ -420,7 +420,7 @@ fn main() {
             //  LoadInstanceField_Base(?insn, ?base),
             //  FieldInstruction_Signature(?insn, ?sig),
             //  LoadInstanceField_To(?insn, ?to).
-            let LoadInstanceField: Collection<_,(Var, Field, Var, Method)> =
+            let LoadInstanceField: VecCollection<_,(Var, Field, Var, Method)> =
             Instruction_Method
                 .join(&LoadInstanceField_Base)
                 .join(&FieldInstruction_Signature)
@@ -432,7 +432,7 @@ fn main() {
             //  StoreInstanceField_From(?insn, ?from),
             //  StoreInstanceField_Base(?insn, ?base),
             //  FieldInstruction_Signature(?insn, ?sig).
-            let StoreInstanceField: Collection<_,(Var, Var, Field, Method)> =
+            let StoreInstanceField: VecCollection<_,(Var, Var, Field, Method)> =
             Instruction_Method
                 .join(&StoreInstanceField_From)
                 .join(&StoreInstanceField_Base)
@@ -443,7 +443,7 @@ fn main() {
             //  Instruction_Method(?insn, ?inmethod),
             //  FieldInstruction_Signature(?insn, ?sig),
             //  LoadStaticField_To(?insn, ?to).
-            let LoadStaticField: Collection<_,(Field, Var, Method)> =
+            let LoadStaticField: VecCollection<_,(Field, Var, Method)> =
             Instruction_Method
                 .join(&FieldInstruction_Signature)
                 .join(&LoadStaticField_To)
@@ -453,7 +453,7 @@ fn main() {
             //  Instruction_Method(?insn, ?inmethod),
             //  StoreStaticField_From(?insn, ?from),
             //  FieldInstruction_Signature(?insn, ?sig).
-            let StoreStaticField: Collection<_,(Var, Field, Method)> =
+            let StoreStaticField: VecCollection<_,(Var, Field, Method)> =
             Instruction_Method
                 .join(&StoreStaticField_From)
                 .join(&FieldInstruction_Signature)
@@ -463,7 +463,7 @@ fn main() {
             //  Instruction_Method(?insn, ?inmethod),
             //  LoadArrayIndex_Base(?insn, ?base),
             //  LoadArrayIndex_To(?insn, ?to).
-            let LoadArrayIndex: Collection<_,(Var, Var, Method)> =
+            let LoadArrayIndex: VecCollection<_,(Var, Var, Method)> =
             Instruction_Method
                 .join(&LoadArrayIndex_Base)
                 .join(&LoadArrayIndex_To)
@@ -473,7 +473,7 @@ fn main() {
             //  Instruction_Method(?insn, ?inmethod),
             //  StoreArrayIndex_From(?insn, ?from),
             //  StoreArrayIndex_Base(?insn, ?base).
-            let StoreArrayIndex: Collection<_,(Var, Var, Method)> =
+            let StoreArrayIndex: VecCollection<_,(Var, Var, Method)> =
             Instruction_Method
                 .join(&StoreArrayIndex_From)
                 .join(&StoreArrayIndex_Base)
@@ -484,7 +484,7 @@ fn main() {
             //  AssignCast_From(?insn, ?from),
             //  AssignInstruction_To(?insn, ?to),
             //  AssignCast_Type(?insn, ?type).
-            let AssignCast: Collection<_,(Type, Var, Var, Method)> =
+            let AssignCast: VecCollection<_,(Type, Var, Var, Method)> =
             Instruction_Method
                 .join(&AssignCast_From)
                 .join(&AssignInstruction_To)
@@ -495,7 +495,7 @@ fn main() {
             //  AssignInstruction_To(?insn, ?to),
             //  Instruction_Method(?insn, ?inmethod),
             //  AssignLocal_From(?insn, ?from).
-            let AssignLocal: Collection<_,(Var, Var, Method)> =
+            let AssignLocal: VecCollection<_,(Var, Var, Method)> =
             Instruction_Method
                 .join(&AssignInstruction_To)
                 .join(&AssignLocal_From)
@@ -505,7 +505,7 @@ fn main() {
             //  Instruction_Method(?insn, ?inmethod),
             //  AssignHeapAllocation_Heap(?insn, ?heap),
             //  AssignInstruction_To(?insn, ?to).
-            let AssignHeapAllocation: Collection<_,(HeapAllocation, Var, Method)> =
+            let AssignHeapAllocation: VecCollection<_,(HeapAllocation, Var, Method)> =
             Instruction_Method
                 .join(&AssignHeapAllocation_Heap)
                 .join(&AssignInstruction_To)
@@ -514,7 +514,7 @@ fn main() {
             // ReturnVar(?var, ?method) :-
             //  Instruction_Method(?insn, ?method),
             //  ReturnNonvoid_Var(?insn, ?var).
-            let ReturnVar: Collection<_,(Var, Method)> =
+            let ReturnVar: VecCollection<_,(Var, Method)> =
             Instruction_Method
                 .join(&ReturnNonvoid_Var)
                 .map(|(_insn, (inmethod, var))| (var, inmethod));
@@ -523,7 +523,7 @@ fn main() {
             //  isStaticMethodInvocation_Insn(?invocation),
             //  Instruction_Method(?invocation, ?inmethod),
             //  MethodInvocation_Method(?invocation, ?signature).
-            let StaticMethodInvocation: Collection<_,(MethodInvocation, Method, Method)> =
+            let StaticMethodInvocation: VecCollection<_,(MethodInvocation, Method, Method)> =
             Instruction_Method
                 .semijoin(&isStaticMethodInvocation_Insn)
                 .join(&MethodInvocation_Method)

--- a/doop/src/main.rs
+++ b/doop/src/main.rs
@@ -11,7 +11,7 @@ use differential_dataflow::{AsCollection, Collection, Hashable};
 use differential_dataflow::ExchangeData as Data;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::input::Input;
-use differential_dataflow::operators::iterate::Variable;
+use differential_dataflow::operators::iterate::VariableRow;
 use differential_dataflow::operators::{Threshold, Join, JoinCore};
 use differential_dataflow::operators::arrange::ArrangeByKey;
 
@@ -56,7 +56,7 @@ type MethodInvocation = Instruction;
 
 /// Set-valued collection.
 pub struct Relation<'a, G: Scope, D: Data+Hashable> where G::Timestamp : Lattice {
-    variable: Variable<Child<'a, G, Iter>, D, Diff>,
+    variable: VariableRow<Child<'a, G, Iter>, D, Diff>,
     current: Collection<Child<'a, G, Iter>, D, Diff>,
 }
 
@@ -68,7 +68,7 @@ impl<'a, G: Scope, D: Data+Hashable> Relation<'a, G, D> where G::Timestamp : Lat
     /// Creates a new variable initialized with `source`.
     pub fn new_from(source: &Collection<Child<'a, G, Iter>, D, Diff>) -> Self {
         use ::timely::order::Product;
-        let variable = Variable::new_from(source.clone(), Product::new(Default::default(), 1));
+        let variable = VariableRow::new_from(source.clone(), Product::new(Default::default(), 1));
         Relation {
             variable: variable,
             current: source.clone(),

--- a/experiments/src/bin/deals-interactive.rs
+++ b/experiments/src/bin/deals-interactive.rs
@@ -5,7 +5,7 @@ use timely::dataflow::*;
 use timely::WorkerConfig;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::ArrangeByKey;
 use differential_dataflow::lattice::Lattice;
@@ -207,10 +207,10 @@ fn main() {
 
 fn interactive<G: Scope>(
     edges: &Arrange<G, Node, Node, isize>,
-    tc_1: Collection<G, Node>,
-    tc_2: Collection<G, Node>,
-    sg_x: Collection<G, Node>
-) -> Collection<G, Node>
+    tc_1: VecCollection<G, Node>,
+    tc_2: VecCollection<G, Node>,
+    sg_x: VecCollection<G, Node>
+) -> VecCollection<G, Node>
 where G::Timestamp: Lattice{
 
     // descendants of tc_1:

--- a/experiments/src/bin/deals.rs
+++ b/experiments/src/bin/deals.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use timely::dataflow::*;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::operators::*;
 
 use differential_dataflow::trace::implementations::{ValSpine, KeySpine, KeyBatcher, KeyBuilder, ValBatcher, ValBuilder};
@@ -83,7 +83,7 @@ fn main() {
 use timely::order::Product;
 
 // returns pairs (n, s) indicating node n can be reached from a root in s steps.
-fn tc<G: Scope<Timestamp=()>>(edges: &EdgeArranged<G, Node, Node, Present>) -> Collection<G, Edge, Present> {
+fn tc<G: Scope<Timestamp=()>>(edges: &EdgeArranged<G, Node, Node, Present>) -> VecCollection<G, Edge, Present> {
 
     // repeatedly update minimal distances each node can be reached from each root
     edges.stream.scope().iterative::<Iter,_,_>(|scope| {
@@ -108,7 +108,7 @@ fn tc<G: Scope<Timestamp=()>>(edges: &EdgeArranged<G, Node, Node, Present>) -> C
 }
 
 // returns pairs (n, s) indicating node n can be reached from a root in s steps.
-fn sg<G: Scope<Timestamp=()>>(edges: &EdgeArranged<G, Node, Node, Present>) -> Collection<G, Edge, Present> {
+fn sg<G: Scope<Timestamp=()>>(edges: &EdgeArranged<G, Node, Node, Present>) -> VecCollection<G, Edge, Present> {
 
     let peers = edges.join_core(&edges, |_,&x,&y| Some((x,y))).filter(|&(x,y)| x != y);
 

--- a/experiments/src/bin/graphs-interactive-alt.rs
+++ b/experiments/src/bin/graphs-interactive-alt.rs
@@ -7,7 +7,7 @@ use timely::dataflow::operators::probe::Handle;
 use timely::order::Product;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::iterate::Variable;
@@ -266,7 +266,7 @@ type Arrange<G, K, V, R> = Arranged<G, TraceAgent<ValSpine<K, V, <G as ScopePare
 fn three_hop<G: Scope>(
     forward_graph: &Arrange<G, Node, Node, isize>,
     reverse_graph: &Arrange<G, Node, Node, isize>,
-    goals: &Collection<G, (Node, Node)>) -> Collection<G, ((Node, Node), u32)>
+    goals: &VecCollection<G, (Node, Node)>) -> VecCollection<G, ((Node, Node), u32)>
 where G::Timestamp: Lattice+Ord {
 
     let sources = goals.map(|(x,_)| x);
@@ -293,7 +293,7 @@ where G::Timestamp: Lattice+Ord {
 fn _bidijkstra<G: Scope>(
     forward_graph: &Arrange<G, Node, Node, isize>,
     reverse_graph: &Arrange<G, Node, Node, isize>,
-    goals: &Collection<G, (Node, Node)>) -> Collection<G, ((Node, Node), u32)>
+    goals: &VecCollection<G, (Node, Node)>) -> VecCollection<G, ((Node, Node), u32)>
 where G::Timestamp: Lattice+Ord {
 
     goals.scope().iterative::<Iter,_,_>(|inner| {
@@ -363,7 +363,7 @@ where G::Timestamp: Lattice+Ord {
 }
 
 
-fn connected_components<G: Scope>(graph: &Arrange<G, Node, Node, isize>) -> Collection<G, (Node, Node)>
+fn connected_components<G: Scope>(graph: &Arrange<G, Node, Node, isize>) -> VecCollection<G, (Node, Node)>
 where G::Timestamp: Lattice {
 
     // each edge (x,y) means that we need at least a label for the min of x and y.

--- a/experiments/src/bin/graphs-interactive-neu-zwei.rs
+++ b/experiments/src/bin/graphs-interactive-neu-zwei.rs
@@ -4,7 +4,7 @@ use timely::dataflow::*;
 use timely::dataflow::operators::probe::Handle;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 // use differential_dataflow::operators::iterate::Variable;
@@ -236,7 +236,7 @@ type Arrange<G, K, V, R> = Arranged<G, TraceAgent<ValSpine<K, V, <G as ScopePare
 fn three_hop<G: Scope>(
     forward_graph: &Arrange<G, Node, Node, isize>,
     reverse_graph: &Arrange<G, Node, Node, isize>,
-    goals: &Collection<G, (Node, Node)>) -> Collection<G, ((Node, Node), u32)>
+    goals: &VecCollection<G, (Node, Node)>) -> VecCollection<G, ((Node, Node), u32)>
 where G::Timestamp: Lattice+Ord {
 
     let sources = goals.map(|(x,_)| x);
@@ -263,8 +263,8 @@ where G::Timestamp: Lattice+Ord {
 // fn bidijkstra<G: Scope>(
 //     forward_graph: &Arrange<G, Node, Node, isize>,
 //     reverse_graph: &Arrange<G, Node, Node, isize>,
-//     goals: &Collection<G, (Node, Node)>,
-//     bound: u64) -> Collection<G, ((Node, Node), u32)>
+//     goals: &VecCollection<G, (Node, Node)>,
+//     bound: u64) -> VecCollection<G, ((Node, Node), u32)>
 // where G::Timestamp: Lattice+Ord {
 
 //     goals.scope().scoped(|inner| {

--- a/experiments/src/bin/graphs-interactive-neu.rs
+++ b/experiments/src/bin/graphs-interactive-neu.rs
@@ -7,7 +7,7 @@ use timely::dataflow::operators::probe::Handle;
 use timely::order::Product;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::iterate::Variable;
@@ -300,7 +300,7 @@ type Arrange<G, K, V, R> = Arranged<G, TraceAgent<ValSpine<K, V, <G as ScopePare
 fn three_hop<G: Scope>(
     forward_graph: &Arrange<G, Node, Node, isize>,
     reverse_graph: &Arrange<G, Node, Node, isize>,
-    goals: &Collection<G, (Node, Node)>) -> Collection<G, ((Node, Node), u32)>
+    goals: &VecCollection<G, (Node, Node)>) -> VecCollection<G, ((Node, Node), u32)>
 where G::Timestamp: Lattice+Ord {
 
     let sources = goals.map(|(x,_)| x);
@@ -327,7 +327,7 @@ where G::Timestamp: Lattice+Ord {
 fn _bidijkstra<G: Scope>(
     forward_graph: &Arrange<G, Node, Node, isize>,
     reverse_graph: &Arrange<G, Node, Node, isize>,
-    goals: &Collection<G, (Node, Node)>) -> Collection<G, ((Node, Node), u32)>
+    goals: &VecCollection<G, (Node, Node)>) -> VecCollection<G, ((Node, Node), u32)>
 where G::Timestamp: Lattice+Ord {
 
     goals.scope().iterative::<Iter,_,_>(|inner| {

--- a/experiments/src/bin/graphs-interactive.rs
+++ b/experiments/src/bin/graphs-interactive.rs
@@ -5,7 +5,7 @@ use timely::dataflow::operators::probe::Handle;
 use timely::order::Product;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::iterate::Variable;
@@ -204,7 +204,7 @@ type Arrange<G, K, V, R> = Arranged<G, TraceAgent<ValSpine<K, V, <G as ScopePare
 fn three_hop<G: Scope>(
     forward_graph: &Arrange<G, Node, Node, isize>,
     reverse_graph: &Arrange<G, Node, Node, isize>,
-    goals: &Collection<G, (Node, Node)>) -> Collection<G, ((Node, Node), u32)>
+    goals: &VecCollection<G, (Node, Node)>) -> VecCollection<G, ((Node, Node), u32)>
 where G::Timestamp: Lattice+Ord {
 
     let sources = goals.map(|(x,_)| x);
@@ -231,7 +231,7 @@ where G::Timestamp: Lattice+Ord {
 fn _bidijkstra<G: Scope>(
     forward_graph: &Arrange<G, Node, Node, isize>,
     reverse_graph: &Arrange<G, Node, Node, isize>,
-    goals: &Collection<G, (Node, Node)>) -> Collection<G, ((Node, Node), u32)>
+    goals: &VecCollection<G, (Node, Node)>) -> VecCollection<G, ((Node, Node), u32)>
 where G::Timestamp: Lattice+Ord {
 
     goals.scope().iterative::<usize,_,_>(|inner| {

--- a/experiments/src/bin/graphs-static.rs
+++ b/experiments/src/bin/graphs-static.rs
@@ -4,7 +4,7 @@ use timely::order::Product;
 use timely::dataflow::operators::ToStream;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::ArrangeByKey;
 use differential_dataflow::operators::arrange::ArrangeBySelf;
@@ -110,8 +110,8 @@ type TraceHandle = TraceAgent<GraphTrace>;
 
 fn reach<G: Scope<Timestamp = ()>> (
     graph: &mut TraceHandle,
-    roots: Collection<G, Node, Diff>
-) -> Collection<G, Node, Diff> {
+    roots: VecCollection<G, Node, Diff>
+) -> VecCollection<G, Node, Diff> {
 
     let graph = graph.import(&roots.scope());
 
@@ -135,8 +135,8 @@ fn reach<G: Scope<Timestamp = ()>> (
 
 fn bfs<G: Scope<Timestamp = ()>> (
     graph: &mut TraceHandle,
-    roots: Collection<G, Node, Diff>
-) -> Collection<G, (Node, u32), Diff> {
+    roots: VecCollection<G, Node, Diff>
+) -> VecCollection<G, (Node, u32), Diff> {
 
     let graph = graph.import(&roots.scope());
     let roots = roots.map(|r| (r,0));
@@ -161,7 +161,7 @@ fn connected_components<G: Scope<Timestamp = ()>>(
     scope: &mut G,
     forward: &mut TraceHandle,
     reverse: &mut TraceHandle,
-) -> Collection<G, (Node, Node), Diff> {
+) -> VecCollection<G, (Node, Node), Diff> {
 
     let forward = forward.import(scope);
     let reverse = reverse.import(scope);

--- a/experiments/src/bin/graphs.rs
+++ b/experiments/src/bin/graphs.rs
@@ -3,7 +3,7 @@ use rand::{Rng, SeedableRng, StdRng};
 use timely::dataflow::*;
 
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::ArrangeByKey;
 use differential_dataflow::operators::arrange::ArrangeBySelf;
@@ -92,8 +92,8 @@ type TraceHandle = TraceAgent<GraphTrace>;
 
 fn reach<G: Scope<Timestamp = ()>> (
     graph: &mut TraceHandle,
-    roots: Collection<G, Node>
-) -> Collection<G, Node> {
+    roots: VecCollection<G, Node>
+) -> VecCollection<G, Node> {
 
     let graph = graph.import(&roots.scope());
 
@@ -114,8 +114,8 @@ fn reach<G: Scope<Timestamp = ()>> (
 
 fn bfs<G: Scope<Timestamp = ()>> (
     graph: &mut TraceHandle,
-    roots: Collection<G, Node>
-) -> Collection<G, (Node, u32)> {
+    roots: VecCollection<G, Node>
+) -> VecCollection<G, (Node, u32)> {
 
     let graph = graph.import(&roots.scope());
     let roots = roots.map(|r| (r,0));
@@ -133,7 +133,7 @@ fn bfs<G: Scope<Timestamp = ()>> (
 
 // fn connected_components<G: Scope<Timestamp = ()>>(
 //     graph: &mut TraceHandle<Node>
-// ) -> Collection<G, (Node, Node)> {
+// ) -> VecCollection<G, (Node, Node)> {
 
 //     // each edge (x,y) means that we need at least a label for the min of x and y.
 //     let nodes =

--- a/experiments/src/bin/graspan2.rs
+++ b/experiments/src/bin/graspan2.rs
@@ -6,7 +6,7 @@ use timely::order::Product;
 
 use differential_dataflow::operators::iterate::SemigroupVariable;
 
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::input::Input;
 use differential_dataflow::operators::*;
 use differential_dataflow::operators::arrange::Arrange;
@@ -92,13 +92,13 @@ fn unoptimized() {
                         ;
 
                     // MA(a,b) <- D(x,a),VA(x,y),D(y,b)
-                    let memory_alias_next: Collection<_,_,Present> =
+                    let memory_alias_next: VecCollection<_,_,Present> =
                     value_alias_next
                         .join_core(&dereference, |_x,&y,&a| Some((y,a)))
                         .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
                         .join_core(&dereference, |_y,&a,&b| Some((a,b)));
 
-                    let memory_alias_next: Collection<_,_,Present>  =
+                    let memory_alias_next: VecCollection<_,_,Present>  =
                     memory_alias_next
                         .arrange::<KeyBatcher<_,_,_>, KeyBuilder<_,_,_>, KeySpine<_,_,_>>()
                         // .distinct_total_core::<Diff>()

--- a/interactive/src/plan/concat.rs
+++ b/interactive/src/plan/concat.rs
@@ -22,7 +22,7 @@ impl<V: ExchangeData+Hash+Datum> Render for Concat<V> {
     fn render<S: Scope<Timestamp = Time>>(
         &self,
         scope: &mut S,
-        arrangements: &mut TraceManager<V>) -> Collection<S, Vec<Self::Value>, Diff>
+        arrangements: &mut TraceManager<V>) -> VecCollection<S, Vec<Self::Value>, Diff>
     {
         use timely::dataflow::operators::Concatenate;
         use differential_dataflow::AsCollection;

--- a/interactive/src/plan/filter.rs
+++ b/interactive/src/plan/filter.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 use serde::{Deserialize, Serialize};
 use timely::dataflow::Scope;
 
-use differential_dataflow::{Collection, ExchangeData};
+use differential_dataflow::{VecCollection, ExchangeData};
 use crate::plan::{Plan, Render};
 use crate::{TraceManager, Time, Diff, Datum};
 
@@ -87,9 +87,9 @@ impl<V: ExchangeData+Hash+Datum> Render for Filter<V> {
     fn render<S: Scope<Timestamp = Time>>(
         &self,
         scope: &mut S,
-        collections: &mut std::collections::HashMap<Plan<Self::Value>, Collection<S, Vec<Self::Value>, Diff>>,
+        collections: &mut std::collections::HashMap<Plan<Self::Value>, VecCollection<S, Vec<Self::Value>, Diff>>,
         arrangements: &mut TraceManager<Self::Value>,
-    ) -> Collection<S, Vec<Self::Value>, Diff>
+    ) -> VecCollection<S, Vec<Self::Value>, Diff>
     {
         let predicate = self.predicate.clone();
         self.plan

--- a/interactive/src/plan/join.rs
+++ b/interactive/src/plan/join.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use timely::dataflow::Scope;
 
-use differential_dataflow::{Collection, ExchangeData};
+use differential_dataflow::{VecCollection, ExchangeData};
 use crate::plan::{Plan, Render};
 use crate::{TraceManager, Time, Diff, Datum};
 
@@ -29,9 +29,9 @@ impl<V: ExchangeData+Hash+Datum> Render for Join<V> {
     fn render<S: Scope<Timestamp = Time>>(
         &self,
         scope: &mut S,
-        collections: &mut std::collections::HashMap<Plan<Self::Value>, Collection<S, Vec<Self::Value>, Diff>>,
+        collections: &mut std::collections::HashMap<Plan<Self::Value>, VecCollection<S, Vec<Self::Value>, Diff>>,
         arrangements: &mut TraceManager<Self::Value>,
-    ) -> Collection<S, Vec<Self::Value>, Diff>
+    ) -> VecCollection<S, Vec<Self::Value>, Diff>
     {
         use differential_dataflow::operators::arrange::ArrangeByKey;
 

--- a/interactive/src/plan/map.rs
+++ b/interactive/src/plan/map.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use timely::dataflow::Scope;
 
-use differential_dataflow::{Collection, ExchangeData};
+use differential_dataflow::{VecCollection, ExchangeData};
 use crate::plan::{Plan, Render};
 use crate::{TraceManager, Time, Diff, Datum};
 
@@ -28,9 +28,9 @@ impl<V: ExchangeData+Hash+Datum> Render for Map<V> {
     fn render<S: Scope<Timestamp = Time>>(
         &self,
         scope: &mut S,
-        collections: &mut std::collections::HashMap<Plan<Self::Value>, Collection<S, Vec<Self::Value>, Diff>>,
+        collections: &mut std::collections::HashMap<Plan<Self::Value>, VecCollection<S, Vec<Self::Value>, Diff>>,
         arrangements: &mut TraceManager<Self::Value>,
-    ) -> Collection<S, Vec<Self::Value>, Diff>
+    ) -> VecCollection<S, Vec<Self::Value>, Diff>
     {
         let expressions = self.expressions.clone();
 

--- a/interactive/src/plan/mod.rs
+++ b/interactive/src/plan/mod.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 use serde::{Deserialize, Serialize};
 
 use timely::dataflow::Scope;
-use differential_dataflow::{Collection, ExchangeData};
+use differential_dataflow::{VecCollection, ExchangeData};
 
 use crate::{TraceManager, Time, Diff};
 
@@ -35,9 +35,9 @@ pub trait Render : Sized {
     fn render<S: Scope<Timestamp = Time>>(
         &self,
         scope: &mut S,
-        collections: &mut std::collections::HashMap<Plan<Self::Value>, Collection<S, Vec<Self::Value>, Diff>>,
+        collections: &mut std::collections::HashMap<Plan<Self::Value>, VecCollection<S, Vec<Self::Value>, Diff>>,
         arrangements: &mut TraceManager<Self::Value>,
-    ) -> Collection<S, Vec<Self::Value>, Diff>;
+    ) -> VecCollection<S, Vec<Self::Value>, Diff>;
 }
 
 /// Possible query plan types.
@@ -145,9 +145,9 @@ impl<V: ExchangeData+Hash+Datum> Render for Plan<V> {
     fn render<S: Scope<Timestamp = Time>>(
         &self,
         scope: &mut S,
-        collections: &mut std::collections::HashMap<Plan<Self::Value>, Collection<S, Vec<Self::Value>, Diff>>,
+        collections: &mut std::collections::HashMap<Plan<Self::Value>, VecCollection<S, Vec<Self::Value>, Diff>>,
         arrangements: &mut TraceManager<Self::Value>,
-    ) -> Collection<S, Vec<Self::Value>, Diff>
+    ) -> VecCollection<S, Vec<Self::Value>, Diff>
     {
         if collections.get(self).is_none() {
 

--- a/interactive/src/plan/sfw.rs
+++ b/interactive/src/plan/sfw.rs
@@ -31,7 +31,7 @@ use timely::dataflow::Scope;
 
 use differential_dataflow::operators::arrange::{ArrangeBySelf, ArrangeByKey};
 
-use differential_dataflow::{Collection, ExchangeData};
+use differential_dataflow::{VecCollection, ExchangeData};
 use crate::plan::{Plan, Render};
 use crate::{TraceManager, Time, Diff, Datum};
 
@@ -70,9 +70,9 @@ impl<V: ExchangeData+Hash+Datum> Render for MultiwayJoin<V> {
     fn render<S: Scope<Timestamp = Time>>(
         &self,
         scope: &mut S,
-        collections: &mut std::collections::HashMap<Plan<Self::Value>, Collection<S, Vec<Self::Value>, Diff>>,
+        collections: &mut std::collections::HashMap<Plan<Self::Value>, VecCollection<S, Vec<Self::Value>, Diff>>,
         arrangements: &mut TraceManager<Self::Value>,
-    ) -> Collection<S, Vec<Self::Value>, Diff>
+    ) -> VecCollection<S, Vec<Self::Value>, Diff>
     {
         // The idea here is the following:
         //

--- a/mdbook/src/chapter_2/chapter_2_1.md
+++ b/mdbook/src/chapter_2/chapter_2_1.md
@@ -11,7 +11,7 @@ As an example, our example program used `map` to reverse the pairs of identifier
 # use differential_dataflow::Collection;
 # use differential_dataflow::lattice::Lattice;
 # use differential_dataflow::operators::Join;
-# fn example<G: Scope>(manages: &Collection<G, (u64, u64)>)
+# fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
 # where G::Timestamp: Lattice
 # {
     manages
@@ -29,7 +29,7 @@ If instead we had just written
 # use timely::dataflow::Scope;
 # use differential_dataflow::Collection;
 # use differential_dataflow::lattice::Lattice;
-# fn example<G: Scope>(manages: &Collection<G, (u64, u64)>)
+# fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
 # where G::Timestamp: Lattice
 # {
     manages

--- a/mdbook/src/chapter_2/chapter_2_1.md
+++ b/mdbook/src/chapter_2/chapter_2_1.md
@@ -8,7 +8,7 @@ As an example, our example program used `map` to reverse the pairs of identifier
 # extern crate timely;
 # extern crate differential_dataflow;
 # use timely::dataflow::Scope;
-# use differential_dataflow::Collection;
+# use differential_dataflow::VecCollection;
 # use differential_dataflow::lattice::Lattice;
 # use differential_dataflow::operators::Join;
 # fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
@@ -27,7 +27,7 @@ If instead we had just written
 # extern crate timely;
 # extern crate differential_dataflow;
 # use timely::dataflow::Scope;
-# use differential_dataflow::Collection;
+# use differential_dataflow::VecCollection;
 # use differential_dataflow::lattice::Lattice;
 # fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
 # where G::Timestamp: Lattice

--- a/mdbook/src/chapter_2/chapter_2_2.md
+++ b/mdbook/src/chapter_2/chapter_2_2.md
@@ -8,7 +8,7 @@ As an example, we might select out those management relation where the manager h
 # extern crate timely;
 # extern crate differential_dataflow;
 # use timely::dataflow::Scope;
-# use differential_dataflow::Collection;
+# use differential_dataflow::VecCollection;
 # use differential_dataflow::lattice::Lattice;
 # fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
 # where G::Timestamp: Lattice

--- a/mdbook/src/chapter_2/chapter_2_2.md
+++ b/mdbook/src/chapter_2/chapter_2_2.md
@@ -10,7 +10,7 @@ As an example, we might select out those management relation where the manager h
 # use timely::dataflow::Scope;
 # use differential_dataflow::Collection;
 # use differential_dataflow::lattice::Lattice;
-# fn example<G: Scope>(manages: &Collection<G, (u64, u64)>)
+# fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
 # where G::Timestamp: Lattice
 # {
     manages

--- a/mdbook/src/chapter_2/chapter_2_3.md
+++ b/mdbook/src/chapter_2/chapter_2_3.md
@@ -10,7 +10,7 @@ For example, we might form the symmetric "management relation" by concatenating 
 # use timely::dataflow::Scope;
 # use differential_dataflow::Collection;
 # use differential_dataflow::lattice::Lattice;
-# fn example<G: Scope>(manages: &Collection<G, (u64, u64)>)
+# fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
 # where G::Timestamp: Lattice
 # {
     manages

--- a/mdbook/src/chapter_2/chapter_2_3.md
+++ b/mdbook/src/chapter_2/chapter_2_3.md
@@ -8,7 +8,7 @@ For example, we might form the symmetric "management relation" by concatenating 
 # extern crate timely;
 # extern crate differential_dataflow;
 # use timely::dataflow::Scope;
-# use differential_dataflow::Collection;
+# use differential_dataflow::VecCollection;
 # use differential_dataflow::lattice::Lattice;
 # fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
 # where G::Timestamp: Lattice

--- a/mdbook/src/chapter_2/chapter_2_4.md
+++ b/mdbook/src/chapter_2/chapter_2_4.md
@@ -13,7 +13,7 @@ As an example, if we were to inspect
 # use differential_dataflow::Collection;
 # use differential_dataflow::lattice::Lattice;
 # use differential_dataflow::operators::Reduce;
-# fn example<G: Scope>(manages: &Collection<G, (u64, u64)>)
+# fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
 # where G::Timestamp: Lattice
 # {
     manages
@@ -38,7 +38,7 @@ However, by introducing `consolidate`
 # use timely::dataflow::Scope;
 # use differential_dataflow::Collection;
 # use differential_dataflow::lattice::Lattice;
-# fn example<G: Scope>(manages: &Collection<G, (u64, u64)>)
+# fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
 # where G::Timestamp: Lattice
 # {
     manages

--- a/mdbook/src/chapter_2/chapter_2_4.md
+++ b/mdbook/src/chapter_2/chapter_2_4.md
@@ -10,7 +10,7 @@ As an example, if we were to inspect
 # extern crate timely;
 # extern crate differential_dataflow;
 # use timely::dataflow::Scope;
-# use differential_dataflow::Collection;
+# use differential_dataflow::VecCollection;
 # use differential_dataflow::lattice::Lattice;
 # use differential_dataflow::operators::Reduce;
 # fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
@@ -36,7 +36,7 @@ However, by introducing `consolidate`
 # extern crate timely;
 # extern crate differential_dataflow;
 # use timely::dataflow::Scope;
-# use differential_dataflow::Collection;
+# use differential_dataflow::VecCollection;
 # use differential_dataflow::lattice::Lattice;
 # fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
 # where G::Timestamp: Lattice

--- a/mdbook/src/chapter_2/chapter_2_5.md
+++ b/mdbook/src/chapter_2/chapter_2_5.md
@@ -11,7 +11,7 @@ Our example from earlier uses a join to match up pairs `(m2, m1)` and `(m1, p)` 
 # use differential_dataflow::Collection;
 # use differential_dataflow::operators::Join;
 # use differential_dataflow::lattice::Lattice;
-# fn example<G: Scope>(manages: &Collection<G, (u64, u64)>)
+# fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
 # where G::Timestamp: Lattice
 # {
     manages

--- a/mdbook/src/chapter_2/chapter_2_5.md
+++ b/mdbook/src/chapter_2/chapter_2_5.md
@@ -8,7 +8,7 @@ Our example from earlier uses a join to match up pairs `(m2, m1)` and `(m1, p)` 
 # extern crate timely;
 # extern crate differential_dataflow;
 # use timely::dataflow::Scope;
-# use differential_dataflow::Collection;
+# use differential_dataflow::VecCollection;
 # use differential_dataflow::operators::Join;
 # use differential_dataflow::lattice::Lattice;
 # fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)

--- a/mdbook/src/chapter_2/chapter_2_6.md
+++ b/mdbook/src/chapter_2/chapter_2_6.md
@@ -11,7 +11,7 @@ For example, to produce for each manager their managee with the lowest identifie
 # use differential_dataflow::Collection;
 # use differential_dataflow::lattice::Lattice;
 # use differential_dataflow::operators::Reduce;
-# fn example<G: Scope>(manages: &Collection<G, (u64, u64), i64>)
+# fn example<G: Scope>(manages: &VecCollection<G, (u64, u64), i64>)
 # where G::Timestamp: Lattice
 # {
     manages

--- a/mdbook/src/chapter_2/chapter_2_6.md
+++ b/mdbook/src/chapter_2/chapter_2_6.md
@@ -8,7 +8,7 @@ For example, to produce for each manager their managee with the lowest identifie
 # extern crate timely;
 # extern crate differential_dataflow;
 # use timely::dataflow::Scope;
-# use differential_dataflow::Collection;
+# use differential_dataflow::VecCollection;
 # use differential_dataflow::lattice::Lattice;
 # use differential_dataflow::operators::Reduce;
 # fn example<G: Scope>(manages: &VecCollection<G, (u64, u64), i64>)

--- a/mdbook/src/chapter_2/chapter_2_7.md
+++ b/mdbook/src/chapter_2/chapter_2_7.md
@@ -8,7 +8,7 @@ As an example, we can take our `manages` relation and determine for all employee
 # extern crate timely;
 # extern crate differential_dataflow;
 # use timely::dataflow::Scope;
-# use differential_dataflow::Collection;
+# use differential_dataflow::VecCollection;
 # use differential_dataflow::operators::{Join, Iterate, Threshold};
 # use differential_dataflow::lattice::Lattice;
 # fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
@@ -44,7 +44,7 @@ In the example above, we could rewrite
 # extern crate timely;
 # extern crate differential_dataflow;
 # use timely::dataflow::Scope;
-# use differential_dataflow::Collection;
+# use differential_dataflow::VecCollection;
 # use differential_dataflow::operators::{Join, Threshold};
 # use differential_dataflow::operators::{Iterate, iterate::VecVariable};
 # use differential_dataflow::lattice::Lattice;
@@ -86,7 +86,7 @@ As an example, the implementation of the `iterate` operator looks something like
 # use timely::dataflow::Scope;
 # use timely::dataflow::scopes::Child;
 # use timely::progress::Antichain;
-# use differential_dataflow::Collection;
+# use differential_dataflow::VecCollection;
 # use differential_dataflow::operators::{Iterate, iterate::VecVariable};
 # use differential_dataflow::lattice::Lattice;
 # fn logic<'a, G: Scope>(variable: &VecVariable<Child<'a, G, G::Timestamp>, (u64, u64), isize>) -> VecCollection<Child<'a, G, G::Timestamp>, (u64, u64)>

--- a/mdbook/src/chapter_2/chapter_2_7.md
+++ b/mdbook/src/chapter_2/chapter_2_7.md
@@ -11,7 +11,7 @@ As an example, we can take our `manages` relation and determine for all employee
 # use differential_dataflow::Collection;
 # use differential_dataflow::operators::{Join, Iterate, Threshold};
 # use differential_dataflow::lattice::Lattice;
-# fn example<G: Scope>(manages: &Collection<G, (u64, u64)>)
+# fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
 # where G::Timestamp: Lattice
 # {
     manages   // transitive contains (manager, person) for many hops.
@@ -46,9 +46,9 @@ In the example above, we could rewrite
 # use timely::dataflow::Scope;
 # use differential_dataflow::Collection;
 # use differential_dataflow::operators::{Join, Threshold};
-# use differential_dataflow::operators::{Iterate, iterate::VariableRow};
+# use differential_dataflow::operators::{Iterate, iterate::VecVariable};
 # use differential_dataflow::lattice::Lattice;
-# fn example<G: Scope>(manages: &Collection<G, (u64, u64)>)
+# fn example<G: Scope>(manages: &VecCollection<G, (u64, u64)>)
 # where G::Timestamp: Lattice
 # {
     manages   // transitive contains (manager, person) for many hops.
@@ -87,18 +87,18 @@ As an example, the implementation of the `iterate` operator looks something like
 # use timely::dataflow::scopes::Child;
 # use timely::progress::Antichain;
 # use differential_dataflow::Collection;
-# use differential_dataflow::operators::{Iterate, iterate::VariableRow};
+# use differential_dataflow::operators::{Iterate, iterate::VecVariable};
 # use differential_dataflow::lattice::Lattice;
-# fn logic<'a, G: Scope>(variable: &VariableRow<Child<'a, G, G::Timestamp>, (u64, u64), isize>) -> Collection<Child<'a, G, G::Timestamp>, (u64, u64)>
+# fn logic<'a, G: Scope>(variable: &VecVariable<Child<'a, G, G::Timestamp>, (u64, u64), isize>) -> VecCollection<Child<'a, G, G::Timestamp>, (u64, u64)>
 # where G::Timestamp: Lattice
 # {
 #     (*variable).clone()
 # }
-# fn example<'a, G: Scope<Timestamp=u64>>(collection: &Collection<G, (u64, u64)>) //, logic: impl Fn(&VariableRow<Child<'a, G, G::Timestamp>, (u64, u64), isize>) -> Collection<Child<'a, G, G::Timestamp>, (u64, u64)>)
+# fn example<'a, G: Scope<Timestamp=u64>>(collection: &VecCollection<G, (u64, u64)>) //, logic: impl Fn(&VecVariable<Child<'a, G, G::Timestamp>, (u64, u64), isize>) -> VecCollection<Child<'a, G, G::Timestamp>, (u64, u64)>)
 #    where G::Timestamp: Lattice
 # {
     collection.scope().scoped("inner", |subgraph| {
-        let variable = VariableRow::new_from(collection.enter(subgraph), 1);
+        let variable = VecVariable::new_from(collection.enter(subgraph), 1);
         let result = logic(&variable);
         variable.set(&result);
         result.leave()

--- a/mdbook/src/chapter_2/chapter_2_7.md
+++ b/mdbook/src/chapter_2/chapter_2_7.md
@@ -46,7 +46,7 @@ In the example above, we could rewrite
 # use timely::dataflow::Scope;
 # use differential_dataflow::Collection;
 # use differential_dataflow::operators::{Join, Threshold};
-# use differential_dataflow::operators::{Iterate, iterate::Variable};
+# use differential_dataflow::operators::{Iterate, iterate::VariableRow};
 # use differential_dataflow::lattice::Lattice;
 # fn example<G: Scope>(manages: &Collection<G, (u64, u64)>)
 # where G::Timestamp: Lattice
@@ -87,18 +87,18 @@ As an example, the implementation of the `iterate` operator looks something like
 # use timely::dataflow::scopes::Child;
 # use timely::progress::Antichain;
 # use differential_dataflow::Collection;
-# use differential_dataflow::operators::{Iterate, iterate::Variable};
+# use differential_dataflow::operators::{Iterate, iterate::VariableRow};
 # use differential_dataflow::lattice::Lattice;
-# fn logic<'a, G: Scope>(variable: &Variable<Child<'a, G, G::Timestamp>, (u64, u64), isize>) -> Collection<Child<'a, G, G::Timestamp>, (u64, u64)>
+# fn logic<'a, G: Scope>(variable: &VariableRow<Child<'a, G, G::Timestamp>, (u64, u64), isize>) -> Collection<Child<'a, G, G::Timestamp>, (u64, u64)>
 # where G::Timestamp: Lattice
 # {
 #     (*variable).clone()
 # }
-# fn example<'a, G: Scope<Timestamp=u64>>(collection: &Collection<G, (u64, u64)>) //, logic: impl Fn(&Variable<Child<'a, G, G::Timestamp>, (u64, u64), isize>) -> Collection<Child<'a, G, G::Timestamp>, (u64, u64)>)
+# fn example<'a, G: Scope<Timestamp=u64>>(collection: &Collection<G, (u64, u64)>) //, logic: impl Fn(&VariableRow<Child<'a, G, G::Timestamp>, (u64, u64), isize>) -> Collection<Child<'a, G, G::Timestamp>, (u64, u64)>)
 #    where G::Timestamp: Lattice
 # {
     collection.scope().scoped("inner", |subgraph| {
-        let variable = Variable::new_from(collection.enter(subgraph), 1);
+        let variable = VariableRow::new_from(collection.enter(subgraph), 1);
         let result = logic(&variable);
         variable.set(&result);
         result.leave()

--- a/tpchlike/src/lib.rs
+++ b/tpchlike/src/lib.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use timely::dataflow::*;
 use timely::dataflow::operators::CapabilitySet;
 
-use differential_dataflow::Collection;
+use differential_dataflow::VecCollection;
 use differential_dataflow::operators::arrange::ArrangeByKey;
 use differential_dataflow::operators::arrange::ShutdownButton;
 

--- a/tpchlike/src/lib.rs
+++ b/tpchlike/src/lib.rs
@@ -66,27 +66,27 @@ impl InputHandles {
 }
 
 pub struct Collections<G: Scope> {
-    customers: Collection<G, Customer, isize>,
-    lineitems: Collection<G, Rc<LineItem>, isize>,
-    nations: Collection<G, Nation, isize>,
-    orders: Collection<G, Order, isize>,
-    parts: Collection<G, Part, isize>,
-    partsupps: Collection<G, PartSupp, isize>,
-    regions: Collection<G, Region, isize>,
-    suppliers: Collection<G, Supplier, isize>,
+    customers: VecCollection<G, Customer, isize>,
+    lineitems: VecCollection<G, Rc<LineItem>, isize>,
+    nations: VecCollection<G, Nation, isize>,
+    orders: VecCollection<G, Order, isize>,
+    parts: VecCollection<G, Part, isize>,
+    partsupps: VecCollection<G, PartSupp, isize>,
+    regions: VecCollection<G, Region, isize>,
+    suppliers: VecCollection<G, Supplier, isize>,
     used: [bool; 8],
 }
 
 impl<G: Scope> Collections<G> {
     pub fn new(
-        customers: Collection<G, Customer, isize>,
-        lineitems: Collection<G, Rc<LineItem>, isize>,
-        nations: Collection<G, Nation, isize>,
-        orders: Collection<G, Order, isize>,
-        parts: Collection<G, Part, isize>,
-        partsupps: Collection<G, PartSupp, isize>,
-        regions: Collection<G, Region, isize>,
-        suppliers: Collection<G, Supplier, isize>,
+        customers: VecCollection<G, Customer, isize>,
+        lineitems: VecCollection<G, Rc<LineItem>, isize>,
+        nations: VecCollection<G, Nation, isize>,
+        orders: VecCollection<G, Order, isize>,
+        parts: VecCollection<G, Part, isize>,
+        partsupps: VecCollection<G, PartSupp, isize>,
+        regions: VecCollection<G, Region, isize>,
+        suppliers: VecCollection<G, Supplier, isize>,
     ) -> Self {
 
         Collections {
@@ -102,14 +102,14 @@ impl<G: Scope> Collections<G> {
         }
     }
 
-    pub fn customers(&mut self) -> &Collection<G, Customer, isize> { self.used[0] = true; &self.customers }
-    pub fn lineitems(&mut self) -> &Collection<G, Rc<LineItem>, isize> { self.used[1] = true; &self.lineitems }
-    pub fn nations(&mut self) -> &Collection<G, Nation, isize> { self.used[2] = true; &self.nations }
-    pub fn orders(&mut self) -> &Collection<G, Order, isize> { self.used[3] = true; &self.orders }
-    pub fn parts(&mut self) -> &Collection<G, Part, isize> { self.used[4] = true; &self.parts }
-    pub fn partsupps(&mut self) -> &Collection<G, PartSupp, isize> { self.used[5] = true; &self.partsupps }
-    pub fn regions(&mut self) -> &Collection<G, Region, isize> { self.used[6] = true; &self.regions }
-    pub fn suppliers(&mut self) -> &Collection<G, Supplier, isize> { self.used[7] = true; &self.suppliers }
+    pub fn customers(&mut self) -> &VecCollection<G, Customer, isize> { self.used[0] = true; &self.customers }
+    pub fn lineitems(&mut self) -> &VecCollection<G, Rc<LineItem>, isize> { self.used[1] = true; &self.lineitems }
+    pub fn nations(&mut self) -> &VecCollection<G, Nation, isize> { self.used[2] = true; &self.nations }
+    pub fn orders(&mut self) -> &VecCollection<G, Order, isize> { self.used[3] = true; &self.orders }
+    pub fn parts(&mut self) -> &VecCollection<G, Part, isize> { self.used[4] = true; &self.parts }
+    pub fn partsupps(&mut self) -> &VecCollection<G, PartSupp, isize> { self.used[5] = true; &self.partsupps }
+    pub fn regions(&mut self) -> &VecCollection<G, Region, isize> { self.used[6] = true; &self.regions }
+    pub fn suppliers(&mut self) -> &VecCollection<G, Supplier, isize> { self.used[7] = true; &self.suppliers }
 
     pub fn used(&self) -> [bool; 8] { self.used }
 }
@@ -268,7 +268,7 @@ impl Experiment {
             buttons: Vec::new(),
         }
     }
-    pub fn lineitem<G: Scope<Timestamp=usize>>(&mut self, scope: &mut G) -> Collection<G, Rc<LineItem>, isize> {
+    pub fn lineitem<G: Scope<Timestamp=usize>>(&mut self, scope: &mut G) -> VecCollection<G, Rc<LineItem>, isize> {
         use timely::dataflow::operators::Input;
         use differential_dataflow::AsCollection;
         scope.input_from(&mut self.lineitem).as_collection()


### PR DESCRIPTION
The `Collection` type has a bunch of generic arguments that need to line up just so, several are usually redundant, and some are phantoms in certain settings. This PR shakes out some of the dust by introducing a `CollectionCore<G, C>` type, generic in the graph scope and the container type, with a `type Collection<G, D, R>` definition that introduces the container `Vec<(D, G::Timestamp, R)>`, which is a handy default when you don't care, but whose details (around `D` and `R`) aren't helpful for containers who may not have owned types in mind.