### PR TITLE
Replace `IndexMap` with `BTreeMap`

### DIFF
--- a/differential-dataflow/Cargo.toml
+++ b/differential-dataflow/Cargo.toml
@@ -16,7 +16,6 @@ readme = "../README.md"
 edition="2021"
 
 [dev-dependencies]
-indexmap = "2.1"
 rand="0.4"
 itertools="^0.13"
 graph_map = "0.1"

--- a/doop/Cargo.toml
+++ b/doop/Cargo.toml
@@ -6,6 +6,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-indexmap = "2.1"
 timely = {workspace = true}
 differential-dataflow = { workspace = true }


### PR DESCRIPTION
We introduced a dependence on `indexmap` due to `HashMap`s inconsistent enumeration order. However, a `BTreeMap` would be good enough, and `indexmap` seems to have done some MSRV bumps that we don't need.