### PR TITLE
Exchange columns more efficiently

### DIFF
--- a/differential-dataflow/src/trace/implementations/ord_neu.rs
+++ b/differential-dataflow/src/trace/implementations/ord_neu.rs
@@ -89,7 +89,7 @@ pub mod layers {
 
     impl<O: for<'a> BatchContainer<ReadItem<'a> = usize>, V: BatchContainer> Vals<O, V> {
         /// Lower and upper bounds in `self.vals` of the indexed list.
-        pub fn bounds(&self, index: usize) -> (usize, usize) {
+        #[inline(always)] pub fn bounds(&self, index: usize) -> (usize, usize) {
             (self.offs.index(index), self.offs.index(index+1))
         }
         /// Retrieves a value using relative indexes.


### PR DESCRIPTION
The columnar trie datastructures used in `examples/columnar.rs` are grouped by key, and also need to be exchanged by (a hash of) the key. We can do this without departing from the columnar representation, which this PR introduces. It also inlines a hot function in `ord_neu.rs`.