### PR TITLE
Remove SizableContainer requirement from InternalMerge

### DIFF
--- a/differential-dataflow/src/columnar/arrangement/mod.rs
+++ b/differential-dataflow/src/columnar/arrangement/mod.rs
@@ -255,17 +255,11 @@ impl<U: super::layout::ColumnarUpdate> timely::container::ContainerBuilder for T
 pub mod batcher {
     //! Batcher trait stubs required to plug `UpdatesTyped` into DD's merge batcher.
 
-    use columnar::Len;
     use timely::progress::frontier::{Antichain, AntichainRef};
     use crate::trace::implementations::merge_batcher::container::InternalMerge;
 
     use super::super::layout::ColumnarUpdate as Update;
     use super::super::updates::UpdatesTyped;
-
-    impl<U: Update> timely::container::SizableContainer for UpdatesTyped<U> {
-        fn at_capacity(&self) -> bool { self.view().diffs.values.len() >= crate::columnar::LINK_TARGET }
-        fn ensure_capacity(&mut self, _stash: &mut Option<Self>) { }
-    }
 
     /// Required by `reduce_abelian`'s bound `Builder::Input: InternalMerge`.
     /// Not called at runtime — our batcher uses `TrieMerger` instead.

--- a/differential-dataflow/src/trace/implementations/merge_batcher.rs
+++ b/differential-dataflow/src/trace/implementations/merge_batcher.rs
@@ -238,7 +238,7 @@ pub mod container {
 
     /// A container that supports the operations needed by the merge batcher:
     /// merging sorted chains and extracting updates by time.
-    pub trait InternalMerge: Accountable + SizableContainer + Default {
+    pub trait InternalMerge: Accountable + Default {
         /// The owned time type, for maintaining antichains.
         type TimeOwned;
 
@@ -457,7 +457,7 @@ pub mod container {
         fn default() -> Self { Self { _marker: PhantomData } }
     }
 
-    impl<MC> InternalMerger<MC> where MC: InternalMerge {
+    impl<MC> InternalMerger<MC> where MC: InternalMerge + SizableContainer {
         #[inline]
         fn empty(&self, stash: &mut Vec<MC>) -> MC {
             stash.pop().unwrap_or_else(|| {
@@ -503,7 +503,7 @@ pub mod container {
 
     impl<MC> Merger for InternalMerger<MC>
     where
-        MC: InternalMerge<TimeOwned: Ord + PartialOrder + Clone + 'static> + 'static,
+        MC: InternalMerge<TimeOwned: Ord + PartialOrder + Clone + 'static> + SizableContainer + 'static,
     {
         type Time = MC::TimeOwned;
         type Chunk = MC;


### PR DESCRIPTION
InternalMerge doesn't require SizableContainer, only some of its implementations do. Instead, we push the requirement where it's used. This allows us to build a columnar-based merge batcher without a SizableContainer implementation.
