### PR TITLE
interactive/explain: correctness fixes

### DIFF
--- a/interactive/src/explain.rs
+++ b/interactive/src/explain.rs
@@ -886,9 +886,23 @@ mod reverse {
                             let contrib = self.filter(dep_this, cond.clone());
                             contribs.entry(*input).or_default().push(contrib);
                         }
-                        LinearOp::Negate | LinearOp::EnterAt(_) => {
-                            // Pure pass-through: data unchanged, scope
-                            // unchanged.
+                        LinearOp::Negate => {
+                            // Pure pass-through: data unchanged, scope unchanged.
+                            contribs.entry(*input).or_default().push(dep_this);
+                        }
+                        LinearOp::EnterAt(_) => {
+                            // Sound but over-broad. EnterAt is a data→time lift: it sets a new
+                            // innermost user_chain coord `t_in = delay($field)` from the value,
+                            // so its output is one scope deeper than its input. The 1:1 reverse
+                            // would DROP that coord (recoverable as `delay($field)` from the
+                            // preserved value): out ((k,v),[t_in,t_out..]) -> in ((k,v),[t_out..]).
+                            // We instead pass demand through unchanged — tenable only because
+                            // `depths()` is positional and treats EnterAt as depth-neutral, so
+                            // the coord is stripped *unconstrained* by the neighboring Project
+                            // that crosses the scope boundary. The result is a superset (kept
+                            // sound by the `semijoin(actual_input)` at seeding); it never drops a
+                            // needed edge. Tight fix: let `depths()` give EnterAt its own level
+                            // and make this arm drop the innermost coord — see `depths()` (ir.rs).
                             contribs.entry(*input).or_default().push(dep_this);
                         }
                         LinearOp::LiftIter => {

--- a/interactive/src/explain.rs
+++ b/interactive/src/explain.rs
@@ -1148,7 +1148,18 @@ mod reverse {
         let total = (0..k_in).all(|c| known.contains_key(&(0, c)))
             && (0..v_in).all(|c| known.contains_key(&(1, c)));
 
-        if total && in_user_len == 0 {
+        // Pure-map shortcut, extended to same-scope projects of any depth.
+        // A Linear[Project] doesn't cross a scope boundary, so the input's
+        // user_chain equals the output's (in_user_len == out_user_len ==
+        // keep_in_len when the input isn't a Leave). When every input field is
+        // also recoverable from the output, the whole reverse is a direct map
+        // from dep_y, narrowing by *all* demanded fields — including value
+        // fields the pair-table join (keyed on K_out only) ignores. That
+        // key-only match is what let sibling rows leak through a re-key that
+        // drops a field from the key (e.g. by_b = tc | key($0[1]; …), keyed by
+        // tc's destination only → fallback recovered every same-destination
+        // pair regardless of source).
+        if total && in_user_len == out_user_len && keep_in_len == in_user_len {
             // Map flat output position p (into [K_out ++ V_out]) to an access
             // expression against dep_y's (key, val) layout:
             //   p < k_out → $0[p]                 (key)
@@ -1158,9 +1169,11 @@ mod reverse {
                 else { FieldExpr::Index(1, p - k_out) }
             };
             let key: Vec<FieldExpr> = (0..k_in).map(|c| access(known[&(0, c)])).collect();
-            let mut val: Vec<FieldExpr> = Vec::with_capacity(v_in + 1);
+            let mut val: Vec<FieldExpr> = Vec::with_capacity(v_in + in_user_len + 1);
             for c in 0..v_in { val.push(access(known[&(1, c)])); }
-            // user_in is empty (in_user_len == 0); q is at $1[v_out + out_user_len].
+            // user_in == user_out (same scope), so copy it through. The filter
+            // user_in ≤ user_out then holds with equality. q at $1[v_out+out_user_len].
+            for i in 0..out_user_len { val.push(FieldExpr::Index(1, v_out + i)); }
             val.push(FieldExpr::Index(1, v_out + out_user_len));
             return self.project(dep_y, Projection { key, val });
         }

--- a/interactive/src/explain.rs
+++ b/interactive/src/explain.rs
@@ -1025,43 +1025,15 @@ mod reverse {
         out_len: usize,
         keep_in_len: usize,
     ) -> Id {
-        assert!(keep_in_len <= in_len);
+        // The user_chain index arithmetic (the outer-end alignment whose
+        // off-by-one made SCC explain unsound) lives in `folded::Joined`, the
+        // single home shared with the scope-builder ports.
+        let layout = crate::folded::Joined { v_pre, in_len, out_len };
         let mut cur = coll;
-        let cmp_len = in_len.min(out_len);
-        if cmp_len > 0 {
-            // user_chain is innermost-first. When `in_len != out_len` (a
-            // `Leave` crossing drops the innermost coord), the *shared*
-            // scopes are the outer ones — the last `cmp_len` coords of each
-            // chain. Align both to their outer ends so we compare the same
-            // scope's iter coord on each side; comparing from index 0 would
-            // pair the just-left inner scope against an enclosing scope.
-            let in_off = in_len - cmp_len;
-            let out_off = out_len - cmp_len;
-            let mut acc: Option<Condition> = None;
-            for i in 0..cmp_len {
-                let cond = Condition::Le(
-                    FieldExpr::Index(1, v_pre + in_off + i),                // user_in[in_off + i]
-                    FieldExpr::Index(1, v_pre + in_len + out_off + i),      // user_out[out_off + i]
-                );
-                acc = Some(match acc {
-                    None => cond,
-                    Some(prev) => Condition::And(Box::new(prev), Box::new(cond)),
-                });
-            }
-            cur = self.filter(cur, acc.unwrap());
+        if let Some(cond) = layout.time_le() {
+            cur = self.filter(cur, cond);
         }
-        // Strip user_out and the innermost coords of user_in past `keep_in_len`,
-        // preserving (K; V_pre ++ user_in[in_len - keep_in_len .. in_len] ++ [q]).
-        // user_chain is innermost-first, so the *last* `keep_in_len` coords
-        // correspond to the outer scopes that contribs at the input side care
-        // about; the dropped innermost coords belong to scope(s) we've left.
-        let key: Vec<FieldExpr> = (0..k_out).map(|i| FieldExpr::Index(0, i)).collect();
-        let mut val: Vec<FieldExpr> = Vec::new();
-        for i in 0..v_pre { val.push(FieldExpr::Index(1, i)); }
-        let drop_in = in_len - keep_in_len;
-        for i in 0..keep_in_len { val.push(FieldExpr::Index(1, v_pre + drop_in + i)); }
-        val.push(FieldExpr::Index(1, v_pre + in_len + out_len)); // q
-        self.project(cur, Projection { key, val })
+        self.project(cur, layout.strip(k_out, keep_in_len))
     }
 
     /// Keyed lookup (Reduce-style): demand on `(K; V_out ++ user_out ++ q)`

--- a/interactive/src/explain.rs
+++ b/interactive/src/explain.rs
@@ -482,7 +482,7 @@ pub mod arities {
     use std::collections::BTreeMap;
 
     use crate::ir::{Id, LinearOp, Node, Program};
-    use crate::parse::Reducer;
+    use crate::parse::{FieldExpr, Reducer};
 
     pub fn compute_arities(
         p: &Program,
@@ -515,7 +515,17 @@ pub mod arities {
                     // shape and let fixed-point iteration propagate.
                     Node::Concat(ids) => ids.iter().find_map(|i| out.get(i).copied()),
                     Node::Arrange(input) => out.get(input).copied(),
-                    Node::Join { projection, .. } => Some((projection.key.len(), projection.val.len())),
+                    // A projection's arity is the sum of each field's *width*,
+                    // not the count of field-exprs: `Pos(r)` is a whole-row
+                    // reference that expands to input row `r`'s arity. The
+                    // join's input rows are [key, left_val, right_val].
+                    Node::Join { left, right, projection } => match (out.get(left), out.get(right)) {
+                        (Some(&(kl, vl)), Some(&(_kr, vr))) => {
+                            let rows = [kl, vl, vr];
+                            Some((proj_arity(&projection.key, &rows), proj_arity(&projection.val, &rows)))
+                        }
+                        _ => None,
+                    },
                     Node::Reduce { input, reducer } => out.get(input).map(|s| match reducer {
                         Reducer::Distinct => (s.0, 0),
                         Reducer::Min => (s.0, s.1),
@@ -536,12 +546,36 @@ pub mod arities {
     fn apply_ops_arity((mut k, mut v): (usize, usize), ops: &[LinearOp]) -> (usize, usize) {
         for op in ops {
             match op {
-                LinearOp::Project(p) => { k = p.key.len(); v = p.val.len(); }
+                // Project's input rows are [key, val]; expand `Pos` refs to
+                // their row arities rather than counting field-exprs.
+                LinearOp::Project(p) => {
+                    let rows = [k, v];
+                    k = proj_arity(&p.key, &rows);
+                    v = proj_arity(&p.val, &rows);
+                }
                 LinearOp::Filter(_) | LinearOp::Negate | LinearOp::EnterAt(_) => {}
                 LinearOp::LiftIter => { v += 1; }
             }
         }
         (k, v)
+    }
+
+    /// Width (output columns) a single `FieldExpr` expands to, given the
+    /// arities of the input rows it may reference. `Pos(r)` is a whole-row
+    /// reference of width `rows[r]`; index/const are single columns.
+    fn field_width(f: &FieldExpr, rows: &[usize]) -> usize {
+        match f {
+            FieldExpr::Pos(r) => rows.get(*r).copied().unwrap_or(0),
+            FieldExpr::Index(_, _) | FieldExpr::Const(_) => 1,
+            FieldExpr::Neg(inner) => field_width(inner, rows),
+            FieldExpr::Sub(a, _) => field_width(a, rows),
+        }
+    }
+
+    /// Total arity of one projection side (`key`/`val`): the sum of its
+    /// fields' widths.
+    fn proj_arity(fields: &[FieldExpr], rows: &[usize]) -> usize {
+        fields.iter().map(|f| field_width(f, rows)).sum()
     }
 }
 
@@ -995,11 +1029,19 @@ mod reverse {
         let mut cur = coll;
         let cmp_len = in_len.min(out_len);
         if cmp_len > 0 {
+            // user_chain is innermost-first. When `in_len != out_len` (a
+            // `Leave` crossing drops the innermost coord), the *shared*
+            // scopes are the outer ones — the last `cmp_len` coords of each
+            // chain. Align both to their outer ends so we compare the same
+            // scope's iter coord on each side; comparing from index 0 would
+            // pair the just-left inner scope against an enclosing scope.
+            let in_off = in_len - cmp_len;
+            let out_off = out_len - cmp_len;
             let mut acc: Option<Condition> = None;
             for i in 0..cmp_len {
                 let cond = Condition::Le(
-                    FieldExpr::Index(1, v_pre + i),               // user_in[i]
-                    FieldExpr::Index(1, v_pre + in_len + i),      // user_out[i]
+                    FieldExpr::Index(1, v_pre + in_off + i),                // user_in[in_off + i]
+                    FieldExpr::Index(1, v_pre + in_len + out_off + i),      // user_out[out_off + i]
                 );
                 acc = Some(match acc {
                     None => cond,

--- a/interactive/src/folded.rs
+++ b/interactive/src/folded.rs
@@ -1,0 +1,133 @@
+//! Centralized `user_chain` (folded iteration-time) algebra.
+//!
+//! The reverse-tracing explanation rewrite moves iteration time *into data*: a
+//! demand row's value carries some number of user-chain coordinates
+//! (innermost-first) plus a trailing query id. Indexing those by hand —
+//! `FieldExpr::Index(1, v_pre + …)` scattered across the reverse rules — is
+//! what produced SCC explain's off-by-one (comparing a just-left inner scope's
+//! coord against an enclosing scope's). This module owns that arithmetic so it
+//! exists once, correct, and every rule (and the scope builder's ports) routes
+//! through it.
+
+use crate::parse::{Condition, FieldExpr, Projection};
+
+/// The value layout of a *joined* demand row, as the reverse lookups produce it
+/// before filtering: in the value row (`$1`),
+/// `[V_pre (v_pre)] [user_in (in_len)] [user_out (out_len)] [q]`,
+/// with each user-chain innermost-first.
+#[derive(Clone, Copy, Debug)]
+pub struct Joined {
+    /// Non-time value columns carried through (e.g. `V_in`).
+    pub v_pre: usize,
+    /// user-chain length of the input side.
+    pub in_len: usize,
+    /// user-chain length of the output (demand) side.
+    pub out_len: usize,
+}
+
+impl Joined {
+    /// Value-row index of input-side user coord `i` (0 = innermost).
+    fn user_in(self, i: usize) -> usize {
+        self.v_pre + i
+    }
+    /// Value-row index of output-side user coord `i` (0 = innermost).
+    fn user_out(self, i: usize) -> usize {
+        self.v_pre + self.in_len + i
+    }
+    /// Value-row index of the trailing query id.
+    fn q(self) -> usize {
+        self.v_pre + self.in_len + self.out_len
+    }
+
+    /// The soundness filter `user_in.time ≤ user_out.time`, aligned at the
+    /// **outer** ends. user_chain is innermost-first, so when the two sides
+    /// differ in length (a `Leave` crossing drops the innermost coord) the
+    /// *shared* scopes are the outer ones — the last `min(in,out)` coords of
+    /// each side. Aligning from index 0 instead is exactly the bug that made
+    /// SCC explain unsound. Returns `None` when there's nothing to compare.
+    pub fn time_le(self) -> Option<Condition> {
+        let n = self.in_len.min(self.out_len);
+        let in_off = self.in_len - n;
+        let out_off = self.out_len - n;
+        let mut acc: Option<Condition> = None;
+        for i in 0..n {
+            let cond = Condition::Le(
+                FieldExpr::Index(1, self.user_in(in_off + i)),
+                FieldExpr::Index(1, self.user_out(out_off + i)),
+            );
+            acc = Some(match acc {
+                None => cond,
+                Some(prev) => Condition::And(Box::new(prev), Box::new(cond)),
+            });
+        }
+        acc
+    }
+
+    /// The projection that strips `user_out` and the innermost `user_in` coords
+    /// past `keep_in_len`, leaving `(K[k_out]; V_pre ++ outer keep_in_len ++ [q])`.
+    /// The kept coords are the *outer* ones (last `keep_in_len`), matching the
+    /// outer alignment in `time_le`.
+    pub fn strip(self, k_out: usize, keep_in_len: usize) -> Projection {
+        assert!(keep_in_len <= self.in_len, "strip: keep_in_len exceeds in_len");
+        let key = (0..k_out).map(|i| FieldExpr::Index(0, i)).collect();
+        let mut val: Vec<FieldExpr> = Vec::new();
+        for i in 0..self.v_pre {
+            val.push(FieldExpr::Index(1, i));
+        }
+        let drop_in = self.in_len - keep_in_len;
+        for i in 0..keep_in_len {
+            val.push(FieldExpr::Index(1, self.user_in(drop_in + i)));
+        }
+        val.push(FieldExpr::Index(1, self.q()));
+        Projection { key, val }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn le_indices(c: &Condition) -> (usize, usize) {
+        match c {
+            Condition::Le(FieldExpr::Index(1, a), FieldExpr::Index(1, b)) => (*a, *b),
+            other => panic!("expected a single value-row Le, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn time_le_aligns_outer_ends_across_a_leave() {
+        // Leave crossing: input is one scope deeper (in_len 2) than the demand
+        // (out_len 1). The shared scope is the OUTER one, so compare
+        // user_in[1] (not user_in[0], the just-left inner scope) vs user_out[0].
+        let j = Joined { v_pre: 3, in_len: 2, out_len: 1 };
+        // user_in[1] = 3 + 1 = 4 ; user_out[0] = 3 + 2 + 0 = 5
+        assert_eq!(le_indices(&j.time_le().unwrap()), (4, 5));
+    }
+
+    #[test]
+    fn time_le_equal_depth_aligns_from_zero() {
+        // Same depth (e.g. a Concat input): align from index 0.
+        let j = Joined { v_pre: 2, in_len: 1, out_len: 1 };
+        // user_in[0] = 2 ; user_out[0] = 2 + 1 = 3
+        assert_eq!(le_indices(&j.time_le().unwrap()), (2, 3));
+    }
+
+    #[test]
+    fn time_le_empty_when_no_shared_coords() {
+        assert!(Joined { v_pre: 1, in_len: 1, out_len: 0 }.time_le().is_none());
+    }
+
+    #[test]
+    fn strip_keeps_outer_coords_and_q() {
+        // in_len 2, keep 1 → drop the innermost input coord, keep the outer one.
+        let j = Joined { v_pre: 1, in_len: 2, out_len: 1 };
+        let p = j.strip(1, 1);
+        let idx = |f: &FieldExpr| match f {
+            FieldExpr::Index(r, c) => (*r, *c),
+            other => panic!("expected Index, got {:?}", other),
+        };
+        assert_eq!(p.key.iter().map(idx).collect::<Vec<_>>(), vec![(0, 0)]);
+        // val = [V_pre[0]=(1,0), user_in[1]=(1,2) (outer kept coord), q=(1,4)]
+        assert_eq!(p.val.iter().map(idx).collect::<Vec<_>>(), vec![(1, 0), (1, 2), (1, 4)]);
+    }
+}

--- a/interactive/src/ir.rs
+++ b/interactive/src/ir.rs
@@ -125,6 +125,14 @@ impl Program {
     /// active at the moment it was lowered; `Scope` itself sits at its
     /// outer depth (the increment applies to subsequent nodes), and
     /// `EndScope` sits at its inner depth (the decrement applies after).
+    ///
+    /// Note: this is purely positional, so `enter_at` — a data→time lift that
+    /// semantically adds one scope coordinate (its output is one level deeper
+    /// than its input) — is counted depth-NEUTRAL here. The coordinate it
+    /// introduces is instead absorbed by a neighboring Project's depth jump and
+    /// stripped *unconstrained* in the reverse rewrite: sound but over-broad.
+    /// The fix is to let `enter_at` own its level (output = input depth + 1);
+    /// see the `LinearOp::EnterAt` arm in `explain.rs::emit_reverse`.
     pub fn depths(&self) -> BTreeMap<Id, usize> {
         let mut out = BTreeMap::new();
         let mut depth = 0usize;

--- a/interactive/src/lib.rs
+++ b/interactive/src/lib.rs
@@ -2,6 +2,7 @@ pub mod parse;
 pub mod ir;
 pub mod lower;
 pub mod explain;
+pub mod folded;
 
 use std::collections::BTreeSet;
 


### PR DESCRIPTION
Correctness fixes for the explanation rewrite (`explain.rs`), which
reverse-traces a program to a per-input demand-set.

## Fixes
1. **SCC explanation was unsound (under-explained)** — two level/index
   errors, both invisible at scope depth ≤1 (so reach/CC were spared):
   projection arity counted field-*expressions* instead of summing field
   *widths*; and `filter_time_and_ user_out`
   filter from index 0, but `user_chain` is innermost-first so the shared
   scopes are the *outer* ends.
2. **Centralize the `user_chain` time algebra** in a new `folded` module
   (`Joined::time_le`/`strip`) — t tested place,
   locking out the bug class.
3. **Narrow the lossy-projection re-key that
   drops a field from the *key* recovered every input row sharing the
   coarsened key, leaking spuriousws by key
   *and* value.

## Not a fix — documented for triage
- The `EnterAt` reverse is a knownr-approximation
  (drops a data-derived time coord unconstrained). Documented inline
  (`OVER-APPROXIMATION` / `TRIAGE`ing so it isn't
  read as a claimed fix.

Soundness check throughout: run forward on the demand-set, confirm it
regenerates the queried output.

