### PR TITLE
interactive: scope-tree IR — structural scopes, region rendering, within-scope optimization

### DIFF
--- a/interactive/Cargo.toml
+++ b/interactive/Cargo.toml
@@ -18,5 +18,8 @@ mimalloc = "0.1.48"
 smallvec = "1.15.1"
 timely = { workspace = true }
 
+[dev-dependencies]
+diagnostics = { path = "../diagnostics" }
+
 [features]
 default = ["timely/getopts"]

--- a/interactive/examples/ddir_col.rs
+++ b/interactive/examples/ddir_col.rs
@@ -426,10 +426,12 @@ fn run(name: &str, stmts: Vec<parse::Stmt>, n_inputs: usize, nodes: u64, edges: 
     let tree_mode = std::env::var("FLAT").is_err();
     let (tree, compiled, result_id, tree_export_idx);
     if tree_mode {
-        let t = lower::lower_tree(stmts);
+        let mut t = lower::lower_tree(stmts);
+        let ops_before = t.op_count();
+        t.optimize();
         tree_export_idx = t.root.exports.iter().position(|e| e.name == "result").unwrap_or(0);
-        println!("{}: tree mode; root has {} items, driving export {:?}",
-            name, t.root.items.len(), t.root.exports[tree_export_idx].name);
+        println!("{}: tree mode; {} ops before optimize, {} after; driving export {:?}",
+            name, ops_before, t.op_count(), t.root.exports[tree_export_idx].name);
         tree = Some(t);
         compiled = Program { nodes: std::collections::BTreeMap::new(), export: vec![] };
         result_id = 0;

--- a/interactive/examples/ddir_col.rs
+++ b/interactive/examples/ddir_col.rs
@@ -135,6 +135,224 @@ mod render {
         }
     }
 
+    /// Render a Linear chain: one pass applying the ops in sequence. `level` is
+    /// the op's scope depth — it locates the iteration coord for LiftIter and
+    /// the coordinate position EnterAt's delay lands in.
+    fn render_linear<'scope>(c: Col<'scope>, ops: Vec<LinearOp>, level: usize) -> Col<'scope> {
+        super::columnar::join_function(c, move |k, v, t_in, _d| {
+            use timely::progress::Timestamp;
+            let k: Row = Columnar::into_owned(k);
+            let v: Row = Columnar::into_owned(v);
+            // Materialize input time once so LiftIter can read
+            // the iter coord at the operator's scope depth.
+            let t_owned: Time = Columnar::into_owned(t_in);
+            let iter_at_level: i64 = level
+                .checked_sub(1)
+                .and_then(|idx| t_owned.inner.get(idx).copied())
+                .unwrap_or(0) as i64;
+            let mut results: Vec<(Row, Row, Time, Diff)> = vec![(k, v, Time::minimum(), 1i64)];
+            for op in &ops {
+                let mut next = Vec::new();
+                for (k, v, t, d) in results {
+                    match op {
+                        LinearOp::Project(proj) => {
+                            let i = [k.as_slice(), v.as_slice()];
+                            next.push((eval_fields(&proj.key, &i), eval_fields(&proj.val, &i), t, d));
+                        },
+                        LinearOp::Filter(cond) => {
+                            let i = [k.as_slice(), v.as_slice()];
+                            if eval_condition(cond, &i) { next.push((k, v, t, d)); }
+                        },
+                        LinearOp::Negate => {
+                            next.push((k, v, t, -d));
+                        },
+                        LinearOp::EnterAt(field) => {
+                            let delay = {
+                                let mut r = Row::new();
+                                eval_field_into(field, &[k.as_slice(), v.as_slice()], &mut r);
+                                256 * (64 - (r.as_slice().first().copied().unwrap_or(0) as u64).leading_zeros() as u64)
+                            };
+                            let mut coords = smallvec::SmallVec::<[u64; 1]>::new();
+                            for _ in 0..level.saturating_sub(1) { coords.push(0); }
+                            coords.push(delay);
+                            next.push((k, v, Product::new(0u64, PointStamp::new(coords)), d));
+                        },
+                        LinearOp::LiftIter => {
+                            let mut new_v = v.clone();
+                            new_v.push(iter_at_level);
+                            next.push((k, new_v, t, d));
+                        },
+                    }
+                }
+                results = next;
+            }
+            results.into_iter()
+        })
+    }
+
+    fn render_join<'scope>(l: Arr<'scope>, r: Arr<'scope>, projection: &interactive::parse::Projection) -> Col<'scope> {
+        let proj = projection.clone();
+        use differential_dataflow::operators::join::join_traces;
+        use differential_dataflow::collection::AsCollection;
+        use super::columnar::ValColBuilder;
+        let stream = join_traces::<_, _, _, ValColBuilder<DdirUpdate>>(l, r, move |k, v1, v2, t, d1, d2, c| {
+            use differential_dataflow::difference::Multiply;
+            let d = d1.clone().multiply(d2);
+            let i = [k.as_slice(), v1.as_slice(), v2.as_slice()];
+            let (k2, v2): (Row, Row) = (eval_fields(&proj.key, &i), eval_fields(&proj.val, &i));
+            c.give((k2, v2, t, d));
+        });
+        stream.as_collection()
+    }
+
+    fn render_reduce<'scope>(a: Arr<'scope>, reducer: &interactive::parse::Reducer) -> Arr<'scope> {
+        let reducer = reducer.clone();
+        type ReduceFn = dyn for<'a> Fn(columnar::Ref<'a, Row>, &[(columnar::Ref<'a, Row>, Diff)], &mut Vec<(Row, Diff)>) + Send + Sync;
+        let f: Arc<ReduceFn> = match reducer {
+            interactive::parse::Reducer::Min => Arc::new(|_key, vals, output| {
+                if let Some(min) = vals.iter().map(|(v, _)| v.as_slice()).min() {
+                    output.push((Row(min.to_vec()), 1));
+                }
+            }),
+            interactive::parse::Reducer::Distinct => Arc::new(|_key, _vals, output| { output.push((Row::new(), 1)); }),
+            interactive::parse::Reducer::Count => Arc::new(|_key, vals, output| {
+                let count: Diff = vals.iter().map(|(_, d)| *d).sum();
+                if count != 0 { let mut r = Row::new(); r.push(count); output.push((r, 1)); }
+            }),
+        };
+        a.reduce_abelian::<_, ColValBuilder<_,_,_,_>, ColValSpine<_,_,_,_>, _>(
+            "Reduce",
+            move |k, vals, output| { f(k, vals, output); },
+            |col, key, upds| {
+                use columnar::{Clear, Push};
+                col.keys.clear();
+                col.vals.clear();
+                col.times.clear();
+                col.diffs.clear();
+                for (val, time, diff) in upds.drain(..) { col.push((key, &val, &time, &diff)); }
+                // NOTE: required because push above doesn't group by key, val.
+                *col = std::mem::take(col).consolidate();
+            },
+        )
+    }
+
+    fn render_inspect<'scope>(col: Col<'scope>, label: String) -> Col<'scope> {
+        col.inspect_container(move |event| {
+            if let Ok((_time, container)) = event {
+                for (k, v, t, d) in container.updates.view().iter() {
+                    eprintln!("  [{}] ({:?}, {:?}, {:?}, {:?})", label, <Row as Columnar>::into_owned(k), <Row as Columnar>::into_owned(v), <Time as Columnar>::into_owned(t), <Diff as Columnar>::into_owned(d));
+                }
+            }
+        })
+    }
+
+    // ===== Scope-tree renderer =====
+    //
+    // Walks the scope-tree IR in item order; each `{}` scope is a real timely
+    // region (imports enter it, exports leave it, then the dynamic coordinate
+    // pops). Mirrors ddir_vec's render_tree with columnar types.
+
+    use interactive::scope_ir as st;
+
+    enum RItem<'scope> {
+        Op(Rendered<'scope>),
+        Sub(Vec<Col<'scope>>),
+    }
+
+    fn resolve<'scope>(
+        items: &[RItem<'scope>],
+        imports: &[Col<'scope>],
+        var_cols: &[Col<'scope>],
+        r: &st::Ref,
+    ) -> Rendered<'scope> {
+        match r {
+            st::Ref::Local(i) => match &items[*i] {
+                RItem::Op(Rendered::Collection(c)) => Rendered::Collection(c.clone()),
+                RItem::Op(Rendered::Arrangement(a)) => Rendered::Arrangement(a.clone()),
+                RItem::Sub(_) => panic!("Ref::Local points at a child scope"),
+            },
+            st::Ref::Import(i) => Rendered::Collection(imports[*i].clone()),
+            st::Ref::Var(i) => Rendered::Collection(var_cols[*i].clone()),
+            st::Ref::ChildExport(i, j) => match &items[*i] {
+                RItem::Sub(exports) => Rendered::Collection(exports[*j].clone()),
+                RItem::Op(_) => panic!("Ref::ChildExport points at an operator"),
+            },
+        }
+    }
+
+    pub fn render_tree<'scope>(
+        s: &st::Scope,
+        scope: Scope<'scope, ConcreteTime>,
+        depth: usize,
+        imports: Vec<Col<'scope>>,
+    ) -> Vec<Col<'scope>> {
+        let mut var_handles: Vec<Option<Variable<'scope, ConcreteTime, DdirRecordedUpdates>>> = Vec::new();
+        let mut var_cols: Vec<Col<'scope>> = Vec::new();
+        for _ in &s.vars {
+            let step: Product<u64, PointStampSummary<u64>> = Product::new(0, feedback_summary::<u64>(depth, 1));
+            let (var, col) = Variable::new(scope, step);
+            var_handles.push(Some(var));
+            var_cols.push(col);
+        }
+
+        let mut items: Vec<RItem<'scope>> = Vec::new();
+        for item in &s.items {
+            match item {
+                st::Item::Op(node) => {
+                    let rendered = match node {
+                        st::Node::Linear { input, ops } => {
+                            let c = resolve(&items, &imports, &var_cols, input).collection();
+                            Rendered::Collection(render_linear(c, ops.clone(), depth))
+                        },
+                        st::Node::Concat(refs) => {
+                            let mut c = resolve(&items, &imports, &var_cols, &refs[0]).collection();
+                            for r in &refs[1..] { c = c.concat(resolve(&items, &imports, &var_cols, r).collection()); }
+                            Rendered::Collection(c)
+                        },
+                        st::Node::Arrange(r) => Rendered::Arrangement(resolve(&items, &imports, &var_cols, r).arrange()),
+                        st::Node::Join { left, right, projection } => {
+                            let l = resolve(&items, &imports, &var_cols, left).arrange();
+                            let r = resolve(&items, &imports, &var_cols, right).arrange();
+                            Rendered::Collection(render_join(l, r, projection))
+                        },
+                        st::Node::Reduce { input, reducer } => {
+                            let a = resolve(&items, &imports, &var_cols, input).arrange();
+                            Rendered::Arrangement(render_reduce(a, reducer))
+                        },
+                        st::Node::Inspect { input, label } => {
+                            let c = resolve(&items, &imports, &var_cols, input).collection();
+                            Rendered::Collection(render_inspect(c, label.clone()))
+                        },
+                    };
+                    items.push(RItem::Op(rendered));
+                },
+                st::Item::Sub(child) => {
+                    let child_imports: Vec<Col<'scope>> = child.imports.iter().map(|imp| match &imp.from {
+                        st::Source::Parent(r) => resolve(&items, &imports, &var_cols, r).collection(),
+                        other => panic!("non-root scope with external source {:?}", other),
+                    }).collect();
+                    // Each `{}` scope is a real timely region: imports enter it,
+                    // the child renders inside, exports leave it structurally —
+                    // and then pop the child's dynamic coordinate.
+                    let exported = scope.region_named(&child.name, |region| {
+                        let entered: Vec<_> = child_imports.iter().map(|c| c.clone().enter(region)).collect();
+                        let exports = render_tree(child, region, depth + 1, entered);
+                        exports.into_iter().map(|c| c.leave(scope)).collect::<Vec<_>>()
+                    });
+                    let left: Vec<Col<'scope>> = exported.into_iter().map(|c| super::columnar::leave_dynamic(c, depth + 1)).collect();
+                    items.push(RItem::Sub(left));
+                },
+            }
+        }
+
+        for bind in &s.binds {
+            let c = resolve(&items, &imports, &var_cols, &bind.value).collection();
+            var_handles[bind.var].take().expect("bind: variable already bound").set(c);
+        }
+
+        s.exports.iter().map(|e| resolve(&items, &imports, &var_cols, &e.value).collection()).collect()
+    }
+
     pub fn render_program<'scope>(program: &Program, scope: Scope<'scope, ConcreteTime>, inputs: &[Col<'scope>]) -> HashMap<Id, Col<'scope>>
     {
         let mut nodes: HashMap<Id, Rendered<'scope>> = HashMap::new();
@@ -150,58 +368,7 @@ mod render {
                 Node::Import { name } => panic!("ddir_col: Import {:?} not supported in this harness (no trace registry).", name),
                 Node::Linear { input, ops } => {
                     let c = nodes[input].collection();
-                    let ops = ops.clone();
-                    let level = level;
-                    let result = super::columnar::join_function(c, move |k, v, t_in, _d| {
-                        use timely::progress::Timestamp;
-                        let k: Row = Columnar::into_owned(k);
-                        let v: Row = Columnar::into_owned(v);
-                        // Materialize input time once so LiftIter can read
-                        // the iter coord at the operator's scope depth.
-                        let t_owned: Time = Columnar::into_owned(t_in);
-                        let iter_at_level: i64 = level
-                            .checked_sub(1)
-                            .and_then(|idx| t_owned.inner.get(idx).copied())
-                            .unwrap_or(0) as i64;
-                        let mut results: Vec<(Row, Row, Time, Diff)> = vec![(k, v, Time::minimum(), 1i64)];
-                        for op in &ops {
-                            let mut next = Vec::new();
-                            for (k, v, t, d) in results {
-                                match op {
-                                    LinearOp::Project(proj) => {
-                                        let i = [k.as_slice(), v.as_slice()];
-                                        next.push((eval_fields(&proj.key, &i), eval_fields(&proj.val, &i), t, d));
-                                    },
-                                    LinearOp::Filter(cond) => {
-                                        let i = [k.as_slice(), v.as_slice()];
-                                        if eval_condition(cond, &i) { next.push((k, v, t, d)); }
-                                    },
-                                    LinearOp::Negate => {
-                                        next.push((k, v, t, -d));
-                                    },
-                                    LinearOp::EnterAt(field) => {
-                                        let delay = {
-                                            let mut r = Row::new();
-                                            eval_field_into(field, &[k.as_slice(), v.as_slice()], &mut r);
-                                            256 * (64 - (r.as_slice().first().copied().unwrap_or(0) as u64).leading_zeros() as u64)
-                                        };
-                                        let mut coords = smallvec::SmallVec::<[u64; 1]>::new();
-                                        for _ in 0..level.saturating_sub(1) { coords.push(0); }
-                                        coords.push(delay);
-                                        next.push((k, v, Product::new(0u64, PointStamp::new(coords)), d));
-                                    },
-                                    LinearOp::LiftIter => {
-                                        let mut new_v = v.clone();
-                                        new_v.push(iter_at_level);
-                                        next.push((k, new_v, t, d));
-                                    },
-                                }
-                            }
-                            results = next;
-                        }
-                        results.into_iter()
-                    });
-                    nodes.insert(id, Rendered::Collection(result));
+                    nodes.insert(id, Rendered::Collection(render_linear(c, ops.clone(), level)));
                 },
                 Node::Concat(ids) => {
                     let mut r = nodes[&ids[0]].collection();
@@ -214,53 +381,11 @@ mod render {
                 Node::Join { left, right, projection } => {
                     let Rendered::Arrangement(l) = &nodes[left] else { panic!("Join: left input must be an Arrangement") };
                     let Rendered::Arrangement(r) = &nodes[right] else { panic!("Join: right input must be an Arrangement") };
-                    let l = l.clone();
-                    let r = r.clone();
-                    let proj = projection.clone();
-                    use differential_dataflow::operators::join::join_traces;
-                    use differential_dataflow::collection::AsCollection;
-                    use super::columnar::ValColBuilder;
-                    let stream = join_traces::<_, _, _, ValColBuilder<DdirUpdate>>(l, r, move |k, v1, v2, t, d1, d2, c| {
-                        use differential_dataflow::difference::Multiply;
-                        let d = d1.clone().multiply(d2);
-                        let i = [k.as_slice(), v1.as_slice(), v2.as_slice()];
-                        let (k2, v2): (Row, Row) = (eval_fields(&proj.key, &i), eval_fields(&proj.val, &i));
-                        c.give((k2, v2, t, d));
-                    });
-                    nodes.insert(id, Rendered::Collection(stream.as_collection()));
+                    nodes.insert(id, Rendered::Collection(render_join(l.clone(), r.clone(), projection)));
                 },
                 Node::Reduce { input, reducer } => {
                     let Rendered::Arrangement(a) = &nodes[input] else { panic!("Reduce: input must be an Arrangement") };
-                    let a = a.clone();
-                    let reducer = reducer.clone();
-                    type ReduceFn = dyn for<'a> Fn(columnar::Ref<'a, Row>, &[(columnar::Ref<'a, Row>, Diff)], &mut Vec<(Row, Diff)>) + Send + Sync;
-                    let f: Arc<ReduceFn> = match reducer {
-                        interactive::parse::Reducer::Min => Arc::new(|_key, vals, output| {
-                            if let Some(min) = vals.iter().map(|(v, _)| v.as_slice()).min() {
-                                output.push((Row(min.to_vec()), 1));
-                            }
-                        }),
-                        interactive::parse::Reducer::Distinct => Arc::new(|_key, _vals, output| { output.push((Row::new(), 1)); }),
-                        interactive::parse::Reducer::Count => Arc::new(|_key, vals, output| {
-                            let count: Diff = vals.iter().map(|(_, d)| *d).sum();
-                            if count != 0 { let mut r = Row::new(); r.push(count); output.push((r, 1)); }
-                        }),
-                    };
-                    let reduced = a.reduce_abelian::<_, ColValBuilder<_,_,_,_>, ColValSpine<_,_,_,_>, _>(
-                        "Reduce",
-                        move |k, vals, output| { f(k, vals, output); },
-                        |col, key, upds| {
-                            use columnar::{Clear, Push};
-                            col.keys.clear();
-                            col.vals.clear();
-                            col.times.clear();
-                            col.diffs.clear();
-                            for (val, time, diff) in upds.drain(..) { col.push((key, &val, &time, &diff)); }
-                            // NOTE: required because push above doesn't group by key, val.
-                            *col = std::mem::take(col).consolidate();
-                        },
-                    );
-                    nodes.insert(id, Rendered::Arrangement(reduced));
+                    nodes.insert(id, Rendered::Arrangement(render_reduce(a.clone(), reducer)));
                 },
                 Node::Variable => {
                     let step: Product<u64, PointStampSummary<u64>> = Product::new(0, feedback_summary::<u64>(level, 1));
@@ -271,14 +396,7 @@ mod render {
                 },
                 Node::Inspect { input, label } => {
                     let col = nodes[input].collection();
-                    let label = label.clone();
-                    nodes.insert(id, Rendered::Collection(col.inspect_container(move |event| {
-                        if let Ok((_time, container)) = event {
-                            for (k, v, t, d) in container.updates.view().iter() {
-                                eprintln!("  [{}] ({:?}, {:?}, {:?}, {:?})", label, <Row as Columnar>::into_owned(k), <Row as Columnar>::into_owned(v), <Time as Columnar>::into_owned(t), <Diff as Columnar>::into_owned(d));
-                            }
-                        }
-                    })));
+                    nodes.insert(id, Rendered::Collection(render_inspect(col, label.clone())));
                 },
                 Node::Leave(inner_id, scope_level) => {
                     let c = nodes[inner_id].collection();
@@ -303,21 +421,39 @@ use differential_dataflow::dynamic::pointstamp::PointStamp;
 type DdirOuterUpdate = (Row, Row, u64, Diff);
 
 fn run(name: &str, stmts: Vec<parse::Stmt>, n_inputs: usize, nodes: u64, edges: u64, arity: usize, batch: u64, rounds: Option<u64>) {
-    let mut compiled: Program = lower::lower(stmts);
-    println!("{}: {} IR nodes (before optimize)", name, compiled.nodes.len());
-    compiled.optimize();
-    println!("{}: {} IR nodes (after optimize), exports = {:?}",
-        name, compiled.nodes.len(),
-        compiled.export.iter().map(|(n, id)| (n.as_str(), *id)).collect::<Vec<_>>());
-    compiled.dump();
+    // The scope-tree IR (lower_tree + render_tree, one timely region per scope)
+    // is the default path; FLAT=1 forces the flat path for A/B comparison.
+    let tree_mode = std::env::var("FLAT").is_err();
+    let (tree, compiled, result_id, tree_export_idx);
+    if tree_mode {
+        let t = lower::lower_tree(stmts);
+        tree_export_idx = t.root.exports.iter().position(|e| e.name == "result").unwrap_or(0);
+        println!("{}: tree mode; root has {} items, driving export {:?}",
+            name, t.root.items.len(), t.root.exports[tree_export_idx].name);
+        tree = Some(t);
+        compiled = Program { nodes: std::collections::BTreeMap::new(), export: vec![] };
+        result_id = 0;
+    } else {
+        let mut c: Program = lower::lower(stmts);
+        println!("{}: {} IR nodes (before optimize)", name, c.nodes.len());
+        c.optimize();
+        println!("{}: {} IR nodes (after optimize), exports = {:?}",
+            name, c.nodes.len(),
+            c.export.iter().map(|(n, id)| (n.as_str(), *id)).collect::<Vec<_>>());
+        c.dump();
+        let (driven_name, id) = {
+            let pick = c.export.iter().find(|(n, _)| n == "result")
+                .or_else(|| c.export.first())
+                .expect("ddir_col: program declares no exports");
+            (pick.0.clone(), pick.1)
+        };
+        println!("{}: driving export {:?} (id {})", name, driven_name, id);
+        tree = None;
+        compiled = c;
+        result_id = id;
+        tree_export_idx = 0;
+    }
     let name = name.to_string();
-    let (driven_name, result_id) = {
-        let pick = compiled.export.iter().find(|(n, _)| n == "result")
-            .or_else(|| compiled.export.first())
-            .expect("ddir_col: program declares no exports");
-        (pick.0.clone(), pick.1)
-    };
-    println!("{}: driving export {:?} (id {})", name, driven_name, result_id);
 
     timely::execute_from_args(std::env::args().skip(4), move |worker| {
         use timely::dataflow::InputHandle;
@@ -338,8 +474,18 @@ fn run(name: &str, stmts: Vec<parse::Stmt>, n_inputs: usize, nodes: u64, edges: 
             let mut probe = timely::dataflow::ProbeHandle::new();
             let output = scope.iterative::<PointStamp<u64>, _, _>(|inner| {
                 let entered: Vec<_> = collections.iter().map(|c| c.clone().enter(inner)).collect();
-                let rendered = render::render_program(&compiled, inner, &entered);
-                rendered[&result_id].clone().leave(scope)
+                if let Some(tree) = &tree {
+                    let root_imports: Vec<_> = tree.root.imports.iter().map(|imp| match &imp.from {
+                        interactive::scope_ir::Source::Input(n) => entered[*n].clone(),
+                        interactive::scope_ir::Source::Trace(name) => panic!("ddir_col: Import {:?} not supported in this harness (no trace registry).", name),
+                        interactive::scope_ir::Source::Parent(_) => unreachable!("root scope cannot import from a parent"),
+                    }).collect();
+                    let exports = render::render_tree(&tree.root, inner, 0, root_imports);
+                    exports[tree_export_idx].clone().leave(scope)
+                } else {
+                    let rendered = render::render_program(&compiled, inner, &entered);
+                    rendered[&result_id].clone().leave(scope)
+                }
             });
             output.probe_with(&mut probe);
             (handles, probe)

--- a/interactive/examples/ddir_vec.rs
+++ b/interactive/examples/ddir_vec.rs
@@ -25,6 +25,7 @@ use smallvec::smallvec as svec;
 
 use interactive::parse;
 use interactive::lower;
+use interactive::scope_ir as st;
 use interactive::ir::{Node, LinearOp, Program, Diff, Id, Time, eval_fields, eval_field_into, eval_condition};
 
 type Row = SmallVec<[i64; 2]>;
@@ -43,6 +44,184 @@ impl<'scope, T: timely::progress::Timestamp + differential_dataflow::lattice::La
 }
 
 
+/// Render a Linear chain: one flat_map applying the ops in sequence. `level` is
+/// the op's scope depth — it locates the iteration coord for LiftIter and the
+/// coordinate position EnterAt's delay lands in.
+fn render_linear<'scope>(c: Col<'scope, DdirTime>, ops: Vec<LinearOp>, level: usize) -> Col<'scope, DdirTime> {
+    use differential_dataflow::AsCollection;
+    use differential_dataflow::lattice::Lattice;
+    use timely::dataflow::operators::core::Map;
+    c.inner.flat_map(move |((key, val), t_in, d_in)| {
+        use timely::progress::Timestamp;
+        let iter_at_level: i64 = level
+            .checked_sub(1)
+            .and_then(|idx| t_in.inner.get(idx).copied())
+            .unwrap_or(0) as i64;
+        let mut results: smallvec::SmallVec<[((Row, Row), Time, Diff); 2]> = svec![((key, val), Time::minimum(), 1)];
+        for op in &ops {
+            let mut next = smallvec::SmallVec::new();
+            for ((k, v), t, d) in results {
+                match op {
+                    LinearOp::Project(proj) => {
+                        let i = [k.as_slice(), v.as_slice()];
+                        next.push(((eval_fields(&proj.key, &i), eval_fields(&proj.val, &i)), t, d));
+                    },
+                    LinearOp::Filter(cond) => {
+                        let i = [k.as_slice(), v.as_slice()];
+                        if eval_condition(cond, &i) { next.push(((k, v), t, d)); }
+                    },
+                    LinearOp::Negate => {
+                        next.push(((k, v), t, -d));
+                    },
+                    LinearOp::EnterAt(field) => {
+                        let delay = {
+                            let mut r = Row::new();
+                            eval_field_into(field, &[k.as_slice(), v.as_slice()], &mut r);
+                            256 * (64 - (r.as_slice().first().copied().unwrap_or(0) as u64).leading_zeros() as u64)
+                        };
+                        let mut coords = smallvec::SmallVec::<[u64; 1]>::new();
+                        for _ in 0..level.saturating_sub(1) { coords.push(0); }
+                        coords.push(delay);
+                        next.push(((k, v), Product::new(0u64, PointStamp::new(coords)), d));
+                    },
+                    LinearOp::LiftIter => {
+                        let mut new_v = v.clone();
+                        new_v.push(iter_at_level);
+                        next.push(((k, new_v), t, d));
+                    },
+                }
+            }
+            results = next;
+        }
+        results.into_iter().map(move |((k, v), t_delta, d)| ((k, v), t_in.join(&t_delta), d_in * d))
+    }).as_collection()
+}
+
+// ===== Scope-tree renderer =====
+//
+// Walks the scope tree (scope_ir) in item order — no scans, no topological
+// re-analysis. Each `{}` scope renders as a timely region (imports enter it,
+// exports leave it), with the dynamic PointStamp coordinate riding inside.
+
+/// A rendered item: an operator's value, or a child scope's surrendered exports
+/// (already returned to this scope's depth via `leave_dynamic`).
+enum RItem<'scope> {
+    Op(Rendered<'scope, DdirTime>),
+    Sub(Vec<Col<'scope, DdirTime>>),
+}
+
+fn resolve<'scope>(
+    items: &[RItem<'scope>],
+    imports: &[Col<'scope, DdirTime>],
+    var_cols: &[Col<'scope, DdirTime>],
+    r: &st::Ref,
+) -> Rendered<'scope, DdirTime> {
+    match r {
+        st::Ref::Local(i) => match &items[*i] {
+            RItem::Op(Rendered::Collection(c)) => Rendered::Collection(c.clone()),
+            RItem::Op(Rendered::Arrangement(a)) => Rendered::Arrangement(a.clone()),
+            RItem::Sub(_) => panic!("Ref::Local points at a child scope"),
+        },
+        st::Ref::Import(i) => Rendered::Collection(imports[*i].clone()),
+        st::Ref::Var(i) => Rendered::Collection(var_cols[*i].clone()),
+        st::Ref::ChildExport(i, j) => match &items[*i] {
+            RItem::Sub(exports) => Rendered::Collection(exports[*j].clone()),
+            RItem::Op(_) => panic!("Ref::ChildExport points at an operator"),
+        },
+    }
+}
+
+/// Render one scope at `depth` (root = 0): feedback vars first (they're listed,
+/// not scanned for), then items in order, then binds close the loops, then the
+/// exports are surrendered. The returned collections are at this scope's depth;
+/// popping the coordinate (`leave_dynamic`) is the caller's job.
+fn render_tree<'scope>(
+    s: &st::Scope,
+    scope: Scope<'scope, DdirTime>,
+    depth: usize,
+    imports: Vec<Col<'scope, DdirTime>>,
+) -> Vec<Col<'scope, DdirTime>> {
+    let mut var_handles: Vec<Option<VecVariable<'scope, DdirTime, (Row, Row), Diff>>> = Vec::new();
+    let mut var_cols: Vec<Col<'scope, DdirTime>> = Vec::new();
+    for _ in &s.vars {
+        let step: Product<u64, PointStampSummary<u64>> = Product::new(0, feedback_summary::<u64>(depth, 1));
+        let (var, col) = VecVariable::new(scope, step);
+        var_handles.push(Some(var));
+        var_cols.push(col);
+    }
+
+    let mut items: Vec<RItem<'scope>> = Vec::new();
+    for item in &s.items {
+        match item {
+            st::Item::Op(node) => {
+                let rendered = match node {
+                    st::Node::Linear { input, ops } => {
+                        let c = resolve(&items, &imports, &var_cols, input).collection();
+                        Rendered::Collection(render_linear(c, ops.clone(), depth))
+                    },
+                    st::Node::Concat(refs) => {
+                        let mut c = resolve(&items, &imports, &var_cols, &refs[0]).collection();
+                        for r in &refs[1..] { c = c.concat(resolve(&items, &imports, &var_cols, r).collection()); }
+                        Rendered::Collection(c)
+                    },
+                    st::Node::Arrange(r) => Rendered::Arrangement(resolve(&items, &imports, &var_cols, r).arrange()),
+                    st::Node::Join { left, right, projection } => {
+                        let l = resolve(&items, &imports, &var_cols, left).arrange();
+                        let r = resolve(&items, &imports, &var_cols, right).arrange();
+                        let proj = projection.clone();
+                        let f: Arc<dyn Fn(&Row, &Row, &Row) -> smallvec::SmallVec<[(Row, Row); 2]> + Send + Sync> =
+                            Arc::new(move |key, left, right| { let i = [key.as_slice(), left.as_slice(), right.as_slice()]; svec![(eval_fields(&proj.key, &i), eval_fields(&proj.val, &i))] });
+                        Rendered::Collection(l.join_core(r, move |k, v1, v2| f(k, v1, v2)))
+                    },
+                    st::Node::Reduce { input, reducer } => {
+                        let a = resolve(&items, &imports, &var_cols, input).arrange();
+                        let f: Arc<dyn Fn(&Row, &[(&Row, Diff)], &mut Vec<(Row, Diff)>) + Send + Sync> = match reducer {
+                            parse::Reducer::Min => Arc::new(|_key, vals, output| { if let Some(min) = vals.iter().map(|(v, _)| *v).min() { output.push((min.clone(), 1)); } }),
+                            parse::Reducer::Distinct => Arc::new(|_key, _vals, output| { output.push((Row::new(), 1)); }),
+                            parse::Reducer::Count => Arc::new(|_key, vals, output| { let count: Diff = vals.iter().map(|(_, d)| *d).sum(); if count > 0 { let mut r = Row::new(); r.push(count); output.push((r, 1)); } }),
+                        };
+                        let reduced = a.reduce_abelian::<_, differential_dataflow::trace::implementations::ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>, _>(
+                            "Reduce",
+                            move |k, v, o| f(k, v, o),
+                            |vec, key, upds| { vec.clear(); vec.extend(upds.drain(..).map(|(v,t,r)| ((key.clone(), v),t,r))); },
+                        );
+                        Rendered::Arrangement(reduced)
+                    },
+                    st::Node::Inspect { input, label } => {
+                        let col = resolve(&items, &imports, &var_cols, input).collection();
+                        let label = label.clone();
+                        Rendered::Collection(col.inspect(move |x| eprintln!("  [{}] {:?}", label, x.clone())))
+                    },
+                };
+                items.push(RItem::Op(rendered));
+            },
+            st::Item::Sub(child) => {
+                let child_imports: Vec<Col<'scope, DdirTime>> = child.imports.iter().map(|imp| match &imp.from {
+                    st::Source::Parent(r) => resolve(&items, &imports, &var_cols, r).collection(),
+                    other => panic!("non-root scope with external source {:?}", other),
+                }).collect();
+                // Each `{}` scope is a real timely region: imports enter it,
+                // the child renders inside, exports leave it structurally —
+                // and then pop the child's dynamic coordinate.
+                let exported = scope.region_named(&child.name, |region| {
+                    let entered: Vec<_> = child_imports.iter().map(|c| c.clone().enter(region)).collect();
+                    let exports = render_tree(child, region, depth + 1, entered);
+                    exports.into_iter().map(|c| c.leave(scope)).collect::<Vec<_>>()
+                });
+                let left: Vec<Col<'scope, DdirTime>> = exported.into_iter().map(|c| c.leave_dynamic(depth + 1)).collect();
+                items.push(RItem::Sub(left));
+            },
+        }
+    }
+
+    for bind in &s.binds {
+        let c = resolve(&items, &imports, &var_cols, &bind.value).collection();
+        var_handles[bind.var].take().expect("bind: variable already bound").set(c);
+    }
+
+    s.exports.iter().map(|e| resolve(&items, &imports, &var_cols, &e.value).collection()).collect()
+}
+
 fn render_program<'scope>(program: &Program, scope: Scope<'scope, DdirTime>, inputs: &[Col<'scope, DdirTime>]) -> HashMap<Id, Col<'scope, DdirTime>>
 {
     let mut nodes: HashMap<Id, Rendered<'scope, DdirTime>> = HashMap::new();
@@ -55,56 +234,8 @@ fn render_program<'scope>(program: &Program, scope: Scope<'scope, DdirTime>, inp
             Node::Input(i) => { nodes.insert(id, Rendered::Collection(inputs[*i].clone())); },
             Node::Import { name } => panic!("ddir_vec: Import {:?} not supported in this harness (no trace registry).", name),
             Node::Linear { input, ops } => {
-                use differential_dataflow::AsCollection;
-                use differential_dataflow::lattice::Lattice;
-                use timely::dataflow::operators::core::Map;
                 let c = nodes[input].collection();
-                let ops = ops.clone();
-                let level = level;
-                let r = c.inner.flat_map(move |((key, val), t_in, d_in)| {
-                    use timely::progress::Timestamp;
-                    let iter_at_level: i64 = level
-                        .checked_sub(1)
-                        .and_then(|idx| t_in.inner.get(idx).copied())
-                        .unwrap_or(0) as i64;
-                    let mut results: smallvec::SmallVec<[((Row, Row), Time, Diff); 2]> = svec![((key, val), Time::minimum(), 1)];
-                    for op in &ops {
-                        let mut next = smallvec::SmallVec::new();
-                        for ((k, v), t, d) in results {
-                            match op {
-                                LinearOp::Project(proj) => {
-                                    let i = [k.as_slice(), v.as_slice()];
-                                    next.push(((eval_fields(&proj.key, &i), eval_fields(&proj.val, &i)), t, d));
-                                },
-                                LinearOp::Filter(cond) => {
-                                    let i = [k.as_slice(), v.as_slice()];
-                                    if eval_condition(cond, &i) { next.push(((k, v), t, d)); }
-                                },
-                                LinearOp::Negate => {
-                                    next.push(((k, v), t, -d));
-                                },
-                                LinearOp::EnterAt(field) => {
-                                    let delay = {
-                                        let mut r = Row::new();
-                                        eval_field_into(field, &[k.as_slice(), v.as_slice()], &mut r);
-                                        256 * (64 - (r.as_slice().first().copied().unwrap_or(0) as u64).leading_zeros() as u64)
-                                    };
-                                    let mut coords = smallvec::SmallVec::<[u64; 1]>::new();
-                                    for _ in 0..level.saturating_sub(1) { coords.push(0); }
-                                    coords.push(delay);
-                                    next.push(((k, v), Product::new(0u64, PointStamp::new(coords)), d));
-                                },
-                                LinearOp::LiftIter => {
-                                    let mut new_v = v.clone();
-                                    new_v.push(iter_at_level);
-                                    next.push(((k, new_v), t, d));
-                                },
-                            }
-                        }
-                        results = next;
-                    }
-                    results.into_iter().map(move |((k, v), t_delta, d)| ((k, v), t_in.join(&t_delta), d_in * d))
-                }).as_collection();
+                let r = render_linear(c, ops.clone(), level);
                 nodes.insert(id, Rendered::Collection(r));
             },
             Node::Concat(ids) => { let mut r = nodes[&ids[0]].collection(); for i in &ids[1..] { r = r.concat(nodes[i].collection()); } nodes.insert(id, Rendered::Collection(r)); },
@@ -166,35 +297,67 @@ fn run(
     rounds: Option<u64>,
     explain: bool,
 ) {
-    let mut compiled: Program = lower::lower(stmts);
-    // When --explain is set, rewrite the program for self-explanation
-    // before optimization. The transformed program declares one extra
-    // input (the query); the last handle below is reserved for it and
-    // seeded from `QUERY=`.
-    if explain {
-        let input_arities = vec![(arity, 0usize); n_inputs];
-        let import_arities = std::collections::BTreeMap::new();
-        compiled = interactive::explain::explain(&compiled, &input_arities, &import_arities);
+    // The scope-tree IR (lower_tree + render_tree, one timely region per scope)
+    // is the default path. `--explain` still goes through the flat IR (the
+    // explanation rewrite operates on it), and FLAT=1 forces the flat path
+    // for A/B comparison; outputs must match either way.
+    let tree_mode = !explain && std::env::var("FLAT").is_err();
+    let (tree, compiled, result_id, tree_export_idx);
+    if tree_mode {
+        let t = lower::lower_tree(stmts);
+        tree_export_idx = t.root.exports.iter().position(|e| e.name == "result").unwrap_or(0);
+        println!("{}: tree mode; root has {} items, driving export {:?}",
+            name, t.root.items.len(), t.root.exports[tree_export_idx].name);
+        tree = Some(t);
+        compiled = Program { nodes: std::collections::BTreeMap::new(), export: vec![] };
+        result_id = 0;
+    } else {
+        let mut c: Program = lower::lower(stmts);
+        // When --explain is set, rewrite the program for self-explanation
+        // before optimization. The transformed program declares one extra
+        // input (the query); the last handle below is reserved for it and
+        // seeded from `QUERY=`.
+        if explain {
+            let input_arities = vec![(arity, 0usize); n_inputs];
+            let import_arities = std::collections::BTreeMap::new();
+            c = interactive::explain::explain(&c, &input_arities, &import_arities);
+        }
+        println!("{}: {} IR nodes (before optimize)", name, c.nodes.len());
+        c.optimize();
+        println!("{}: {} IR nodes (after optimize), exports = {:?}",
+            name, c.nodes.len(),
+            c.export.iter().map(|(n, id)| (n.as_str(), *id)).collect::<Vec<_>>());
+        c.dump();
+        // Drive one export: prefer `$result`, else the first declared.
+        let (driven_name, id) = {
+            let pick = c.export.iter().find(|(n, _)| n == "result")
+                .or_else(|| c.export.first())
+                .expect("ddir_vec: program declares no exports");
+            (pick.0.clone(), pick.1)
+        };
+        println!("{}: driving export {:?} (id {})", name, driven_name, id);
+        tree = None;
+        compiled = c;
+        result_id = id;
+        tree_export_idx = 0;
     }
-    println!("{}: {} IR nodes (before optimize)", name, compiled.nodes.len());
-    compiled.optimize();
-    println!("{}: {} IR nodes (after optimize), exports = {:?}",
-        name, compiled.nodes.len(),
-        compiled.export.iter().map(|(n, id)| (n.as_str(), *id)).collect::<Vec<_>>());
-    compiled.dump();
     let name = name.to_string();
-    // Drive one export: prefer `$result`, else the first declared.
-    let (driven_name, result_id) = {
-        let pick = compiled.export.iter().find(|(n, _)| n == "result")
-            .or_else(|| compiled.export.first())
-            .expect("ddir_vec: program declares no exports");
-        (pick.0.clone(), pick.1)
-    };
-    println!("{}: driving export {:?} (id {})", name, driven_name, result_id);
     let total_inputs = if explain { n_inputs + 1 } else { n_inputs };
     let query_input_idx = if explain { Some(n_inputs) } else { None };
 
     timely::execute_from_args(std::env::args().skip(4), move |worker| {
+
+        // DIAG=1 registers timely/DD logging and serves the diagnostics
+        // WebSocket on worker 0 (port 51371) — see diagnostics/README.md.
+        let _diag = if std::env::var("DIAG").is_ok() {
+            let state = diagnostics::logging::register(worker, false);
+            if worker.index() == 0 {
+                Some(diagnostics::server::Server::start(51371, state.sink))
+            } else {
+                drop(state.sink);
+                None
+            }
+        } else { None };
 
         let (mut inputs, probe) = worker.dataflow::<u64, _, _>(|scope| {
             let mut handles = Vec::new();
@@ -206,8 +369,18 @@ fn run(
             let mut probe = timely::dataflow::ProbeHandle::new();
             let output = scope.iterative::<PointStamp<u64>, _, _>(|inner| {
                 let entered: Vec<_> = collections.iter().map(|c| c.clone().enter(inner)).collect();
-                let rendered = render_program(&compiled, inner, &entered);
-                rendered[&result_id].clone().leave(scope)
+                if let Some(tree) = &tree {
+                    let root_imports: Vec<_> = tree.root.imports.iter().map(|imp| match &imp.from {
+                        st::Source::Input(n) => entered[*n].clone(),
+                        st::Source::Trace(name) => panic!("ddir_vec: Import {:?} not supported in this harness (no trace registry).", name),
+                        st::Source::Parent(_) => unreachable!("root scope cannot import from a parent"),
+                    }).collect();
+                    let exports = render_tree(&tree.root, inner, 0, root_imports);
+                    exports[tree_export_idx].clone().leave(scope)
+                } else {
+                    let rendered = render_program(&compiled, inner, &entered);
+                    rendered[&result_id].clone().leave(scope)
+                }
             });
             output.probe_with(&mut probe);
             (handles, probe)

--- a/interactive/examples/ddir_vec.rs
+++ b/interactive/examples/ddir_vec.rs
@@ -304,10 +304,12 @@ fn run(
     let tree_mode = !explain && std::env::var("FLAT").is_err();
     let (tree, compiled, result_id, tree_export_idx);
     if tree_mode {
-        let t = lower::lower_tree(stmts);
+        let mut t = lower::lower_tree(stmts);
+        let ops_before = t.op_count();
+        t.optimize();
         tree_export_idx = t.root.exports.iter().position(|e| e.name == "result").unwrap_or(0);
-        println!("{}: tree mode; root has {} items, driving export {:?}",
-            name, t.root.items.len(), t.root.exports[tree_export_idx].name);
+        println!("{}: tree mode; {} ops before optimize, {} after; driving export {:?}",
+            name, ops_before, t.op_count(), t.root.exports[tree_export_idx].name);
         tree = Some(t);
         compiled = Program { nodes: std::collections::BTreeMap::new(), export: vec![] };
         result_id = 0;

--- a/interactive/src/lib.rs
+++ b/interactive/src/lib.rs
@@ -3,6 +3,7 @@ pub mod ir;
 pub mod lower;
 pub mod explain;
 pub mod folded;
+pub mod scope_ir;
 
 use std::collections::BTreeSet;
 

--- a/interactive/src/lower.rs
+++ b/interactive/src/lower.rs
@@ -354,8 +354,18 @@ impl ScopeLower {
             Expr::EnterAt(e, f) => { let r = self.lower_expr(e); self.push(st::Node::Linear { input: r, ops: vec![LinearOp::EnterAt(f.clone())] }) },
             Expr::LiftIter(e)   => { let r = self.lower_expr(e); self.push(st::Node::Linear { input: r, ops: vec![LinearOp::LiftIter] }) },
             Expr::Arrange(e)    => { let r = self.lower_expr(e); self.push(st::Node::Arrange(r)) },
-            Expr::Join(l, r, p) => { let lr = self.lower_expr(l); let rr = self.lower_expr(r); self.push(st::Node::Join { left: lr, right: rr, projection: p.clone() }) },
-            Expr::Reduce(e, red)=> { let r = self.lower_expr(e); self.push(st::Node::Reduce { input: r, reducer: red.clone() }) },
+            // Join/Reduce consume arrangements; arrange their inputs explicitly
+            // (as the flat lowering does) so identical arrangements are visible
+            // to `optimize`'s within-scope dedup and shared at render.
+            Expr::Join(l, r, p) => {
+                let lr = self.lower_expr(l); let la = self.push(st::Node::Arrange(lr));
+                let rr = self.lower_expr(r); let ra = self.push(st::Node::Arrange(rr));
+                self.push(st::Node::Join { left: la, right: ra, projection: p.clone() })
+            },
+            Expr::Reduce(e, red)=> {
+                let r = self.lower_expr(e); let a = self.push(st::Node::Arrange(r));
+                self.push(st::Node::Reduce { input: a, reducer: red.clone() })
+            },
             Expr::Inspect(e, l) => { let r = self.lower_expr(e); self.push(st::Node::Inspect { input: r, label: l.clone() }) },
             Expr::Concat(es)    => { let rs: Vec<st::Ref> = es.iter().map(|e| self.lower_expr(e)).collect(); self.push(st::Node::Concat(rs)) },
         }
@@ -616,5 +626,78 @@ mod tree_tests {
             assert!(child.exports.iter().any(|e| e.name == "labels"));
         }
         assert!(reads_a_child_export(&prog.root)); // root reads outer::scc
+    }
+}
+
+#[cfg(test)]
+mod optimize_tests {
+    use super::*;
+    use crate::scope_ir::{Item, Node, Ref};
+
+    fn parse(src: &str) -> Vec<Stmt> { crate::parse::pipe::parse(src) }
+    fn ops(s: &st::Scope) -> Vec<&Node> {
+        s.items.iter().filter_map(|i| match i { Item::Op(n) => Some(n), _ => None }).collect()
+    }
+
+    #[test]
+    fn fuses_linear_chains() {
+        let src = "let a = input 0 | key($0[0] ; $0[1]) | filter($0[0] != $1[0]) | negate;\nexport \"result\" = a;";
+        let mut p = lower_tree(parse(src));
+        assert_eq!(p.op_count(), 3); // three single-op Linears
+        p.optimize();
+        assert_eq!(p.op_count(), 1, "chain should fuse to one Linear");
+        let Node::Linear { ops, .. } = ops(&p.root)[0] else { panic!("expected a Linear") };
+        assert_eq!(ops.len(), 3, "fused Linear carries all three ops in order");
+        assert!(matches!(ops[0], LinearOp::Project(_)));
+        assert!(matches!(ops[2], LinearOp::Negate));
+    }
+
+    #[test]
+    fn shares_arrangements_across_joins() {
+        // `a` feeds two joins; its two implicit Arranges must dedup to one.
+        let src = "\
+            let a = input 0 | key($0[0] ; $0[1]);\n\
+            let b = input 0 | key($0[1] ; $0[0]);\n\
+            let j1 = a | join(b, ($1 ; $2));\n\
+            let j2 = a | join(b, ($2 ; $1));\n\
+            export \"result\" = j1 + j2;";
+        let mut p = lower_tree(parse(src));
+        p.optimize();
+        let arranges = ops(&p.root).iter().filter(|n| matches!(n, Node::Arrange(_))).count();
+        assert_eq!(arranges, 2, "one shared arrangement per distinct input (a, b)");
+    }
+
+    #[test]
+    fn collapses_arrange_of_reduce() {
+        // distinct produces an arrangement; joining on it must not re-arrange.
+        let src = "\
+            let a = input 0 | key($0[0] ; $0[1]) | distinct;\n\
+            let b = input 0 | key($0[0] ; $0[1]);\n\
+            export \"result\" = a | join(b, ($1 ;));";
+        let mut p = lower_tree(parse(src));
+        p.optimize();
+        // No Arrange may target a Reduce item.
+        for n in ops(&p.root) {
+            if let Node::Arrange(Ref::Local(j)) = n {
+                assert!(!matches!(&p.root.items[*j], Item::Op(Node::Reduce { .. })),
+                    "Arrange of a Reduce should have collapsed");
+            }
+        }
+    }
+
+    #[test]
+    fn optimizes_within_nested_scopes() {
+        // The fusible chain sits inside a scope; optimize must recurse.
+        let src = "\
+            let e = input 0 | key($0[0] ; $0[1]);\n\
+            s: {\n\
+                var x = e | key($0 ; $1) | filter($0[0] != $1[0]) | distinct;\n\
+            }\n\
+            export \"result\" = s::x;";
+        let mut p = lower_tree(parse(src));
+        p.optimize();
+        let Item::Sub(child) = p.root.items.iter().find(|i| matches!(i, Item::Sub(_))).unwrap() else { unreachable!() };
+        let linears: Vec<usize> = ops(child).iter().filter_map(|n| match n { Node::Linear { ops, .. } => Some(ops.len()), _ => None }).collect();
+        assert_eq!(linears, vec![2], "the key|filter chain fuses inside the child scope");
     }
 }

--- a/interactive/src/lower.rs
+++ b/interactive/src/lower.rs
@@ -284,3 +284,337 @@ pub fn lower(stmts: Vec<Stmt>) -> Program {
     program.validate_lift_iter().unwrap_or_else(|e| panic!("{}", e));
     program
 }
+
+// ===== Scope-tree lowering (AST -> scope_ir) =====
+//
+// Produces the tree IR (see `scope_ir`): each `{ .. }` becomes an
+// owned child scope, cross-scope flow becomes explicit import/export edges,
+// and feedback vars are first-class. `input`/`import` external sources are
+// accepted at the root scope only. Shapes are not stored on the tree; a
+// shape pass derives them when a consumer needs them.
+
+use crate::scope_ir as st;
+
+pub fn lower_tree(stmts: Vec<Stmt>) -> st::Program {
+    let empty = HashMap::new();
+    st::Program { root: lower_scope_tree("root", &stmts, &empty, &[], true) }
+}
+
+/// Expr-lowering state for one scope. Resolves names to scope-local `Ref`s and
+/// accumulates this scope's nodes and (input/trace) imports.
+struct ScopeLower {
+    is_root: bool,
+    items: Vec<st::Item>,
+    imports: Vec<st::Import>,
+    input_import: HashMap<usize, usize>, // input n  -> import idx (root, deduped)
+    trace_import: HashMap<String, usize>, // trace name -> import idx (root, deduped)
+    env: HashMap<String, st::Ref>,        // local names + pre-created imports -> Ref
+    child_idx: HashMap<String, usize>,    // child scope name -> children index
+    child_exports: HashMap<String, Vec<String>>, // child name -> its export field order
+}
+
+impl ScopeLower {
+    fn push(&mut self, n: st::Node) -> st::Ref {
+        let i = self.items.len();
+        self.items.push(st::Item::Op(n));
+        st::Ref::Local(i)
+    }
+    fn input_ref(&mut self, n: usize) -> st::Ref {
+        assert!(self.is_root, "`input {}` used outside the root scope (not yet supported)", n);
+        if let Some(&i) = self.input_import.get(&n) { return st::Ref::Import(i); }
+        let i = self.imports.len();
+        self.imports.push(st::Import { name: format!("input{}", n), from: st::Source::Input(n) });
+        self.input_import.insert(n, i);
+        st::Ref::Import(i)
+    }
+    fn trace_ref(&mut self, name: &str) -> st::Ref {
+        assert!(self.is_root, "`import {:?}` used outside the root scope (not yet supported)", name);
+        if let Some(&i) = self.trace_import.get(name) { return st::Ref::Import(i); }
+        let i = self.imports.len();
+        self.imports.push(st::Import { name: name.to_string(), from: st::Source::Trace(name.to_string()) });
+        self.trace_import.insert(name.to_string(), i);
+        st::Ref::Import(i)
+    }
+    fn qualified_ref(&self, scope: &str, field: &str) -> st::Ref {
+        let cidx = *self.child_idx.get(scope).unwrap_or_else(|| panic!("unknown scope `{}`", scope));
+        let pos = self.child_exports[scope].iter().position(|f| f == field)
+            .unwrap_or_else(|| panic!("scope `{}` does not export `{}`", scope, field));
+        st::Ref::ChildExport(cidx, pos)
+    }
+    fn lower_expr(&mut self, e: &Expr) -> st::Ref {
+        match e {
+            Expr::Input(n) => self.input_ref(*n),
+            Expr::Import(name) => self.trace_ref(name),
+            Expr::Name(name) => self.env.get(name).cloned()
+                .unwrap_or_else(|| panic!("unresolved name `{}`", name)),
+            Expr::Qualified(s, f) => self.qualified_ref(s, f),
+            Expr::Map(e, p)     => { let r = self.lower_expr(e); self.push(st::Node::Linear { input: r, ops: vec![LinearOp::Project(p.clone())] }) },
+            Expr::Filter(e, c)  => { let r = self.lower_expr(e); self.push(st::Node::Linear { input: r, ops: vec![LinearOp::Filter(c.clone())] }) },
+            Expr::Negate(e)     => { let r = self.lower_expr(e); self.push(st::Node::Linear { input: r, ops: vec![LinearOp::Negate] }) },
+            Expr::EnterAt(e, f) => { let r = self.lower_expr(e); self.push(st::Node::Linear { input: r, ops: vec![LinearOp::EnterAt(f.clone())] }) },
+            Expr::LiftIter(e)   => { let r = self.lower_expr(e); self.push(st::Node::Linear { input: r, ops: vec![LinearOp::LiftIter] }) },
+            Expr::Arrange(e)    => { let r = self.lower_expr(e); self.push(st::Node::Arrange(r)) },
+            Expr::Join(l, r, p) => { let lr = self.lower_expr(l); let rr = self.lower_expr(r); self.push(st::Node::Join { left: lr, right: rr, projection: p.clone() }) },
+            Expr::Reduce(e, red)=> { let r = self.lower_expr(e); self.push(st::Node::Reduce { input: r, reducer: red.clone() }) },
+            Expr::Inspect(e, l) => { let r = self.lower_expr(e); self.push(st::Node::Inspect { input: r, label: l.clone() }) },
+            Expr::Concat(es)    => { let rs: Vec<st::Ref> = es.iter().map(|e| self.lower_expr(e)).collect(); self.push(st::Node::Concat(rs)) },
+        }
+    }
+}
+
+fn lower_scope_tree(
+    scope_name: &str,
+    body: &[Stmt],
+    parent_env: &HashMap<String, st::Ref>,
+    exports_wanted: &[String],
+    is_root: bool,
+) -> st::Scope {
+    let mut s = ScopeLower {
+        is_root,
+        items: Vec::new(),
+        imports: Vec::new(),
+        input_import: HashMap::new(),
+        trace_import: HashMap::new(),
+        env: HashMap::new(),
+        child_idx: HashMap::new(),
+        child_exports: HashMap::new(),
+    };
+
+    // Pre-create imports from this scope's transitive free names (names used
+    // here or in a descendant but not defined here). Doing it up front handles
+    // cross-level references: an outer name a grandchild needs is imported into
+    // every scope on the path.
+    if !is_root {
+        let mut free: BTreeSet<&str> = BTreeSet::new();
+        collect_body_free_names(body, &mut free);
+        for name in free {
+            let from = parent_env.get(name).cloned()
+                .unwrap_or_else(|| panic!("scope references unknown outer name `{}`", name));
+            let i = s.imports.len();
+            s.imports.push(st::Import { name: name.to_string(), from: st::Source::Parent(from) });
+            s.env.insert(name.to_string(), st::Ref::Import(i));
+        }
+    }
+
+    // Bucket statements.
+    let mut lets: HashMap<String, &Expr> = HashMap::new();
+    let mut var_list: Vec<(&str, &Expr)> = Vec::new();
+    let mut child_bodies: HashMap<String, &[Stmt]> = HashMap::new();
+    let mut export_stmts: Vec<(&str, &Expr)> = Vec::new();
+    let mut order: Vec<(ItemKind, String)> = Vec::new();
+    for stmt in body {
+        match stmt {
+            Stmt::Let(n, e)  => { lets.insert(n.clone(), e); order.push((ItemKind::Let, n.clone())); },
+            Stmt::Var(n, e)  => { var_list.push((n.as_str(), e)); },
+            Stmt::Scope(n, b)=> { child_bodies.insert(n.clone(), b.as_slice()); order.push((ItemKind::Scope, n.clone())); },
+            Stmt::Export(n, e) => { export_stmts.push((n.as_str(), e)); },
+        }
+    }
+
+    // Pre-declare feedback variables so anything in the scope can refer to them.
+    let mut vars: Vec<st::Var> = Vec::new();
+    let mut var_id: HashMap<&str, usize> = HashMap::new();
+    for (name, _) in &var_list {
+        let idx = vars.len();
+        vars.push(st::Var { name: (*name).to_string() });
+        s.env.insert((*name).to_string(), st::Ref::Var(idx));
+        var_id.insert(*name, idx);
+    }
+
+    // Topologically lower lets and child scopes (deps restricted to local
+    // let/scope names; vars are already bound).
+    let defined: BTreeSet<&str> = lets.keys().map(|k| k.as_str())
+        .chain(child_bodies.keys().map(|k| k.as_str())).collect();
+    let mut deps: HashMap<String, BTreeSet<String>> = HashMap::new();
+    for (n, e) in &lets { deps.insert(n.clone(), expr_deps(e, &defined, n)); }
+    for (n, b) in &child_bodies { deps.insert(n.clone(), scope_body_deps(b, &defined, n)); }
+    drop(defined);
+
+    let mut pending = order;
+    while !pending.is_empty() {
+        let pos = pending.iter().position(|(_, n)| deps[n].is_empty())
+            .unwrap_or_else(|| panic!("Cyclic let/scope dependency; use `var` for recursion: {:?}",
+                pending.iter().map(|(_, n)| n.clone()).collect::<Vec<_>>()));
+        let (kind, name) = pending.remove(pos);
+        deps.remove(&name);
+        for d in deps.values_mut() { d.remove(&name); }
+        match kind {
+            ItemKind::Let => {
+                let e = lets.remove(&name).unwrap();
+                let r = s.lower_expr(e);
+                s.env.insert(name, r);
+            },
+            ItemKind::Scope => {
+                let b = child_bodies.remove(&name).unwrap();
+                let wanted = qualified_fields(body, &name);
+                let child = lower_scope_tree(&name, b, &s.env, &wanted, false);
+                let cidx = s.items.len();
+                s.items.push(st::Item::Sub(child));
+                s.child_idx.insert(name.clone(), cidx);
+                s.child_exports.insert(name, wanted);
+            },
+        }
+    }
+
+    // Lower var bodies and emit binds.
+    let mut binds: Vec<st::Bind> = Vec::new();
+    for (name, e) in &var_list {
+        let r = s.lower_expr(e);
+        binds.push(st::Bind { var: var_id[*name], value: r });
+    }
+
+    // Exports: the root takes its `export` statements; a child surrenders the
+    // fields its parent asked for.
+    let mut exports: Vec<st::Export> = Vec::new();
+    if is_root {
+        for (name, e) in &export_stmts {
+            let r = s.lower_expr(e);
+            exports.push(st::Export { name: (*name).to_string(), value: r });
+        }
+    } else {
+        for field in exports_wanted {
+            let r = s.env.get(field).cloned()
+                .unwrap_or_else(|| panic!("scope export `{}` is not a local name", field));
+            exports.push(st::Export { name: field.clone(), value: r });
+        }
+    }
+
+    st::Scope { name: scope_name.to_string(), imports: s.imports, vars, items: s.items, binds, exports }
+}
+
+/// The fields of child scope `scope` that this body references via `scope::field`.
+fn qualified_fields(body: &[Stmt], scope: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for stmt in body {
+        match stmt {
+            Stmt::Let(_, e) | Stmt::Var(_, e) | Stmt::Export(_, e) => collect_qualified(e, scope, &mut out),
+            Stmt::Scope(_, _) => {} // a child's `scope::field`s reference *its* children, not ours
+        }
+    }
+    out
+}
+
+fn collect_qualified(e: &Expr, scope: &str, out: &mut Vec<String>) {
+    match e {
+        Expr::Qualified(s, f) => if s == scope && !out.contains(f) { out.push(f.clone()); },
+        Expr::Map(e, _) | Expr::Filter(e, _) | Expr::Negate(e) | Expr::EnterAt(e, _)
+        | Expr::LiftIter(e) | Expr::Reduce(e, _) | Expr::Inspect(e, _) | Expr::Arrange(e) => collect_qualified(e, scope, out),
+        Expr::Join(l, r, _) => { collect_qualified(l, scope, out); collect_qualified(r, scope, out); },
+        Expr::Concat(es) => for e in es { collect_qualified(e, scope, out); },
+        Expr::Input(_) | Expr::Import(_) | Expr::Name(_) => {}
+    }
+}
+
+#[cfg(test)]
+mod tree_tests {
+    use super::*;
+    use crate::scope_ir::{Ref, Source};
+
+    fn parse(src: &str) -> Vec<Stmt> { crate::parse::pipe::parse(src) }
+    fn subs(s: &st::Scope) -> Vec<&st::Scope> {
+        s.items.iter().filter_map(|i| match i { st::Item::Sub(c) => Some(c), _ => None }).collect()
+    }
+    fn reads_a_child_export(s: &st::Scope) -> bool {
+        s.items.iter().any(|i| matches!(i, st::Item::Op(st::Node::Linear { input: Ref::ChildExport(..), .. })))
+    }
+
+    #[test]
+    fn lowers_reach_to_tree() {
+        let src = "\
+            let edges = input 0 | key($0[0] ; $0[1]);\n\
+            let roots = input 1 | key($0[0] ;);\n\
+            reach: {\n\
+                let proposals = reach | join(edges, ($2 ;));\n\
+                var reach = roots + proposals | distinct;\n\
+            }\n\
+            export \"result\" = reach::reach | key(;) | arrange | inspect(total);";
+        let prog = lower_tree(parse(src));
+
+        // root: two Input imports, one child (reach), one export.
+        assert_eq!(prog.root.imports.len(), 2);
+        assert!(prog.root.imports.iter().all(|i| matches!(i.from, Source::Input(_))));
+        assert_eq!(subs(&prog.root).len(), 1);
+        assert_eq!(prog.root.exports.len(), 1);
+        assert_eq!(prog.root.exports[0].name, "result");
+
+        // the reach scope: one feedback var, two Parent imports, one bind,
+        // and one export named "reach".
+        let reach = subs(&prog.root)[0];
+        assert_eq!(reach.vars.len(), 1);
+        assert_eq!(reach.imports.len(), 2);
+        assert!(reach.imports.iter().all(|i| matches!(i.from, Source::Parent(_))));
+        assert_eq!(reach.binds.len(), 1);
+        assert_eq!(reach.exports.len(), 1);
+        assert_eq!(reach.exports[0].name, "reach");
+
+        // the root export chain consumes the child's export.
+        assert!(reads_a_child_export(&prog.root), "root should read reach::reach as a child export");
+    }
+
+    #[test]
+    fn lowers_two_level_nesting_with_transitive_import() {
+        // root -> outer -> inner, with `i` (a root input) used only deep in inner.
+        let src = "\
+            let i = input 0 | key($0[0] ; $0[1]);\n\
+            outer: {\n\
+                inner: {\n\
+                    var x = i | distinct;\n\
+                }\n\
+                let y = inner::x;\n\
+            }\n\
+            export \"result\" = outer::y;";
+        let prog = lower_tree(parse(src));
+        assert_eq!(subs(&prog.root).len(), 1);              // outer
+        let outer = subs(&prog.root)[0];
+        assert_eq!(subs(outer).len(), 1);                   // inner
+        let inner = subs(outer)[0];
+        assert_eq!(inner.vars.len(), 1);                    // x
+        // `i` is threaded as an import through both levels.
+        assert!(outer.imports.iter().any(|im| im.name == "i"));
+        assert!(inner.imports.iter().any(|im| im.name == "i"));
+    }
+
+    #[test]
+    fn lowers_scc_depth_two() {
+        let src = r#"
+            let edges = input 0 | key($0[0] ; $0[1]);
+            let trans = edges | key($1 ; $0);
+            outer: {
+                let scc = edges + trim;
+                fwd: {
+                    let nodes = edges | key($1 ; $1) | enter_at($1[0]);
+                    let labels = proposals + nodes | min;
+                    var proposals = labels | join(scc, ($2 ; $1));
+                }
+                let trim_fwd = edges
+                    | join(fwd::labels, ($1 ; $0, $2))
+                    | join(fwd::labels, ($0 ; $1, $2))
+                    | filter($1[1] == $1[2])
+                    | key($0 ; $1[0]);
+                bwd: {
+                    let nodes = trans | key($1 ; $1) | enter_at($1[0]);
+                    let labels = proposals + nodes | min;
+                    var proposals = labels | join(trim_fwd, ($2 ; $1));
+                }
+                let trim_bwd = trans
+                    | join(bwd::labels, ($1 ; $0, $2))
+                    | join(bwd::labels, ($0 ; $1, $2))
+                    | filter($1[1] == $1[2])
+                    | key($0 ; $1[0]);
+                var trim = trim_bwd - edges;
+            }
+            export "result" = outer::scc | map(;) | arrange | inspect(total);
+        "#;
+        let prog = lower_tree(parse(src));
+        assert_eq!(subs(&prog.root).len(), 1); // outer
+        let outer = subs(&prog.root)[0];
+        assert_eq!(subs(outer).len(), 2); // fwd, bwd (depth 2)
+        assert_eq!(outer.vars.len(), 1); // trim
+        assert!(outer.exports.iter().any(|e| e.name == "scc"));
+        for child in subs(outer) {
+            assert_eq!(child.vars.len(), 1); // proposals
+            assert!(child.exports.iter().any(|e| e.name == "labels"));
+        }
+        assert!(reads_a_child_export(&prog.root)); // root reads outer::scc
+    }
+}

--- a/interactive/src/scope_ir.rs
+++ b/interactive/src/scope_ir.rs
@@ -143,6 +143,164 @@ pub struct Program {
     pub root: Scope,
 }
 
+impl Program {
+    /// Optimize every scope in place. See `Scope::optimize`.
+    pub fn optimize(&mut self) {
+        self.root.optimize();
+    }
+
+    /// Total operator (`Op`) count across all scopes.
+    pub fn op_count(&self) -> usize {
+        fn count(s: &Scope) -> usize {
+            s.items.iter().map(|i| match i { Item::Op(_) => 1, Item::Sub(c) => count(c) }).sum()
+        }
+        count(&self.root)
+    }
+}
+
+impl Scope {
+    /// Optimize this scope (and, recursively, its children) in place, iterating
+    /// three rewrites to a fixed point:
+    ///
+    /// - collapse an `Arrange` whose input is already an arrangement
+    ///   (an `Arrange` or a `Reduce`);
+    /// - fuse a `Linear` into its `Linear` input when it is that input's only
+    ///   consumer;
+    /// - deduplicate structurally identical operators.
+    ///
+    /// All three are *within-scope*: a scope boundary is a semantic barrier,
+    /// so nothing merges or moves across one. (The flat IR's dedup was
+    /// position-blind and could merge across boundaries — sound only because
+    /// the dynamic model has no structural nesting; here the structure makes
+    /// the restriction automatic.)
+    pub fn optimize(&mut self) {
+        for item in self.items.iter_mut() {
+            if let Item::Sub(child) = item { child.optimize(); }
+        }
+        let mut dead: Vec<bool> = vec![false; self.items.len()];
+        loop {
+            let changed = self.collapse_arranges(&mut dead)
+                | self.fuse_linear(&mut dead)
+                | self.dedup(&mut dead);
+            if !changed { break; }
+        }
+        self.compact(&dead);
+    }
+
+    /// Apply `f` to every `Ref` in this scope: operator inputs, child-scope
+    /// import edges, binds, and exports.
+    fn for_each_ref(&mut self, mut f: impl FnMut(&mut Ref)) {
+        for item in self.items.iter_mut() {
+            match item {
+                Item::Op(node) => match node {
+                    Node::Linear { input, .. } | Node::Arrange(input)
+                    | Node::Reduce { input, .. } | Node::Inspect { input, .. } => f(input),
+                    Node::Join { left, right, .. } => { f(left); f(right); },
+                    Node::Concat(refs) => for r in refs { f(r); },
+                },
+                Item::Sub(child) => for imp in child.imports.iter_mut() {
+                    if let Source::Parent(r) = &mut imp.from { f(r); }
+                },
+            }
+        }
+        for b in self.binds.iter_mut() { f(&mut b.value); }
+        for e in self.exports.iter_mut() { f(&mut e.value); }
+    }
+
+    /// Count, for each item, the references to it (`Local` or `ChildExport`).
+    fn use_counts(&mut self) -> Vec<usize> {
+        let mut counts = vec![0usize; self.items.len()];
+        self.for_each_ref(|r| match r {
+            Ref::Local(i) | Ref::ChildExport(i, _) => counts[*i] += 1,
+            Ref::Import(_) | Ref::Var(_) => {},
+        });
+        counts
+    }
+
+    /// Redirect every `Ref::Local(from)` to `to`, and mark `from` dead.
+    fn redirect(&mut self, from: usize, to: Ref, dead: &mut [bool]) {
+        self.for_each_ref(|r| if matches!(r, Ref::Local(i) if *i == from) { *r = to.clone(); });
+        dead[from] = true;
+    }
+
+    /// `Arrange` of an arrangement (an `Arrange` or `Reduce` item) is redundant.
+    fn collapse_arranges(&mut self, dead: &mut [bool]) -> bool {
+        let mut changed = false;
+        for i in 0..self.items.len() {
+            if dead[i] { continue; }
+            let Item::Op(Node::Arrange(Ref::Local(j))) = &self.items[i] else { continue };
+            let j = *j;
+            if !dead[j] && matches!(&self.items[j], Item::Op(Node::Arrange(_) | Node::Reduce { .. })) {
+                self.redirect(i, Ref::Local(j), dead);
+                changed = true;
+            }
+        }
+        changed
+    }
+
+    /// Fuse a `Linear` into its `Linear` input when it is the only consumer.
+    fn fuse_linear(&mut self, dead: &mut [bool]) -> bool {
+        let counts = self.use_counts();
+        let mut changed = false;
+        for i in 0..self.items.len() {
+            if dead[i] { continue; }
+            let Item::Op(Node::Linear { input: Ref::Local(j), .. }) = &self.items[i] else { continue };
+            let j = *j;
+            if dead[j] || counts[j] != 1 { continue; }
+            let Item::Op(Node::Linear { input: inner_input, ops: inner_ops }) = self.items[j].clone() else { continue };
+            let Item::Op(Node::Linear { ops, .. }) = &mut self.items[i] else { unreachable!() };
+            let mut fused = inner_ops;
+            fused.append(ops);
+            self.items[i] = Item::Op(Node::Linear { input: inner_input, ops: fused });
+            dead[j] = true;
+            changed = true;
+        }
+        changed
+    }
+
+    /// Deduplicate structurally identical operators (the later one redirects to
+    /// the earlier, so references keep pointing backward).
+    fn dedup(&mut self, dead: &mut [bool]) -> bool {
+        use std::collections::HashMap;
+        let mut seen: HashMap<String, usize> = HashMap::new();
+        let mut redirects: Vec<(usize, usize)> = Vec::new();
+        for i in 0..self.items.len() {
+            if dead[i] { continue; }
+            let Item::Op(node) = &self.items[i] else { continue };
+            let key = format!("{:?}", node);
+            match seen.get(&key) {
+                Some(&first) => redirects.push((i, first)),
+                None => { seen.insert(key, i); },
+            }
+        }
+        let changed = !redirects.is_empty();
+        for (i, first) in redirects {
+            self.redirect(i, Ref::Local(first), dead);
+        }
+        changed
+    }
+
+    /// Drop dead items and remap every item-indexed `Ref` to the compacted
+    /// positions. Dead items have no remaining references (their uses were
+    /// redirected when they were marked).
+    fn compact(&mut self, dead: &[bool]) {
+        let mut remap = vec![usize::MAX; self.items.len()];
+        let mut next = 0;
+        for (i, &d) in dead.iter().enumerate() {
+            if !d { remap[i] = next; next += 1; }
+        }
+        let mut keep = dead.iter().map(|d| !d);
+        self.items.retain(|_| keep.next().unwrap());
+        self.for_each_ref(|r| match r {
+            Ref::Local(i) | Ref::ChildExport(i, _) => {
+                assert!(remap[*i] != usize::MAX, "compact: a reference points at a dead item");
+                *i = remap[*i];
+            },
+            Ref::Import(_) | Ref::Var(_) => {},
+        });
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/interactive/src/scope_ir.rs
+++ b/interactive/src/scope_ir.rs
@@ -1,0 +1,192 @@
+//! Scope-tree IR: a tree of scopes, each owning its IR, with cross-scope flow
+//! as explicit import/export edges and feedback variables first-class.
+//! `lower::lower_tree` (AST -> tree) builds it; the backends' `render_tree`
+//! (tree -> dataflow) walk it.
+//!
+//! # Why a tree
+//!
+//! A scope boundary is a real semantic barrier: an operator cannot be hoisted
+//! across it, and an arrangement cannot be shared across it freely. The flat
+//! IR encodes boundaries *positionally* (`Scope`/`EndScope` markers in a node
+//! list), so every consumer that cares reconstructs them by analysis — and
+//! that reconstruction is where the explanation rewrite's level errors lived.
+//! Here the boundary is structural: a `Scope` owns its items, and nothing
+//! crosses except through an explicit import or export.
+//!
+//! The guiding principle throughout: make explicit anything a consumer would
+//! otherwise have to analyze the IR to recover. Feedback variables are a
+//! first-class list (the renderer never scans for them), `items` is in
+//! dependency order (rendering is a straight walk, no topological pass), and
+//! cross-scope references are edges (no reconstruction of who-refers-to-whom).
+//!
+//! # Two axes of a scope
+//!
+//! Structurally, every `{ .. }` renders as a timely region (`enter_region` /
+//! `leave_region`): real dataflow nesting, timestamp *type* unchanged.
+//! Temporally, an *iterating* scope additionally pushes a `PointStamp`
+//! coordinate (`enter_dynamic` / `leave_dynamic`): a timestamp *value*, the
+//! iteration counter. A scope iterates iff it has `vars`; there is no
+//! separate kind field to fall out of sync with that. When acyclic scopes
+//! earn distinct (region-only) rendering, `Scope` becomes an enum so each
+//! variant carries only its valid fields.
+//!
+//! # Cross-scope names
+//!
+//! Names are local to a scope; the front-end's spanning names (`edges`,
+//! `scope::field`) are resolved by lowering into local handles plus edges.
+//! Identity is the *definition an edge points at*, not string equality: two
+//! imports targeting the same definition are the same entity, so facts
+//! learned at a definition propagate to every importer along its edges.
+
+use crate::ir::LinearOp;
+use crate::parse::{Projection, Reducer};
+
+pub type ItemId = usize; // index into `Scope::items`
+pub type ImportId = usize; // index into `Scope::imports`
+pub type VarId = usize; // index into `Scope::vars`
+
+/// A reference, resolved *within its own scope*. Nothing here can name an item
+/// in another scope's interior — cross-scope flow goes through imports/exports.
+#[derive(Clone, Debug)]
+pub enum Ref {
+    /// An earlier `Op` item in this scope.
+    Local(ItemId),
+    /// A value entered via this scope's imports.
+    Import(ImportId),
+    /// A feedback variable of this scope.
+    Var(VarId),
+    /// Export `usize` of a `Sub` item (a child scope) in this scope.
+    ChildExport(ItemId, usize),
+}
+
+/// Where an import's value comes from. Inner scopes import from the parent; the
+/// root imports the program's external sources — unifying `Input`/`Import`.
+#[derive(Clone, Debug)]
+pub enum Source {
+    /// A reference in the parent scope.
+    Parent(Ref),
+    /// A positional program input (root only).
+    Input(usize),
+    /// A named external trace (root only).
+    Trace(String),
+}
+
+/// A value brought into a scope — `enter_region` (+ `enter_dynamic` if iterating).
+#[derive(Clone, Debug)]
+pub struct Import {
+    pub name: String,
+    pub from: Source,
+}
+
+/// A value surrendered up — `leave_region` (+ `leave_dynamic` if iterating).
+#[derive(Clone, Debug)]
+pub struct Export {
+    pub name: String,
+    pub value: Ref,
+}
+
+/// A feedback variable, identified by its index in `Scope::vars`. Carries its
+/// source name (readability, cross-scope name visibility). Its shape is *not*
+/// stored — the shape pass derives every node/var shape when a consumer needs
+/// it, so storing it here would cache a derivable (and currently unknown) value.
+#[derive(Clone, Debug)]
+pub struct Var {
+    pub name: String,
+}
+
+/// Closes a feedback loop: `var <- value`.
+#[derive(Clone, Debug)]
+pub struct Bind {
+    pub var: VarId,
+    pub value: Ref,
+}
+
+/// A pure operator. Sources (`Input`/`Import`) are imports; structure
+/// (`Scope`/`Variable`/`Leave`/`Bind`) is the scope itself — neither is a node.
+#[derive(Clone, Debug)]
+pub enum Node {
+    Linear { input: Ref, ops: Vec<LinearOp> },
+    Concat(Vec<Ref>),
+    Arrange(Ref),
+    Join { left: Ref, right: Ref, projection: Projection },
+    Reduce { input: Ref, reducer: Reducer },
+    Inspect { input: Ref, label: String },
+}
+
+/// An item in a scope's body: a pure operator or a nested child scope. The
+/// `items` vec is in dependency order, so rendering is a straight walk — no
+/// topological re-analysis. `Ref::Local`/`ChildExport` index into it.
+#[derive(Clone, Debug)]
+pub enum Item {
+    Op(Node),
+    Sub(Scope),
+}
+
+/// A scope owns its IR. It iterates iff it has `vars` (no `kind` field yet; see
+/// the design doc). Children are owned, inline in `items`.
+#[derive(Clone, Debug, Default)]
+pub struct Scope {
+    /// The source name of the `{ .. }` block ("root" for the program root).
+    /// Names the timely region at render time and labels the scope in viz.
+    pub name: String,
+    pub imports: Vec<Import>,
+    pub vars: Vec<Var>,
+    pub items: Vec<Item>,
+    pub binds: Vec<Bind>,
+    pub exports: Vec<Export>,
+}
+
+/// A program is its root scope: root imports are the external sources, root
+/// exports are the program's outputs.
+#[derive(Clone, Debug)]
+pub struct Program {
+    pub root: Scope,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Express a reach-shaped program by hand: it exercises items (Op + Sub),
+    // every `Ref` variant, and both relevant `Source` variants — proving the
+    // shape can represent a real scoped, iterative program.
+    #[test]
+    fn expresses_a_scoped_iterative_program() {
+        let noproj = Projection { key: vec![], val: vec![] };
+        let inner = Scope {
+            name: "reach".into(),
+            imports: vec![
+                Import { name: "edges".into(), from: Source::Parent(Ref::Import(0)) },
+                Import { name: "roots".into(), from: Source::Parent(Ref::Import(1)) },
+            ],
+            vars: vec![Var { name: "reach".into() }],
+            items: vec![
+                // proposals = reach JOIN edges  — references Var + Import
+                Item::Op(Node::Join { left: Ref::Var(0), right: Ref::Import(0), projection: noproj.clone() }),
+                // body = roots + proposals       — references Import + Local
+                Item::Op(Node::Concat(vec![Ref::Import(1), Ref::Local(0)])),
+            ],
+            binds: vec![Bind { var: 0, value: Ref::Local(1) }], // reach <- body
+            exports: vec![Export { name: "reach".into(), value: Ref::Var(0) }],
+        };
+        let root = Scope {
+            name: "root".into(),
+            imports: vec![
+                Import { name: "in0".into(), from: Source::Input(0) },
+                Import { name: "in1".into(), from: Source::Input(1) },
+            ],
+            items: vec![Item::Sub(inner)], // item 0 = the reach sub-scope
+            exports: vec![Export { name: "result".into(), value: Ref::ChildExport(0, 0) }],
+            ..Scope::default()
+        };
+        let prog = Program { root };
+
+        assert_eq!(prog.root.items.len(), 1);
+        assert!(matches!(prog.root.items[0], Item::Sub(_)));
+        let Item::Sub(reach) = &prog.root.items[0] else { unreachable!() };
+        assert_eq!(reach.vars.len(), 1);
+        assert!(matches!(prog.root.exports[0].value, Ref::ChildExport(0, 0)));
+        assert!(matches!(prog.root.imports[0].from, Source::Input(0)));
+        assert!(matches!(reach.binds[0].value, Ref::Local(1)));
+    }
+}


### PR DESCRIPTION
Replaces the positional scope encoding (`Scope`/`EndScope` markers in a flat node list) with a tree of scopes as the IR the backends actually run, and renders each source `{ .. }` as a real timely region.

## What

- **`scope_ir`**: a `Program` is its root `Scope`; a scope owns its `imports`, first-class feedback `vars`, `items` (operators and child scopes, in dependency order), `binds`, and `exports`. References resolve within their scope; nothing crosses a boundary except through an explicit import/export edge. The module doc carries the design rationale.
- **`lower_tree`**: AST → tree, mirroring the source nesting; a scope imports its transitive free outer names and exports the fields reached via `scope::field`. Join/reduce inputs are arranged explicitly.
- **Rendering** (both backends): one `region_named` per scope — imports `enter` the region, exports `leave` it, and the dynamic `PointStamp` coordinate rides inside (the dynamic model is unchanged; regions add structure, not timestamp types). Feedback variables come from the `vars` list; items render in recorded order — no scanning, no topological re-analysis.
- **`Scope::optimize`**: within-scope linear fusion, structural dedup, and arrange-collapse to a fixed point, recursing into children. Notably *within-scope by construction*: the flat dedup was position-blind and could in principle merge across scope boundaries (sound only in the dynamic model); the tree makes the restriction automatic.

## Verification

- Corpus (reach; scc with nested `fwd`/`bwd` regions; stable; kcore via the applicative parser) matches the flat renderer **byte-for-byte** on both backends, at rounds 0 and 7, optimized on both sides.
- Operator counts are identical like-for-like: reach 10 = 10, scc 31 = 31 (tree-optimized vs flat-optimized).
- Unit tests: tree structure (reach, two-level nesting, scc), fusion, arrangement sharing across joins, arrange-of-reduce collapse, nested-scope optimization.
- `DIAG=1` serves the diagnostics WebSocket; the per-scope regions are visible in the diagnostics UI.

## What this does not do

- The flat IR remains: `--explain` still runs on it (the explanation rewrite operates on flat programs), and `FLAT=1` forces the flat path for A/B comparison. Retirement comes with a follow-up PR that ports the explanation rewrite to the tree and deletes flat in the same change.
- Every scope still renders as iterative (region + dynamic coordinate). Detecting acyclic scopes and rendering them region-only is future work, at which point `Scope` becomes an `Iterative | Region` enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)