### PR TITLE
interactive: rename explain_tree to explain

### DIFF
--- a/interactive/examples/ddir_vec.rs
+++ b/interactive/examples/ddir_vec.rs
@@ -1,6 +1,6 @@
 //! DD IR vec-backed backend: parse, lower, render, execute.
 //!
-//! With `--explain`, applies the explanation rewrite (explain_tree) after lowering
+//! With `--explain`, applies the explanation rewrite after lowering
 //! and treats the last input handle as the query input (seeded from the
 //! `QUERY` env var, format `"key_fields:val_fields"`).
 
@@ -232,15 +232,12 @@ fn run(
     rounds: Option<u64>,
     explain: bool,
 ) {
-    // The scope-tree IR (lower_tree + render_tree, one timely region per scope)
-    // is the default path, including for `--explain` (explain_tree). FLAT=1
-    // forces the flat path for A/B comparison; outputs must match either way.
     let mut query_shape: Option<(usize, usize)> = None;
     let mut tree = lower::lower_tree(stmts);
     // CLONE_RT=1 routes the program through the explain rewrite's
     // clone-with-lifts as an identity check: outputs must be unchanged.
     if std::env::var("CLONE_RT").is_ok() {
-        tree = interactive::explain_tree::clone_identity(&tree);
+        tree = interactive::explain::clone_identity(&tree);
     }
     // --explain: rewrite for self-explanation before optimization (the
     // rules assume single-op Linears). Sources are the root's imports.
@@ -249,8 +246,8 @@ fn run(
             interactive::scope_ir::Source::Input(_) => (arity, 0usize),
             other => panic!("ddir_vec --explain: unsupported source {:?}", other),
         }).collect();
-        query_shape = Some(interactive::explain_tree::export_shape(&tree, &source_shapes));
-        tree = interactive::explain_tree::explain_tree(&tree, &source_shapes);
+        query_shape = Some(interactive::explain::export_shape(&tree, &source_shapes));
+        tree = interactive::explain::explain(&tree, &source_shapes);
     }
     let ops_before = tree.op_count();
     tree.optimize();

--- a/interactive/examples/dump_explain.rs
+++ b/interactive/examples/dump_explain.rs
@@ -29,7 +29,7 @@ fn main() {
         scope_ir::Source::Input(_) | scope_ir::Source::Trace(_) => (arity, 0usize),
         scope_ir::Source::Parent(_) => unreachable!("root scope cannot import from a parent"),
     }).collect();
-    let rewritten = interactive::explain_tree::explain_tree(&original, &source_shapes);
+    let rewritten = interactive::explain::explain(&original, &source_shapes);
 
     println!();
     println!("-- ====================================================");

--- a/interactive/src/explain.rs
+++ b/interactive/src/explain.rs
@@ -1,6 +1,6 @@
 //! The explanation rewrite on the scope-tree IR.
 //!
-//! `explain_tree(p)` transforms a program into one whose execution produces
+//! `explain(p)` transforms a program into one whose execution produces
 //! per-source demand-set explanations for queries against `p`'s first
 //! export: root { sources, query input, witness clone } plus an iterative
 //! `explain` scope { demand-set vars, forward clone on demanded rows,
@@ -178,7 +178,7 @@ fn clone_rec(orig: &Scope, out: &mut Scope, import_map: &[Ref], path: &[usize]) 
 
 // ===== The explanation transform =====
 //
-// `explain_tree(p)` produces a Program whose execution yields per-source
+// `explain(p)` produces a Program whose execution yields per-source
 // demand-set explanations for queries against `p`'s first export. Output
 // shape: root { sources, query input, witness clone } and an iterative
 // `explain` scope { demand-set vars, forward clone on demanded rows,
@@ -625,7 +625,7 @@ pub fn export_shape(p: &Program, source_shapes: &[(usize, usize)]) -> (usize, us
 /// The transform. `source_shapes[k]` is the `(k, v)` of the original root's
 /// import `k` (positional inputs and named traces alike). The query arrives
 /// as one extra positional input appended after the original inputs.
-pub fn explain_tree(p: &Program, source_shapes: &[(usize, usize)]) -> Program {
+pub fn explain(p: &Program, source_shapes: &[(usize, usize)]) -> Program {
     let n_sources = p.root.imports.len();
     assert_eq!(source_shapes.len(), n_sources, "one shape per root import");
     let shapes = site_shapes(p, source_shapes);
@@ -688,7 +688,7 @@ pub fn explain_tree(p: &Program, source_shapes: &[(usize, usize)]) -> Program {
         contribs: BTreeMap::new(),
     };
     // Seed: the query rows are demand against the first export's target.
-    let first = p.root.exports.first().expect("explain_tree: program has no export").value.clone();
+    let first = p.root.exports.first().expect("explain: program has no export").value.clone();
     let target = resolve(&p.root, &[], &first);
     let seeded = rev.route(&mut ex, ex_query, 0, &target);
     rev.contribs.entry(target).or_default().push(seeded);
@@ -859,7 +859,7 @@ impl<'a> Reverse<'a> {
             Node::Linear { input, ops } => {
                 let op = match ops.as_slice() {
                     [single] => single,
-                    _ => panic!("explain_tree: multi-op Linear (run before optimize)"),
+                    _ => panic!("explain: multi-op Linear (run before optimize)"),
                 };
                 match op {
                     LinearOp::Project(proj) => {
@@ -878,7 +878,7 @@ impl<'a> Reverse<'a> {
                         // the routing adapter handles any depth difference.
                         self.push(ex, path, input, dep_this, out_user_len);
                     }
-                    LinearOp::LiftIter => panic!("explain_tree: LiftIter in user program"),
+                    LinearOp::LiftIter => panic!("explain: LiftIter in user program"),
                 }
             }
             Node::Concat(refs) => {

--- a/interactive/src/lib.rs
+++ b/interactive/src/lib.rs
@@ -3,7 +3,7 @@ pub mod ir;
 pub mod lower;
 pub mod folded;
 pub mod scope_ir;
-pub mod explain_tree;
+pub mod explain;
 
 use std::collections::BTreeSet;
 


### PR DESCRIPTION
The `_tree` qualifier lost its meaning once the flat rewrite was deleted in #753/#754.
This renames `explain_tree.rs` → `explain.rs` and the public `explain_tree` → `explain`, and drops the now-stale flat-path comments.

Mechanical: rename plus comment cleanup, no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)