### PR TITLE
interactive/explain: decouple reverse rules behind a data-model trait

### DIFF
--- a/interactive/src/explain/decouple.rs
+++ b/interactive/src/explain/decouple.rs
@@ -1,0 +1,615 @@
+//! Data-model-agnostic surface for explain's reverse-tracing.
+//!
+//! The reverse rules used to hard-code the flat `[i64]` row layout — building
+//! projections as `FieldExpr` index ranges inline. This module factors that
+//! out: the rules are written **once** over two traits, and the data model
+//! supplies the representation.
+//!
+//! * [`RowModel`] builds the projections/predicates each rule needs.
+//! * [`Dataflow`] is the orchestration backend (concat/project/filter/join) —
+//!   the scope builder `Sb` for real explain.
+//!
+//! Changing the data model means reimplementing [`RowModel`]; the rules and the
+//! orchestration are untouched. The flat `[i64]` impl lives in `explain.rs` and
+//! reuses `folded` for the time-filter/strip algebra.
+//!
+//! ## The demand envelope
+//!
+//! Every method speaks in terms of one object — a **demand row**, written
+//!
+//! ```text
+//!     (K ; V, chain, [q])
+//! ```
+//!
+//! where `;` separates the *key* from the *value*. The value packs three
+//! logical parts, in order:
+//!
+//! * **`V`** — the underlying data value (`v` columns in the flat model). The
+//!   demanded output's value on the `dep` side, the candidate input's value on
+//!   the pair-table side.
+//! * **`chain`** — the loop-iteration coordinates, innermost-first, length =
+//!   the node's scope depth. Time lives in data here; `folded` owns the
+//!   per-coordinate algebra (compare outer-aligned, strip).
+//! * **`q`** — a single trailing query id, present on `dep` rows (the thing
+//!   being explained), absent on pair-table rows.
+//!
+//! ## Reading the method contracts
+//!
+//! Each method returns a projection/predicate that the rule applies to a row of
+//! a stated shape. Inputs are addressed by **slot**: after a binary `join`, the
+//! row exposes `$0` = the join key, `$1` = the left input's value, `$2` = the
+//! right input's value; before a join, `$0`/`$1` are key/value. A method's doc
+//! gives the *input row shape it expects* and the *output row shape it
+//! produces*, both in the `(K ; …)` notation above; an implementer needs only
+//! those shapes, not the flat positions. Sizes arrive as parameters: `k`/`v`
+//! column counts, `*_len`/`*_depth` chain lengths, `min` toggling Min's
+//! value-narrowing. Predicate methods return `None` for "no constraint" (the
+//! rule then skips the filter).
+
+/// Builds the projections/predicates the reverse rules need, in terms of the
+/// demand envelope `(K ; V, chain, [q])` documented at the module level.
+pub trait RowModel {
+    type Proj;
+    type Pred;
+
+    // --- packing / unpacking data and the join key ---
+
+    /// Move the data `(K, V)` into the join key, keeping the row's `chain` (and
+    /// `q` when `has_q`): `(K ; V, chain, [q]) -> (pack[K,V] ; chain, [q])`. The
+    /// chain and the query id are kept as distinct parts — `chain_len` and
+    /// `has_q` are passed separately (not folded into a column count) so a
+    /// nested model can preserve their boundary. Pair rows pass `has_q = false`,
+    /// `dep` rows `has_q = true`, and a full-row distinct `chain_len = 0`.
+    fn pack(k: usize, v: usize, chain_len: usize, has_q: bool) -> Self::Proj;
+    /// Unpack a packed-and-distinct key back to a row: `(pack[K,V] ; ) -> (K ; V)`.
+    fn distinct_unpack(k: usize, v: usize) -> Self::Proj;
+    /// The identity reshaping `(K ; V ++ rest) -> (K ; V)` — drops a row's
+    /// chain/`q` (used by demand-set seeding and the semijoin).
+    fn project_kv(k: usize, v: usize) -> Self::Proj;
+
+    // --- shape-preserving lookup (Concat/Leave) ---
+
+    /// Reassemble after the SP join on `pack[K,V]`. Input: the joined row
+    /// `[$0 = pack[K,V], $1 = chain_out ++ q (dep), $2 = chain_in (pair)]`.
+    /// Output: `(K ; V, chain_in, chain_out, q)`.
+    fn sp_reassemble(k: usize, v: usize, in_len: usize, out_len: usize) -> Self::Proj;
+
+    // --- keyed lookup (Reduce) ---
+
+    /// Project the keyed (join-on-`K`) row. Input:
+    /// `[$0 = K, $1 = V_out ++ chain_out ++ q (dep), $2 = V_in ++ chain_in (pair)]`.
+    /// Output: `(K ; V_in, [V_out,] chain_in, chain_out, q)` — `V_out` is
+    /// carried only when `min`, for the narrowing below.
+    fn ky_join(k: usize, v_in: usize, v_out: usize, in_len: usize, out_len: usize, min: bool) -> Self::Proj;
+    /// Min value-narrowing on the `min` row above: keep rows with `V_in == V_out`
+    /// (both `v_in` columns of the value, at `[0..v_in]` and `[v_in..2*v_in]`).
+    fn ky_data_eq(v_in: usize) -> Option<Self::Pred>;
+    /// Drop the carried `V_out`, restoring the SP-shaped row
+    /// `(K ; V_in, chain_in, chain_out, q)`.
+    fn ky_drop_vout(k: usize, v_in: usize, v_out: usize, in_len: usize, out_len: usize) -> Self::Proj;
+
+    // --- lossy lookup (Linear[Project]) ---
+
+    /// Fast path used when `proj` is invertible and the chains have equal length
+    /// (`in_len == out_len`): map `dep` directly to a contrib without the pair
+    /// table. `(K_out ; V_out, chain_out, q) -> (K_in ; V_in, chain_out, q)`,
+    /// reconstructing `(K_in, V_in)` from the output. `None` if not invertible.
+    fn lossy_try_invert(proj: &Self::Proj, k_in: usize, v_in: usize, k_out: usize, v_out: usize, out_len: usize) -> Option<Self::Proj>;
+    /// Fallback pair re-key: apply the user `proj.key` to a pair row to compute
+    /// `K_out`, carrying the input data through.
+    /// `(K_in ; V_in, chain_in) -> (K_out ; K_in, V_in, chain_in)`.
+    fn lossy_pair(proj: &Self::Proj, k_in: usize, v_in: usize, in_len: usize) -> Self::Proj;
+    /// Reassemble after the fallback join on `K_out`. Input:
+    /// `[$0 = K_out, $1 = V_out ++ chain_out ++ q (dep), $2 = K_in ++ V_in ++ chain_in (pair)]`.
+    /// Output: `(K_in ; V_in, chain_in, chain_out, q)`.
+    fn lossy_reassemble(k_in: usize, v_in: usize, v_out: usize, in_len: usize, out_len: usize) -> Self::Proj;
+
+    // --- join lookup (two inputs; #758 filters both times before splitting) ---
+
+    /// Forward-join the two pair tables on `K`, applying the user `proj`. Input:
+    /// `[$0 = K, $1 = V_L ++ chain_L (left), $2 = V_R ++ chain_R (right)]`.
+    /// Output: `(K_out ; K, V_L, V_R, chain_L, chain_R, V_out)`, where
+    /// `K_out`/`V_out` are `proj.key`/`proj.val` over `(K, V_L, V_R)`.
+    fn join_forward(proj: &Self::Proj, k: usize, v_l: usize, v_r: usize, l_len: usize, r_len: usize) -> Self::Proj;
+    /// Reassemble after joining `dep` against the forward-join pair on `K_out`,
+    /// into one wide row carrying everything both sides' filters and splits need.
+    /// Input: `[$0 = K_out, $1 = V_out ++ chain_out ++ q (dep), $2 = pair row above]`.
+    /// Output: `(K ; V_L, V_R, chain_L, chain_R, chain_out, q, V_out_dep, V_out_pair)`.
+    #[allow(clippy::too_many_arguments)]
+    fn join_combined(k: usize, v_l: usize, v_r: usize, v_out: usize, l_len: usize, r_len: usize, out_len: usize) -> Self::Proj;
+    /// Narrowing on the wide row: `chain_L ≤ chain_out` ∧ `chain_R ≤ chain_out`
+    /// (both outer-aligned) ∧ `V_out_dep == V_out_pair`. Both sides' times are
+    /// filtered here, before either side's chain is projected away (#758).
+    fn join_filter(v_l: usize, v_r: usize, v_out: usize, l_len: usize, r_len: usize, out_len: usize) -> Option<Self::Pred>;
+    /// Project one side's contrib out of the filtered wide row. `left` selects
+    /// `(K ; V_L, chain_L, q)` vs `(K ; V_R, chain_R, q)`.
+    #[allow(clippy::too_many_arguments)]
+    fn join_split(left: bool, k: usize, v_l: usize, v_r: usize, l_len: usize, r_len: usize, out_len: usize) -> Self::Proj;
+
+    // --- the chain (`folded`) algebra, shared by SP / keyed / lossy ---
+
+    /// Soundness filter on a `(K ; V, chain_in, chain_out, q)` row: keep rows
+    /// with `chain_in ≤ chain_out`, compared outer-aligned (an input can only
+    /// explain an output that came no earlier). `None` when the chains share no
+    /// coordinate. (`v` locates the chains after the `v`-column value.)
+    fn time_le(v: usize, in_len: usize, out_len: usize) -> Option<Self::Pred>;
+    /// Strip `chain_out` and the inner `chain_in` coords past `keep` from a
+    /// `(K ; V, chain_in, chain_out, q)` row, leaving `(K ; V, chain_in[..keep], q)`.
+    /// Kept coords are the *outer* ones, matching `time_le`'s alignment.
+    fn strip(k: usize, v: usize, in_len: usize, out_len: usize, keep: usize) -> Self::Proj;
+
+    // --- bind iter-decrement (inverts a loop variable's feedback) ---
+
+    /// Keep only rows whose innermost chain coordinate is `> 0` (iteration-0
+    /// demand has no body-side source). The coordinate sits just after the
+    /// `v`-column value.
+    fn bind_filter(v: usize) -> Option<Self::Pred>;
+    /// Decrement the innermost chain coordinate by one, leaving everything else
+    /// intact: `(K ; V, chain, q) -> (K ; V, chain with chain[0]-1, q)`.
+    /// `user_len` is the chain length.
+    fn bind_decrement(k: usize, v: usize, user_len: usize) -> Self::Proj;
+}
+
+/// Orchestration backend: collection handles and the four primitive ops.
+pub trait Dataflow {
+    type Handle: Clone;
+    type Proj;
+    type Pred;
+    fn project(&mut self, c: &Self::Handle, p: Self::Proj) -> Self::Handle;
+    fn filter(&mut self, c: &Self::Handle, p: Self::Pred) -> Self::Handle;
+    fn join(&mut self, l: &Self::Handle, r: &Self::Handle, p: Self::Proj) -> Self::Handle;
+    fn concat(&mut self, cs: Vec<Self::Handle>) -> Self::Handle;
+}
+
+fn opt_filter<D: Dataflow>(df: &mut D, c: D::Handle, p: Option<D::Pred>) -> D::Handle {
+    match p { Some(p) => df.filter(&c, p), None => c }
+}
+
+/// One side's inputs to a reverse rule: its pair-table halves, shape, chain length.
+pub struct SideInfo<D: Dataflow> {
+    pub witness: D::Handle,
+    pub forward: D::Handle,
+    pub shape: (usize, usize),
+    pub user_len: usize,
+}
+
+/// Shape-preserving lookup (Concat/Leave). `keep == in_len` here.
+pub fn shape_preserving_lookup<M, D>(df: &mut D, dep: &D::Handle, side: &SideInfo<D>, out_depth: usize) -> D::Handle
+where M: RowModel, D: Dataflow<Proj = M::Proj, Pred = M::Pred> {
+    let (k, v) = side.shape;
+    let in_len = side.user_len;
+    let pair = df.concat(vec![side.witness.clone(), side.forward.clone()]);
+    let pair_keyed = df.project(&pair, M::pack(k, v, in_len, false));
+    let dep_keyed = df.project(dep, M::pack(k, v, out_depth, true));
+    let joined = df.join(&dep_keyed, &pair_keyed, M::sp_reassemble(k, v, in_len, out_depth));
+    let filtered = opt_filter(df, joined, M::time_le(v, in_len, out_depth));
+    df.project(&filtered, M::strip(k, v, in_len, out_depth, in_len))
+}
+
+/// Keyed (Reduce) lookup; `min` enables value-narrowing.
+pub fn keyed_lookup<M, D>(df: &mut D, dep: &D::Handle, side: &SideInfo<D>, output_shape: (usize, usize), out_len: usize, reducer_min: bool) -> D::Handle
+where M: RowModel, D: Dataflow<Proj = M::Proj, Pred = M::Pred> {
+    let (k, v_in) = side.shape;
+    let in_len = side.user_len;
+    let (_, v_out) = output_shape;
+    let min = reducer_min && v_in == v_out && v_in > 0;
+    let pair = df.concat(vec![side.witness.clone(), side.forward.clone()]);
+    let joined = df.join(dep, &pair, M::ky_join(k, v_in, v_out, in_len, out_len, min));
+    let after = if min {
+        let f = opt_filter(df, joined, M::ky_data_eq(v_in));
+        df.project(&f, M::ky_drop_vout(k, v_in, v_out, in_len, out_len))
+    } else {
+        joined
+    };
+    let filtered = opt_filter(df, after, M::time_le(v_in, in_len, out_len));
+    df.project(&filtered, M::strip(k, v_in, in_len, out_len, in_len))
+}
+
+/// Lossy (Project) lookup: invert fast-path (equal chain lengths) else pair table.
+pub fn lossy_lookup<M, D>(df: &mut D, dep: &D::Handle, side: &SideInfo<D>, output_shape: (usize, usize), out_len: usize, proj: &M::Proj) -> D::Handle
+where M: RowModel, D: Dataflow<Proj = M::Proj, Pred = M::Pred> {
+    let (k_in, v_in) = side.shape;
+    let in_len = side.user_len;
+    let (k_out, v_out) = output_shape;
+    if in_len == out_len {
+        if let Some(p) = M::lossy_try_invert(proj, k_in, v_in, k_out, v_out, out_len) {
+            return df.project(dep, p);
+        }
+    }
+    let pair = df.concat(vec![side.witness.clone(), side.forward.clone()]);
+    let pair_keyed = df.project(&pair, M::lossy_pair(proj, k_in, v_in, in_len));
+    let joined = df.join(dep, &pair_keyed, M::lossy_reassemble(k_in, v_in, v_out, in_len, out_len));
+    let filtered = opt_filter(df, joined, M::time_le(v_in, in_len, out_len));
+    df.project(&filtered, M::strip(k_in, v_in, in_len, out_len, in_len))
+}
+
+/// Join lookup (#758): forward-join pair tables, one combined dep×pair join
+/// carrying both chains, one combined time+value filter, then split per side.
+pub fn join_lookup<M, D>(df: &mut D, dep: &D::Handle, left: &SideInfo<D>, right: &SideInfo<D>, output_shape: (usize, usize), out_len: usize, proj: &M::Proj) -> (D::Handle, D::Handle)
+where M: RowModel, D: Dataflow<Proj = M::Proj, Pred = M::Pred> {
+    let (k, v_l) = left.shape;
+    let (_, v_r) = right.shape;
+    let (_, v_out) = output_shape;
+    let l_len = left.user_len;
+    let r_len = right.user_len;
+    let lp = df.concat(vec![left.witness.clone(), left.forward.clone()]);
+    let rp = df.concat(vec![right.witness.clone(), right.forward.clone()]);
+    let pair = df.join(&lp, &rp, M::join_forward(proj, k, v_l, v_r, l_len, r_len));
+    let joined = df.join(dep, &pair, M::join_combined(k, v_l, v_r, v_out, l_len, r_len, out_len));
+    let timed = opt_filter(df, joined, M::join_filter(v_l, v_r, v_out, l_len, r_len, out_len));
+    let lc = df.project(&timed, M::join_split(true, k, v_l, v_r, l_len, r_len, out_len));
+    let rc = df.project(&timed, M::join_split(false, k, v_l, v_r, l_len, r_len, out_len));
+    (lc, rc)
+}
+
+#[cfg(test)]
+mod contract {
+    //! Executable contract for the reverse rules.
+    //!
+    //! Each test is a by-example spec: concrete `dep`/pair rows in the demand
+    //! envelope go in, and the asserted demand rows come out. They run the
+    //! generic rules on an in-memory `Dataflow` against the flat `RowModel`, so
+    //! the requirements are runnable and machine-checked rather than only prose.
+    //! A new `RowModel` (e.g. a nested-value model) is correct when it
+    //! reproduces these same semantics.
+
+    use super::*;
+    use crate::explain::Flat;
+    use crate::ir::{eval_condition, eval_fields};
+    use crate::parse::{Condition, FieldExpr, Projection};
+
+    type Row = Vec<i64>;
+    type Coll = Vec<(Row, Row)>;
+
+    /// In-memory dataflow: applies projections/predicates with the flat row
+    /// evaluator (`ir::eval_*`). `join` is a nested-loop equi-join on the key.
+    struct Mem;
+    impl Dataflow for Mem {
+        type Handle = Coll;
+        type Proj = Projection;
+        type Pred = Condition;
+        fn project(&mut self, c: &Coll, p: Projection) -> Coll {
+            c.iter().map(|(k, v)| {
+                let i = [k.as_slice(), v.as_slice()];
+                (eval_fields(&p.key, &i), eval_fields(&p.val, &i))
+            }).collect()
+        }
+        fn filter(&mut self, c: &Coll, p: Condition) -> Coll {
+            c.iter().filter(|(k, v)| eval_condition(&p, &[k.as_slice(), v.as_slice()])).cloned().collect()
+        }
+        fn join(&mut self, l: &Coll, r: &Coll, p: Projection) -> Coll {
+            let mut out = Vec::new();
+            for (lk, lv) in l {
+                for (rk, rv) in r {
+                    if lk == rk {
+                        let i = [lk.as_slice(), lv.as_slice(), rv.as_slice()];
+                        out.push((eval_fields(&p.key, &i), eval_fields(&p.val, &i)));
+                    }
+                }
+            }
+            out
+        }
+        fn concat(&mut self, cs: Vec<Coll>) -> Coll { cs.into_iter().flatten().collect() }
+    }
+
+    fn side(witness: Coll, shape: (usize, usize), user_len: usize) -> SideInfo<Mem> {
+        SideInfo { witness, forward: vec![], shape, user_len }
+    }
+    fn sorted(mut c: Coll) -> Coll { c.sort(); c }
+
+    // --- shape-preserving lookup (Concat/Leave) ---
+
+    #[test]
+    fn sp_depth0_keeps_only_value_matching_pair() {
+        // pair table has two same-key rows; dep demands V=7 (with q=9). Packing
+        // (K,V) into the join key means only the V=7 pair can match.
+        let pair = vec![(vec![5], vec![7]), (vec![5], vec![8])];
+        let dep = vec![(vec![5], vec![7, 9])]; // (K=5 ; V_out=7, q=9)
+        let out = shape_preserving_lookup::<Flat, _>(&mut Mem, &dep, &side(pair, (1, 1), 0), 0);
+        assert_eq!(out, vec![(vec![5], vec![7, 9])]); // (K=5 ; V=7, q=9)
+    }
+
+    #[test]
+    fn sp_depth1_time_filters_late_inputs() {
+        // chain length 1. An input at iter 2 explains an output demanded at
+        // iter 3 (2 ≤ 3, kept); one at iter 4 does not (4 ≤ 3 false, dropped).
+        let keep = vec![(vec![5], vec![7, 2])];   // (K=5 ; V=7, chain_in=2)
+        let drop = vec![(vec![5], vec![7, 4])];   // chain_in=4
+        let dep = vec![(vec![5], vec![7, 3, 9])]; // (K=5 ; V=7, chain_out=3, q=9)
+        let kept = shape_preserving_lookup::<Flat, _>(&mut Mem, &dep, &side(keep, (1, 1), 1), 1);
+        assert_eq!(kept, vec![(vec![5], vec![7, 2, 9])]); // chain_in=2 kept
+        let dropped = shape_preserving_lookup::<Flat, _>(&mut Mem, &dep, &side(drop, (1, 1), 1), 1);
+        assert!(dropped.is_empty());
+    }
+
+    // --- keyed lookup (Reduce) ---
+
+    #[test]
+    fn keyed_min_narrows_to_the_demanded_value() {
+        // Min: only the input row whose V equals the demanded (min) value is
+        // demanded; the sibling at the same key is not.
+        let pair = vec![(vec![5], vec![7]), (vec![5], vec![6])];
+        let dep = vec![(vec![5], vec![7, 9])]; // (K=5 ; V_out=7, q=9)
+        let out = keyed_lookup::<Flat, _>(&mut Mem, &dep, &side(pair, (1, 1), 0), (1, 1), 0, true);
+        assert_eq!(out, vec![(vec![5], vec![7, 9])]);
+    }
+
+    #[test]
+    fn keyed_nonmin_demands_all_same_key_inputs() {
+        // Count/Distinct: every input row at the key contributes.
+        let pair = vec![(vec![5], vec![7]), (vec![5], vec![6])];
+        let dep = vec![(vec![5], vec![1, 9])]; // V_out unrelated (a count)
+        let out = keyed_lookup::<Flat, _>(&mut Mem, &dep, &side(pair, (1, 1), 0), (1, 1), 0, false);
+        assert_eq!(sorted(out), vec![(vec![5], vec![6, 9]), (vec![5], vec![7, 9])]);
+    }
+
+    // --- lossy lookup (Linear[Project]) ---
+
+    #[test]
+    fn lossy_invertible_recovers_input_directly() {
+        // proj: K_out = V_in, V_out = K_in (a rekey). Invertible, depth 0 -> the
+        // fast path reconstructs (K_in, V_in) from the demanded output.
+        let proj = Projection { key: vec![FieldExpr::Index(1, 0)], val: vec![FieldExpr::Index(0, 0)] };
+        let pair = vec![(vec![3], vec![8])];      // (K_in=3 ; V_in=8)
+        let dep = vec![(vec![8], vec![3, 9])];    // (K_out=8 ; V_out=3, q=9)
+        let out = lossy_lookup::<Flat, _>(&mut Mem, &dep, &side(pair, (1, 1), 0), (1, 1), 0, &proj);
+        assert_eq!(out, vec![(vec![3], vec![8, 9])]); // (K_in=3 ; V_in=8, q=9)
+    }
+
+    // --- join lookup (two inputs; #758) ---
+
+    #[test]
+    fn join_demands_both_inputs_that_produced_the_output() {
+        // proj: K_out = K, V_out = V_L. A (left,right) pair at key 5 produces
+        // V_out=7; demanding that output demands both inputs.
+        let proj = Projection { key: vec![FieldExpr::Index(0, 0)], val: vec![FieldExpr::Index(1, 0)] };
+        let left = side(vec![(vec![5], vec![7])], (1, 1), 0);  // (K=5 ; V_L=7)
+        let right = side(vec![(vec![5], vec![9])], (1, 1), 0); // (K=5 ; V_R=9)
+        let dep = vec![(vec![5], vec![7, 1])]; // (K_out=5 ; V_out=7, q=1)
+        let (lc, rc) = join_lookup::<Flat, _>(&mut Mem, &dep, &left, &right, (1, 1), 0, &proj);
+        assert_eq!(lc, vec![(vec![5], vec![7, 1])]); // (K=5 ; V_L=7, q=1)
+        assert_eq!(rc, vec![(vec![5], vec![9, 1])]); // (K=5 ; V_R=9, q=1)
+    }
+}
+
+#[cfg(test)]
+mod nested_contract {
+    //! Proof that the trait is model-agnostic: a second `RowModel` over a
+    //! *nested* value (`Value::Tuple`/`Int`) — the shape an AST/JSON data model
+    //! would use — implemented against the SAME rules, run through the SAME
+    //! by-example specs as the flat model. Where the flat model lays the
+    //! envelope out positionally, this one nests it as `Tuple([V, chain, q])`;
+    //! e.g. the Min narrowing is one whole-`Value` equality, not a column loop.
+    //! If these pass, "swap the data model = reimplement `RowModel`" is earned.
+
+    use super::*;
+
+    /// Minimal nested value: an integer or a tuple. (`Variant`/`List` would
+    /// extend this; the reverse rules need only product nesting.)
+    #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+    enum Value { Int(i64), Tuple(Vec<Value>) }
+    use Value::{Int, Tuple};
+    fn int(n: i64) -> Value { Int(n) }
+    fn tup(xs: Vec<Value>) -> Value { Tuple(xs) }
+
+    /// A scalar term over a nested row. `Field`/`Tuple` are project/construct.
+    #[derive(Clone, Debug)]
+    enum Term { Var(usize), Field(Box<Term>, usize), Tup(Vec<Term>), Sub1(Box<Term>) }
+    fn var(s: usize) -> Term { Term::Var(s) }
+    fn fld(t: Term, i: usize) -> Term { Term::Field(Box::new(t), i) }
+    fn f(s: usize, i: usize) -> Term { fld(var(s), i) }
+
+    #[derive(Clone, Debug)]
+    struct Proj { key: Term, val: Term }
+    #[derive(Clone, Debug)]
+    enum Pred { Le(Term, Term), Eq(Term, Term), Gt0(Term), And(Box<Pred>, Box<Pred>) }
+
+    fn eval(t: &Term, env: &[Value]) -> Value {
+        match t {
+            Term::Var(s) => env[*s].clone(),
+            Term::Field(x, i) => match eval(x, env) { Tuple(xs) => xs[*i].clone(), v => panic!("field of {:?}", v) },
+            Term::Tup(xs) => Tuple(xs.iter().map(|x| eval(x, env)).collect()),
+            Term::Sub1(x) => match eval(x, env) { Int(n) => Int(n - 1), v => panic!("sub1 of {:?}", v) },
+        }
+    }
+    fn eval_pred(p: &Pred, env: &[Value]) -> bool {
+        match p {
+            Pred::Le(a, b) => eval(a, env) <= eval(b, env),
+            Pred::Eq(a, b) => eval(a, env) == eval(b, env),
+            Pred::Gt0(a) => matches!(eval(a, env), Int(n) if n > 0),
+            Pred::And(a, b) => eval_pred(a, env) && eval_pred(b, env),
+        }
+    }
+
+    /// Redirect a user projection's value-access: `Var(r)` for `r` in `vars`
+    /// becomes `Var(r)[0]` (the `V` field of that slot's envelope).
+    fn subst(t: &Term, vars: &[usize]) -> Term {
+        match t {
+            Term::Var(r) if vars.contains(r) => f(*r, 0),
+            Term::Var(r) => var(*r),
+            Term::Field(x, i) => fld(subst(x, vars), *i),
+            Term::Tup(xs) => Term::Tup(xs.iter().map(|x| subst(x, vars)).collect()),
+            Term::Sub1(x) => Term::Sub1(Box::new(subst(x, vars))),
+        }
+    }
+
+    type Row = Value;
+    type Coll = Vec<(Row, Row)>;
+    struct Mem;
+    impl Dataflow for Mem {
+        type Handle = Coll;
+        type Proj = Proj;
+        type Pred = Pred;
+        fn project(&mut self, c: &Coll, p: Proj) -> Coll {
+            c.iter().map(|(k, v)| { let e = [k.clone(), v.clone()]; (eval(&p.key, &e), eval(&p.val, &e)) }).collect()
+        }
+        fn filter(&mut self, c: &Coll, p: Pred) -> Coll {
+            c.iter().filter(|(k, v)| eval_pred(&p, &[k.clone(), v.clone()])).cloned().collect()
+        }
+        fn join(&mut self, l: &Coll, r: &Coll, p: Proj) -> Coll {
+            let mut out = Vec::new();
+            for (lk, lv) in l { for (rk, rv) in r {
+                if lk == rk { let e = [lk.clone(), lv.clone(), rv.clone()]; out.push((eval(&p.key, &e), eval(&p.val, &e))); }
+            }}
+            out
+        }
+        fn concat(&mut self, cs: Vec<Coll>) -> Coll { cs.into_iter().flatten().collect() }
+    }
+
+    /// The nested model. `K`/`V` are single (opaque) values, so the column
+    /// counts `k`/`v`/… are ignored; only chain lengths matter for the algebra.
+    struct Nested;
+    fn chain_le(chain_in: Term, chain_out: Term, in_len: usize, out_len: usize) -> Option<Pred> {
+        let n = in_len.min(out_len);
+        let (is, os) = (in_len - n, out_len - n);
+        (0..n).map(|i| Pred::Le(fld(chain_in.clone(), is + i), fld(chain_out.clone(), os + i)))
+            .reduce(|a, b| Pred::And(Box::new(a), Box::new(b)))
+    }
+    impl RowModel for Nested {
+        type Proj = Proj;
+        type Pred = Pred;
+        fn pack(_k: usize, _v: usize, _cl: usize, has_q: bool) -> Proj {
+            let key = Term::Tup(vec![var(0), f(1, 0)]);            // [K, V]
+            let val = if has_q { Term::Tup(vec![f(1, 1), f(1, 2)]) } else { Term::Tup(vec![f(1, 1)]) };
+            Proj { key, val }
+        }
+        fn distinct_unpack(_k: usize, _v: usize) -> Proj { Proj { key: f(0, 0), val: f(0, 1) } }
+        fn project_kv(_k: usize, _v: usize) -> Proj { Proj { key: var(0), val: f(1, 0) } }
+        fn sp_reassemble(_k: usize, _v: usize, _il: usize, _ol: usize) -> Proj {
+            // [pack[K,V], dep=(chain_out,q), pair=(chain_in)]
+            Proj { key: f(0, 0), val: Term::Tup(vec![f(0, 1), f(2, 0), f(1, 0), f(1, 1)]) }
+        }
+        fn ky_join(_k: usize, _vi: usize, _vo: usize, _il: usize, _ol: usize, min: bool) -> Proj {
+            // [K, dep=(V_out,chain_out,q), pair=(V_in,chain_in)]
+            let mut val = vec![f(2, 0)];                          // V_in
+            if min { val.push(f(1, 0)); }                         // V_out
+            val.extend([f(2, 1), f(1, 1), f(1, 2)]);              // chain_in, chain_out, q
+            Proj { key: var(0), val: Term::Tup(val) }
+        }
+        fn ky_data_eq(_vi: usize) -> Option<Pred> { Some(Pred::Eq(f(1, 0), f(1, 1))) } // whole-Value
+        fn ky_drop_vout(_k: usize, _vi: usize, _vo: usize, _il: usize, _ol: usize) -> Proj {
+            Proj { key: var(0), val: Term::Tup(vec![f(1, 0), f(1, 2), f(1, 3), f(1, 4)]) }
+        }
+        fn lossy_try_invert(_p: &Proj, _ki: usize, _vi: usize, _ko: usize, _vo: usize, _ol: usize) -> Option<Proj> {
+            None // a nested model may skip the invert optimization; the fallback is always sound.
+        }
+        fn lossy_pair(proj: &Proj, _ki: usize, _vi: usize, _il: usize) -> Proj {
+            Proj { key: subst(&proj.key, &[1]), val: Term::Tup(vec![var(0), f(1, 0), f(1, 1)]) }
+        }
+        fn lossy_reassemble(_ki: usize, _vi: usize, _vo: usize, _il: usize, _ol: usize) -> Proj {
+            // [K_out, dep=(V_out,chain_out,q), pair=(K_in,V_in,chain_in)]
+            Proj { key: f(2, 0), val: Term::Tup(vec![f(2, 1), f(2, 2), f(1, 1), f(1, 2)]) }
+        }
+        fn join_forward(proj: &Proj, _k: usize, _vl: usize, _vr: usize, _ll: usize, _rl: usize) -> Proj {
+            // [K, left=(V_L,chain_L), right=(V_R,chain_R)]
+            let key = subst(&proj.key, &[1, 2]);
+            let v_out = subst(&proj.val, &[1, 2]);
+            Proj { key, val: Term::Tup(vec![var(0), f(1, 0), f(2, 0), f(1, 1), f(2, 1), v_out]) }
+        }
+        fn join_combined(_k: usize, _vl: usize, _vr: usize, _vo: usize, _ll: usize, _rl: usize, _ol: usize) -> Proj {
+            // [K_out, dep=(V_out,chain_out,q), pair=(K,V_L,V_R,chain_L,chain_R,V_out)]
+            Proj { key: f(2, 0), val: Term::Tup(vec![
+                f(2, 1), f(2, 2), f(2, 3), f(2, 4), f(1, 1), f(1, 2), f(1, 0), f(2, 5),
+            ]) }
+        }
+        fn join_filter(_vl: usize, _vr: usize, _vo: usize, ll: usize, rl: usize, ol: usize) -> Option<Pred> {
+            // wide val: V_L,V_R,chain_L,chain_R,chain_out,q,V_out_dep,V_out_pair
+            let conds = [
+                chain_le(f(1, 2), f(1, 4), ll, ol),
+                chain_le(f(1, 3), f(1, 4), rl, ol),
+                Some(Pred::Eq(f(1, 6), f(1, 7))),
+            ];
+            conds.into_iter().flatten().reduce(|a, b| Pred::And(Box::new(a), Box::new(b)))
+        }
+        fn join_split(left: bool, _k: usize, _vl: usize, _vr: usize, _ll: usize, _rl: usize, _ol: usize) -> Proj {
+            let val = if left { Term::Tup(vec![f(1, 0), f(1, 2), f(1, 5)]) }
+                      else { Term::Tup(vec![f(1, 1), f(1, 3), f(1, 5)]) };
+            Proj { key: var(0), val }
+        }
+        fn time_le(_v: usize, il: usize, ol: usize) -> Option<Pred> {
+            chain_le(f(1, 1), f(1, 2), il, ol)
+        }
+        fn strip(_k: usize, _v: usize, il: usize, _ol: usize, keep: usize) -> Proj {
+            let drop = il - keep;
+            let chain = Term::Tup((0..keep).map(|i| fld(f(1, 1), drop + i)).collect());
+            Proj { key: var(0), val: Term::Tup(vec![f(1, 0), chain, f(1, 3)]) }
+        }
+        fn bind_filter(_v: usize) -> Option<Pred> { Some(Pred::Gt0(fld(f(1, 1), 0))) }
+        fn bind_decrement(_k: usize, _v: usize, user_len: usize) -> Proj {
+            let mut coords = vec![Term::Sub1(Box::new(fld(f(1, 1), 0)))];
+            coords.extend((1..user_len).map(|i| fld(f(1, 1), i)));
+            Proj { key: var(0), val: Term::Tup(vec![f(1, 0), Term::Tup(coords), f(1, 2)]) }
+        }
+    }
+
+    fn side(witness: Coll, user_len: usize) -> SideInfo<Mem> {
+        SideInfo { witness, forward: vec![], shape: (1, 1), user_len }
+    }
+    fn chain(cs: &[i64]) -> Value { tup(cs.iter().map(|n| int(*n)).collect()) }
+
+    // The same six specs as the flat contract, in nested envelopes.
+
+    #[test]
+    fn sp_depth0_keeps_only_value_matching_pair() {
+        // pair vals are (V, chain); dep val is (V, chain, q).
+        let pair = vec![
+            (int(5), tup(vec![int(7), chain(&[])])),
+            (int(5), tup(vec![int(8), chain(&[])])),
+        ];
+        let dep = vec![(int(5), tup(vec![int(7), chain(&[]), int(9)]))];
+        let out = shape_preserving_lookup::<Nested, _>(&mut Mem, &dep, &side(pair, 0), 0);
+        assert_eq!(out, vec![(int(5), tup(vec![int(7), chain(&[]), int(9)]))]);
+    }
+
+    #[test]
+    fn sp_depth1_time_filters_late_inputs() {
+        let dep = vec![(int(5), tup(vec![int(7), chain(&[3]), int(9)]))];
+        let keep = vec![(int(5), tup(vec![int(7), chain(&[2])]))]; // iter 2 ≤ 3
+        let drop = vec![(int(5), tup(vec![int(7), chain(&[4])]))]; // iter 4 > 3
+        let kept = shape_preserving_lookup::<Nested, _>(&mut Mem, &dep, &side(keep, 1), 1);
+        assert_eq!(kept, vec![(int(5), tup(vec![int(7), chain(&[2]), int(9)]))]);
+        let dropped = shape_preserving_lookup::<Nested, _>(&mut Mem, &dep, &side(drop, 1), 1);
+        assert!(dropped.is_empty());
+    }
+
+    #[test]
+    fn keyed_min_narrows_to_the_demanded_value() {
+        let pair = vec![(int(5), tup(vec![int(7), chain(&[])])), (int(5), tup(vec![int(6), chain(&[])]))];
+        let dep = vec![(int(5), tup(vec![int(7), chain(&[]), int(9)]))];
+        let out = keyed_lookup::<Nested, _>(&mut Mem, &dep, &side(pair, 0), (1, 1), 0, true);
+        assert_eq!(out, vec![(int(5), tup(vec![int(7), chain(&[]), int(9)]))]);
+    }
+
+    #[test]
+    fn keyed_nonmin_demands_all_same_key_inputs() {
+        let pair = vec![(int(5), tup(vec![int(7), chain(&[])])), (int(5), tup(vec![int(6), chain(&[])]))];
+        let dep = vec![(int(5), tup(vec![int(1), chain(&[]), int(9)]))];
+        let mut out = keyed_lookup::<Nested, _>(&mut Mem, &dep, &side(pair, 0), (1, 1), 0, false);
+        out.sort();
+        assert_eq!(out, vec![
+            (int(5), tup(vec![int(6), chain(&[]), int(9)])),
+            (int(5), tup(vec![int(7), chain(&[]), int(9)])),
+        ]);
+    }
+
+    #[test]
+    fn lossy_via_fallback_recovers_input() {
+        // proj: K_out = V_in (Var 1), V_out = K_in (Var 0). No invert -> fallback.
+        let proj = Proj { key: var(1), val: var(0) };
+        let pair = vec![(int(3), tup(vec![int(8), chain(&[])]))];   // (K_in=3 ; V_in=8)
+        let dep = vec![(int(8), tup(vec![int(3), chain(&[]), int(9)]))]; // (K_out=8 ; V_out=3, q=9)
+        let out = lossy_lookup::<Nested, _>(&mut Mem, &dep, &side(pair, 0), (1, 1), 0, &proj);
+        assert_eq!(out, vec![(int(3), tup(vec![int(8), chain(&[]), int(9)]))]);
+    }
+
+    #[test]
+    fn join_demands_both_inputs() {
+        let proj = Proj { key: var(0), val: var(1) }; // K_out = K, V_out = V_L
+        let left = side(vec![(int(5), tup(vec![int(7), chain(&[])]))], 0);
+        let right = side(vec![(int(5), tup(vec![int(9), chain(&[])]))], 0);
+        let dep = vec![(int(5), tup(vec![int(7), chain(&[]), int(1)]))];
+        let (lc, rc) = join_lookup::<Nested, _>(&mut Mem, &dep, &left, &right, (1, 1), 0, &proj);
+        assert_eq!(lc, vec![(int(5), tup(vec![int(7), chain(&[]), int(1)]))]);
+        assert_eq!(rc, vec![(int(5), tup(vec![int(9), chain(&[]), int(1)]))]);
+    }
+}

--- a/interactive/src/explain/mod.rs
+++ b/interactive/src/explain/mod.rs
@@ -197,6 +197,8 @@ fn clone_rec(orig: &Scope, out: &mut Scope, import_map: &[Ref], path: &[usize]) 
 use std::collections::BTreeMap;
 use crate::parse::{Condition, FieldExpr, Projection, Reducer};
 use crate::ir::{apply_ops_arity, proj_arity};
+mod decouple;
+use decouple::{Dataflow, RowModel};
 
 /// What a reference ultimately names: a value-producing site, or one of the
 /// root's external sources.
@@ -385,26 +387,13 @@ impl Sb {
     }
     /// Semijoin `left (K; V)` with `right (K; V)` by `(K)`, keep left's rows.
     fn semijoin_data(&mut self, left: Ref, right: Ref, k_arity: usize, v_arity: usize) -> Ref {
-        let key: Vec<FieldExpr> = (0..k_arity).map(|i| FieldExpr::Index(0, i)).collect();
-        let val: Vec<FieldExpr> = (0..v_arity).map(|i| FieldExpr::Index(1, i)).collect();
-        self.join(left, right, Projection { key, val })
+        self.join(left, right, <Flat as RowModel>::project_kv(k_arity, v_arity))
     }
     /// Set-level distinct on `(K; V)` rows (pack-distinct-unpack).
     fn distinct_full(&mut self, input: Ref, k_arity: usize, v_arity: usize) -> Ref {
-        let mut pack_key: Vec<FieldExpr> = (0..k_arity).map(|i| FieldExpr::Index(0, i)).collect();
-        for i in 0..v_arity { pack_key.push(FieldExpr::Index(1, i)); }
-        let packed = self.project(input, Projection { key: pack_key, val: vec![] });
+        let packed = self.project(input, <Flat as RowModel>::pack(k_arity, v_arity, 0, false));
         let dist = self.reduce(packed, Reducer::Distinct);
-        let unpack_key: Vec<FieldExpr> = (0..k_arity).map(|i| FieldExpr::Index(0, i)).collect();
-        let unpack_val: Vec<FieldExpr> = (0..v_arity).map(|i| FieldExpr::Index(0, k_arity + i)).collect();
-        self.project(dist, Projection { key: unpack_key, val: unpack_val })
-    }
-    /// Soundness filter + strip, via the shared `folded` layout algebra.
-    fn filter_time_and_strip(&mut self, coll: Ref, k_out: usize, v_pre: usize, in_len: usize, out_len: usize, keep_in_len: usize) -> Ref {
-        let layout = crate::folded::Joined { v_pre, in_len, out_len };
-        let mut cur = coll;
-        if let Some(cond) = layout.time_le() { cur = self.filter(cur, cond); }
-        self.project(cur, layout.strip(k_out, keep_in_len))
+        self.project(dist, <Flat as RowModel>::distinct_unpack(k_arity, v_arity))
     }
 }
 
@@ -419,11 +408,20 @@ struct Side {
     user_len: usize,
 }
 
-#[allow(clippy::too_many_arguments)]
 fn strip_user_and_q(k_arity: usize, v_arity: usize) -> Projection {
-    let key: Vec<FieldExpr> = (0..k_arity).map(|i| FieldExpr::Index(0, i)).collect();
-    let val: Vec<FieldExpr> = (0..v_arity).map(|i| FieldExpr::Index(1, i)).collect();
-    Projection { key, val }
+    <Flat as RowModel>::project_kv(k_arity, v_arity)
+}
+
+impl Side {
+    /// View this edge as the data-model-agnostic `SideInfo` the reverse rules take.
+    fn info(&self) -> decouple::SideInfo<Sb> {
+        decouple::SideInfo {
+            witness: self.witness.clone(),
+            forward: self.forward.clone(),
+            shape: self.shape,
+            user_len: self.user_len,
+        }
+    }
 }
 
 impl Sb {
@@ -432,219 +430,209 @@ impl Sb {
     /// the target's host form injects (deeper target) or strips (shallower)
     /// the difference, outer-aligned by `folded`.
     fn emit_lookup_shape_preserving(&mut self, dep_y: Ref, side: &Side, output_depth: usize) -> Ref {
-        let (k, v) = side.shape;
-        let user_len = side.user_len;
-        let pack_kv = |k: usize, v: usize| -> Vec<FieldExpr> {
-            let mut out: Vec<FieldExpr> = Vec::with_capacity(k + v);
-            for i in 0..k { out.push(FieldExpr::Index(0, i)); }
-            for i in 0..v { out.push(FieldExpr::Index(1, i)); }
-            out
-        };
-        let pair = self.concat(vec![side.witness.clone(), side.forward.clone()]);
-        let pair_keyed = self.project(pair, Projection {
-            key: pack_kv(k, v),
-            val: (0..user_len).map(|i| FieldExpr::Index(1, v + i)).collect(),
-        });
-        let dep_keyed = self.project(dep_y, Projection {
-            key: pack_kv(k, v),
-            val: (0..output_depth + 1).map(|i| FieldExpr::Index(1, v + i)).collect(),
-        });
-        let key: Vec<FieldExpr> = (0..k).map(|i| FieldExpr::Index(0, i)).collect();
-        let mut val: Vec<FieldExpr> = Vec::new();
-        for i in 0..v { val.push(FieldExpr::Index(0, k + i)); }
-        for i in 0..user_len { val.push(FieldExpr::Index(2, i)); }
-        for i in 0..output_depth { val.push(FieldExpr::Index(1, i)); }
-        val.push(FieldExpr::Index(1, output_depth)); // q
-        let joined = self.join(dep_keyed, pair_keyed, Projection { key, val });
-        self.filter_time_and_strip(joined, k, v, user_len, output_depth, user_len)
+        decouple::shape_preserving_lookup::<Flat, Sb>(self, &dep_y, &side.info(), output_depth)
     }
 
     /// Keyed lookup (Reduce-style), with Min's value-narrowing.
     fn emit_lookup_keyed(&mut self, dep_y: Ref, side: &Side, output_shape: (usize, usize), out_user_len: usize, reducer: &Reducer) -> Ref {
-        let (k_in, v_in) = side.shape;
-        let in_user_len = side.user_len;
-        let (_, v_out) = output_shape;
-        let pair = self.concat(vec![side.witness.clone(), side.forward.clone()]);
-        let include_v_out = matches!(reducer, Reducer::Min) && v_in == v_out && v_in > 0;
-        let mut val: Vec<FieldExpr> = Vec::new();
-        for i in 0..v_in { val.push(FieldExpr::Index(2, i)); }
-        if include_v_out {
-            for i in 0..v_out { val.push(FieldExpr::Index(1, i)); }
-        }
-        for i in 0..in_user_len { val.push(FieldExpr::Index(2, v_in + i)); }
-        for i in 0..out_user_len { val.push(FieldExpr::Index(1, v_out + i)); }
-        val.push(FieldExpr::Index(1, v_out + out_user_len));
-        let proj = Projection { key: (0..k_in).map(|i| FieldExpr::Index(0, i)).collect(), val };
-        let joined = self.join(dep_y, pair, proj);
-        let after_min = if include_v_out {
-            let mut acc: Option<Condition> = None;
-            for i in 0..v_in {
-                let cond = Condition::Eq(FieldExpr::Index(1, i), FieldExpr::Index(1, v_in + i));
-                acc = Some(match acc { None => cond, Some(prev) => Condition::And(Box::new(prev), Box::new(cond)) });
-            }
-            let filtered = self.filter(joined, acc.unwrap());
-            let key: Vec<FieldExpr> = (0..k_in).map(|i| FieldExpr::Index(0, i)).collect();
-            let mut new_val: Vec<FieldExpr> = Vec::new();
-            for i in 0..v_in { new_val.push(FieldExpr::Index(1, i)); }
-            let after_vout = v_in + v_out;
-            for i in 0..in_user_len { new_val.push(FieldExpr::Index(1, after_vout + i)); }
-            for i in 0..out_user_len { new_val.push(FieldExpr::Index(1, after_vout + in_user_len + i)); }
-            new_val.push(FieldExpr::Index(1, after_vout + in_user_len + out_user_len));
-            self.project(filtered, Projection { key, val: new_val })
-        } else {
-            joined
-        };
-        self.filter_time_and_strip(after_min, k_in, v_in, in_user_len, out_user_len, in_user_len)
+        let min = matches!(reducer, Reducer::Min);
+        decouple::keyed_lookup::<Flat, Sb>(self, &dep_y, &side.info(), output_shape, out_user_len, min)
     }
 
     /// Lossy lookup (Linear[Project]): pure-map shortcut when invertible and
     /// same-scope, pair-table fallback otherwise.
     fn emit_lookup_lossy(&mut self, dep_y: Ref, side: &Side, output_shape: (usize, usize), out_user_len: usize, proj: &Projection) -> Ref {
-        let (k_in, v_in) = side.shape;
-        let in_user_len = side.user_len;
-        let (k_out, v_out) = output_shape;
-        let known = analyze_lossy_invertibility(proj, k_in, v_in);
-        let total = (0..k_in).all(|c| known.contains_key(&(0, c)))
-            && (0..v_in).all(|c| known.contains_key(&(1, c)));
-        if total && in_user_len == out_user_len {
-            let access = |p: usize| -> FieldExpr {
-                if p < k_out { FieldExpr::Index(0, p) } else { FieldExpr::Index(1, p - k_out) }
-            };
-            let key: Vec<FieldExpr> = (0..k_in).map(|c| access(known[&(0, c)])).collect();
-            let mut val: Vec<FieldExpr> = Vec::with_capacity(v_in + in_user_len + 1);
-            for c in 0..v_in { val.push(access(known[&(1, c)])); }
-            for i in 0..out_user_len { val.push(FieldExpr::Index(1, v_out + i)); }
-            val.push(FieldExpr::Index(1, v_out + out_user_len));
-            return self.project(dep_y, Projection { key, val });
-        }
-        let pair_src = self.concat(vec![side.witness.clone(), side.forward.clone()]);
-        let mut pair_val: Vec<FieldExpr> = Vec::with_capacity(k_in + v_in + in_user_len);
-        for i in 0..k_in { pair_val.push(FieldExpr::Index(0, i)); }
-        for i in 0..v_in + in_user_len { pair_val.push(FieldExpr::Index(1, i)); }
-        let pair = self.project(pair_src, Projection { key: proj.key.clone(), val: pair_val });
-        let key: Vec<FieldExpr> = (0..k_in).map(|i| FieldExpr::Index(2, i)).collect();
-        let mut val: Vec<FieldExpr> = Vec::new();
-        for i in 0..v_in { val.push(FieldExpr::Index(2, k_in + i)); }
-        for i in 0..in_user_len { val.push(FieldExpr::Index(2, k_in + v_in + i)); }
-        for i in 0..out_user_len { val.push(FieldExpr::Index(1, v_out + i)); }
-        val.push(FieldExpr::Index(1, v_out + out_user_len));
-        let joined = self.join(dep_y, pair, Projection { key, val });
-        self.filter_time_and_strip(joined, k_in, v_in, in_user_len, out_user_len, in_user_len)
+        decouple::lossy_lookup::<Flat, Sb>(self, &dep_y, &side.info(), output_shape, out_user_len, proj)
     }
 
     /// Join's backward rule: two contribs (left, right).
     fn emit_lookup_join(&mut self, dep_y: Ref, left: &Side, right: &Side, output_shape: (usize, usize), out_user_len: usize, projection: &Projection) -> (Ref, Ref) {
-        let (k_arity, v_l) = left.shape;
-        let (_, v_r) = right.shape;
-        let (_, v_out) = output_shape;
-        let left_user_len = left.user_len;
-        let right_user_len = right.user_len;
-        let left_pair_src = self.concat(vec![left.witness.clone(), left.forward.clone()]);
-        let right_pair_src = self.concat(vec![right.witness.clone(), right.forward.clone()]);
-        let mut pair_val: Vec<FieldExpr> = Vec::new();
-        for i in 0..k_arity { pair_val.push(FieldExpr::Index(0, i)); }
-        for i in 0..v_l { pair_val.push(FieldExpr::Index(1, i)); }
-        for i in 0..v_r { pair_val.push(FieldExpr::Index(2, i)); }
-        for i in 0..left_user_len { pair_val.push(FieldExpr::Index(1, v_l + i)); }
-        for i in 0..right_user_len { pair_val.push(FieldExpr::Index(2, v_r + i)); }
-        let pos_arities = [k_arity, v_l, v_r];
-        let key_expanded = expand_pos_bounded(&projection.key, &pos_arities);
-        // Also record the chained V_out each pair produces, so demand can be
-        // narrowed to the pairs that produced the demanded output VALUE.
-        // Matching on K_out alone charges every same-key sibling pair (e.g.
-        // every in-edge of a node, not just the one carrying the demanded
-        // label).
-        pair_val.extend(expand_pos_bounded(&projection.val, &pos_arities));
-        let pair = self.join(left_pair_src, right_pair_src, Projection { key: key_expanded, val: pair_val });
-        let q_pair_pos = v_out + out_user_len;
-        let vl_pair_start = k_arity;
-        let vr_pair_start = vl_pair_start + v_l;
-        let ul_pair_start = vr_pair_start + v_r;
-        let ur_pair_start = ul_pair_start + left_user_len;
-        // One dep ⋈ pair join carrying BOTH sides' user chains, so that both
-        // time filters apply before either side's coords are projected away.
-        // Projecting away the partner's user chain first is unsound: pair rows
-        // that differ only in the partner's time — e.g. a `+1` while the
-        // partner held the row and a `-1` from the partner's later retraction
-        // — merge into the same contribution row and cancel, annihilating
-        // demand that the surviving (time-valid) configuration justifies.
-        // A (left, right) pair can only explain output demanded at `u_out` if
-        // BOTH inputs were present at times ≤ `u_out`.
-        let key: Vec<FieldExpr> = (0..k_arity).map(|i| FieldExpr::Index(2, i)).collect();
-        let mut val: Vec<FieldExpr> = Vec::new();
-        for i in 0..v_l { val.push(FieldExpr::Index(2, vl_pair_start + i)); }
-        for i in 0..v_r { val.push(FieldExpr::Index(2, vr_pair_start + i)); }
-        for i in 0..left_user_len { val.push(FieldExpr::Index(2, ul_pair_start + i)); }
-        for i in 0..right_user_len { val.push(FieldExpr::Index(2, ur_pair_start + i)); }
-        for i in 0..out_user_len { val.push(FieldExpr::Index(1, v_out + i)); }
-        val.push(FieldExpr::Index(1, q_pair_pos));
-        let vout_pair_start = ur_pair_start + right_user_len;
-        for i in 0..v_out { val.push(FieldExpr::Index(1, i)); }                    // demanded V_out
-        for i in 0..v_out { val.push(FieldExpr::Index(2, vout_pair_start + i)); }  // pair-produced V_out
-        let joined = self.join(dep_y, pair, Projection { key, val });
-        // Joined val layout:
-        //   V_L ++ V_R ++ U_L ++ U_R ++ user_out ++ [q] ++ V_out_dep ++ V_out_pair.
+        decouple::join_lookup::<Flat, Sb>(
+            self, &dep_y, &left.info(), &right.info(), output_shape, out_user_len, projection,
+        )
+    }
+}
+
+/// `Index(row, lo..hi)`.
+fn fidx(row: usize, lo: usize, hi: usize) -> Vec<FieldExpr> {
+    (lo..hi).map(|c| FieldExpr::Index(row, c)).collect()
+}
+/// Conjoin comparisons; `None` for the empty conjunction.
+fn and_all(conds: Vec<Condition>) -> Option<Condition> {
+    conds.into_iter().reduce(|a, b| Condition::And(Box::new(a), Box::new(b)))
+}
+
+/// The flat `[i64]` data model: an envelope is one positional sequence
+/// `V ++ chain ++ [q]`. Every builder works in index ranges; the time-filter
+/// and strip reuse the `folded` algebra. This is the instantiation explain
+/// runs on — a nested ADT model would implement the same trait differently.
+pub(crate) struct Flat;
+
+impl Dataflow for Sb {
+    type Handle = Ref;
+    type Proj = Projection;
+    type Pred = Condition;
+    fn project(&mut self, c: &Ref, p: Projection) -> Ref { Sb::project(self, c.clone(), p) }
+    fn filter(&mut self, c: &Ref, p: Condition) -> Ref { Sb::filter(self, c.clone(), p) }
+    fn join(&mut self, l: &Ref, r: &Ref, p: Projection) -> Ref { Sb::join(self, l.clone(), r.clone(), p) }
+    fn concat(&mut self, cs: Vec<Ref>) -> Ref { Sb::concat(self, cs) }
+}
+
+impl RowModel for Flat {
+    type Proj = Projection;
+    type Pred = Condition;
+
+    fn pack(k: usize, v: usize, chain_len: usize, has_q: bool) -> Projection {
+        let mut key = fidx(0, 0, k); key.extend(fidx(1, 0, v));
+        let tail = chain_len + has_q as usize;
+        Projection { key, val: fidx(1, v, v + tail) }
+    }
+    fn project_kv(k: usize, v: usize) -> Projection {
+        Projection { key: fidx(0, 0, k), val: fidx(1, 0, v) }
+    }
+    fn sp_reassemble(k: usize, v: usize, user_len: usize, out_depth: usize) -> Projection {
+        let key = fidx(0, 0, k);
+        let mut val = fidx(0, k, k + v);              // V (from packed key)
+        val.extend(fidx(2, 0, user_len));             // chain_in (pair)
+        val.extend(fidx(1, 0, out_depth));            // chain_out (dep)
+        val.push(FieldExpr::Index(1, out_depth));     // q
+        Projection { key, val }
+    }
+
+    fn ky_join(k: usize, v_in: usize, v_out: usize, in_len: usize, out_len: usize, min: bool) -> Projection {
+        let mut val = fidx(2, 0, v_in);               // V_in
+        if min { val.extend(fidx(1, 0, v_out)); }     // V_out (for narrowing)
+        val.extend(fidx(2, v_in, v_in + in_len));     // chain_in
+        val.extend(fidx(1, v_out, v_out + out_len));  // chain_out
+        val.push(FieldExpr::Index(1, v_out + out_len)); // q
+        Projection { key: fidx(0, 0, k), val }
+    }
+    fn ky_data_eq(v_in: usize) -> Option<Condition> {
+        and_all((0..v_in).map(|i| Condition::Eq(FieldExpr::Index(1, i), FieldExpr::Index(1, v_in + i))).collect())
+    }
+    fn ky_drop_vout(k: usize, v_in: usize, v_out: usize, in_len: usize, out_len: usize) -> Projection {
+        let after_vout = v_in + v_out;
+        let mut val = fidx(1, 0, v_in);
+        val.extend(fidx(1, after_vout, after_vout + in_len));
+        val.extend(fidx(1, after_vout + in_len, after_vout + in_len + out_len));
+        val.push(FieldExpr::Index(1, after_vout + in_len + out_len));
+        Projection { key: fidx(0, 0, k), val }
+    }
+
+    fn lossy_try_invert(proj: &Projection, k_in: usize, v_in: usize, k_out: usize, v_out: usize, out_len: usize) -> Option<Projection> {
+        let known = analyze_lossy_invertibility(proj, k_in, v_in);
+        let total = (0..k_in).all(|c| known.contains_key(&(0, c)))
+            && (0..v_in).all(|c| known.contains_key(&(1, c)));
+        if !total { return None; }
+        let access = |p: usize| if p < k_out { FieldExpr::Index(0, p) } else { FieldExpr::Index(1, p - k_out) };
+        let key: Vec<FieldExpr> = (0..k_in).map(|c| access(known[&(0, c)])).collect();
+        let mut val: Vec<FieldExpr> = (0..v_in).map(|c| access(known[&(1, c)])).collect();
+        val.extend(fidx(1, v_out, v_out + out_len));  // chain_out passthrough
+        val.push(FieldExpr::Index(1, v_out + out_len)); // q
+        Some(Projection { key, val })
+    }
+    fn lossy_pair(proj: &Projection, k_in: usize, v_in: usize, in_len: usize) -> Projection {
+        let mut val = fidx(0, 0, k_in);
+        val.extend(fidx(1, 0, v_in + in_len));
+        Projection { key: proj.key.clone(), val }
+    }
+    fn lossy_reassemble(k_in: usize, v_in: usize, v_out: usize, in_len: usize, out_len: usize) -> Projection {
+        let key = fidx(2, 0, k_in);
+        let mut val = fidx(2, k_in, k_in + v_in);
+        val.extend(fidx(2, k_in + v_in, k_in + v_in + in_len));
+        val.extend(fidx(1, v_out, v_out + out_len));
+        val.push(FieldExpr::Index(1, v_out + out_len));
+        Projection { key, val }
+    }
+
+    fn join_forward(proj: &Projection, k: usize, v_l: usize, v_r: usize, l_len: usize, r_len: usize) -> Projection {
+        let key = expand_pos_bounded(&proj.key, &[k, v_l, v_r]);
+        let mut val = fidx(0, 0, k);             // K
+        val.extend(fidx(1, 0, v_l));             // V_L
+        val.extend(fidx(2, 0, v_r));             // V_R
+        val.extend(fidx(1, v_l, v_l + l_len));   // chain_L
+        val.extend(fidx(2, v_r, v_r + r_len));   // chain_R
+        val.extend(expand_pos_bounded(&proj.val, &[k, v_l, v_r])); // V_out (pair-produced)
+        Projection { key, val }
+    }
+    fn join_combined(k: usize, v_l: usize, v_r: usize, v_out: usize, l_len: usize, r_len: usize, out_len: usize) -> Projection {
+        let vl_s = k;
+        let vr_s = vl_s + v_l;
+        let ul_s = vr_s + v_r;
+        let ur_s = ul_s + l_len;
+        let vout_s = ur_s + r_len;
+        let key = fidx(2, 0, k);
+        let mut val = fidx(2, vl_s, vl_s + v_l);          // V_L
+        val.extend(fidx(2, vr_s, vr_s + v_r));            // V_R
+        val.extend(fidx(2, ul_s, ul_s + l_len));          // chain_L
+        val.extend(fidx(2, ur_s, ur_s + r_len));          // chain_R
+        val.extend(fidx(1, v_out, v_out + out_len));      // chain_out
+        val.push(FieldExpr::Index(1, v_out + out_len));   // q
+        val.extend(fidx(1, 0, v_out));                    // V_out_dep
+        val.extend(fidx(2, vout_s, vout_s + v_out));      // V_out_pair
+        Projection { key, val }
+    }
+    fn join_filter(v_l: usize, v_r: usize, v_out: usize, l_len: usize, r_len: usize, out_len: usize) -> Option<Condition> {
         let ul_j = v_l + v_r;
-        let ur_j = ul_j + left_user_len;
-        let uo_j = ur_j + right_user_len;
-        let q_j = uo_j + out_user_len;
+        let ur_j = ul_j + l_len;
+        let uo_j = ur_j + r_len;
+        let q_j = uo_j + out_len;
         let vdep_j = q_j + 1;
         let vpair_j = vdep_j + v_out;
-        // Outer-aligned `u_in ≤ u_out` for one side's chain at offset `off`.
         let time_cond = |off: usize, in_len: usize| -> Option<Condition> {
-            let n = in_len.min(out_user_len);
+            let n = in_len.min(out_len);
             let in_skip = in_len - n;
-            let out_skip = out_user_len - n;
-            let mut acc: Option<Condition> = None;
-            for i in 0..n {
-                let cond = Condition::Le(
-                    FieldExpr::Index(1, off + in_skip + i),
-                    FieldExpr::Index(1, uo_j + out_skip + i),
-                );
-                acc = Some(match acc {
-                    None => cond,
-                    Some(prev) => Condition::And(Box::new(prev), Box::new(cond)),
-                });
-            }
-            acc
+            let out_skip = out_len - n;
+            and_all((0..n).map(|i| Condition::Le(
+                FieldExpr::Index(1, off + in_skip + i),
+                FieldExpr::Index(1, uo_j + out_skip + i),
+            )).collect())
         };
-        // Value narrowing: keep only pairs whose produced V_out equals the
-        // demanded V_out, element-wise. Unlike time, every joined row carries
-        // both columns explicitly, so this is a plain equality filter.
-        let value_cond = {
-            let mut acc: Option<Condition> = None;
-            for i in 0..v_out {
-                let cond = Condition::Eq(
-                    FieldExpr::Index(1, vdep_j + i),
-                    FieldExpr::Index(1, vpair_j + i),
-                );
-                acc = Some(match acc {
-                    None => cond,
-                    Some(prev) => Condition::And(Box::new(prev), Box::new(cond)),
-                });
-            }
-            acc
+        let value_cond = and_all((0..v_out).map(|i| Condition::Eq(
+            FieldExpr::Index(1, vdep_j + i), FieldExpr::Index(1, vpair_j + i),
+        )).collect());
+        [time_cond(ul_j, l_len), time_cond(ur_j, r_len), value_cond]
+            .into_iter().flatten().reduce(|a, b| Condition::And(Box::new(a), Box::new(b)))
+    }
+    fn join_split(left: bool, k: usize, v_l: usize, v_r: usize, l_len: usize, r_len: usize, out_len: usize) -> Projection {
+        let ul_j = v_l + v_r;
+        let ur_j = ul_j + l_len;
+        let uo_j = ur_j + r_len;
+        let q_j = uo_j + out_len;
+        let key = fidx(0, 0, k);
+        let val = if left {
+            let mut v = fidx(1, 0, v_l);                 // V_L
+            v.extend(fidx(1, ul_j, ul_j + l_len));       // chain_L
+            v.push(FieldExpr::Index(1, q_j));            // q
+            v
+        } else {
+            let mut v = fidx(1, v_l, v_l + v_r);         // V_R
+            v.extend(fidx(1, ur_j, ur_j + r_len));       // chain_R
+            v.push(FieldExpr::Index(1, q_j));            // q
+            v
         };
-        let conds = [time_cond(ul_j, left_user_len), time_cond(ur_j, right_user_len), value_cond];
-        let both = conds.into_iter().flatten().reduce(|a, b| Condition::And(Box::new(a), Box::new(b)));
-        let timed = match both {
-            Some(cond) => self.filter(joined, cond),
-            None => joined,
-        };
-        // Per-side contributions: (K; V_side ++ U_side ++ [q]).
-        let key_left: Vec<FieldExpr> = (0..k_arity).map(|i| FieldExpr::Index(0, i)).collect();
-        let mut val_left: Vec<FieldExpr> = Vec::new();
-        for i in 0..v_l { val_left.push(FieldExpr::Index(1, i)); }
-        for i in 0..left_user_len { val_left.push(FieldExpr::Index(1, ul_j + i)); }
-        val_left.push(FieldExpr::Index(1, q_j));
-        let left_contrib = self.project(timed.clone(), Projection { key: key_left, val: val_left });
-        let key_right: Vec<FieldExpr> = (0..k_arity).map(|i| FieldExpr::Index(0, i)).collect();
-        let mut val_right: Vec<FieldExpr> = Vec::new();
-        for i in 0..v_r { val_right.push(FieldExpr::Index(1, v_l + i)); }
-        for i in 0..right_user_len { val_right.push(FieldExpr::Index(1, ur_j + i)); }
-        val_right.push(FieldExpr::Index(1, q_j));
-        let right_contrib = self.project(timed, Projection { key: key_right, val: val_right });
-        (left_contrib, right_contrib)
+        Projection { key, val }
+    }
+
+    fn time_le(v: usize, in_len: usize, out_len: usize) -> Option<Condition> {
+        crate::folded::Joined { v_pre: v, in_len, out_len }.time_le()
+    }
+    fn strip(k: usize, v: usize, in_len: usize, out_len: usize, keep: usize) -> Projection {
+        crate::folded::Joined { v_pre: v, in_len, out_len }.strip(k, keep)
+    }
+
+    fn bind_filter(v: usize) -> Option<Condition> {
+        Some(Condition::Gt(FieldExpr::Index(1, v), FieldExpr::Const(0)))
+    }
+    fn bind_decrement(k: usize, v: usize, user_len: usize) -> Projection {
+        let mut val = fidx(1, 0, v);
+        val.push(FieldExpr::Sub(Box::new(FieldExpr::Index(1, v)), Box::new(FieldExpr::Const(1))));
+        val.extend(fidx(1, v + 1, v + user_len));
+        val.push(FieldExpr::Index(1, v + user_len));
+        Projection { key: fidx(0, 0, k), val }
+    }
+    fn distinct_unpack(k: usize, v: usize) -> Projection {
+        Projection { key: fidx(0, 0, k), val: fidx(0, k, k + v) }
     }
 }
 
@@ -890,15 +878,11 @@ impl<'a> Reverse<'a> {
             let dv = self.demand[&var_addr].clone();
             let (kx, vx) = self.shapes[&var_addr];
             let var_user_len = path.len();
-            let chain_pos = vx;
-            let filtered = ex.filter(dv, Condition::Gt(FieldExpr::Index(1, chain_pos), FieldExpr::Const(0)));
-            let key: Vec<FieldExpr> = (0..kx).map(|i| FieldExpr::Index(0, i)).collect();
-            let mut val: Vec<FieldExpr> = Vec::new();
-            for i in 0..vx { val.push(FieldExpr::Index(1, i)); }
-            val.push(FieldExpr::Sub(Box::new(FieldExpr::Index(1, chain_pos)), Box::new(FieldExpr::Const(1))));
-            for i in 1..var_user_len { val.push(FieldExpr::Index(1, chain_pos + i)); }
-            val.push(FieldExpr::Index(1, chain_pos + var_user_len));
-            let contrib = ex.project(filtered, Projection { key, val });
+            let filtered = match <Flat as RowModel>::bind_filter(vx) {
+                Some(c) => ex.filter(dv, c),
+                None => dv,
+            };
+            let contrib = ex.project(filtered, <Flat as RowModel>::bind_decrement(kx, vx, var_user_len));
             self.push(ex, path, &b.value, contrib, var_user_len);
         }
         // Items in reverse: consumers have contributed by the time we arrive.


### PR DESCRIPTION
## What

The reverse-tracing rules built their projections as flat `FieldExpr` index ranges inline, hard-coding the `[i64]` row representation throughout. This factors that out so the data model is swappable behind a trait — a continuation of what `folded::Joined` started for the time-filter/strip algebra.

**`explain/decouple.rs`** (new) adds two traits and the reverse rules written **once** against them:

- **`RowModel`** builds the per-rule projections/predicates, documented in terms of one object — the demand envelope `(K ; V, chain, [q])`. A module doc defines that envelope and the `$0`/`$1`/`$2` input-slot convention once; each method then states the *input row shape it expects* and the *output it produces*, so an implementer reads the contract rather than the flat positions.
- **`Dataflow`** is the orchestration backend (`concat`/`project`/`filter`/`join`).

**`explain/mod.rs`** implements `RowModel` for the flat `[i64]` model (`Flat`, reusing `folded` for `time_le`/`strip`) and `Dataflow` for the scope builder `Sb`. Every `emit_lookup_*` body, the bind iter-decrement, and the demand-set seeding helpers now delegate to the generic rules; the now-redundant `filter_time_and_strip` is removed.

`decouple` is a submodule of `explain` (it serves explain, not a peer).

## Why

Explain is the most representation-coupled part of the interactive subproject, and the data model is under active exploration (e.g. nested ADT values for JSON/AST-shaped data). After this change, swapping the data model means **reimplementing `RowModel` only** — the rule logic and orchestration are untouched. `folded` is *subsumed* rather than duplicated: the flat model uses it internally, and the trait generalizes the rest.

## Requirements pinned executably

Beyond the prose contracts, `decouple.rs`'s test module runs the rules on a small in-memory `Dataflow` with by-example specs — concrete `dep`/pair rows in, asserted demand rows out (e.g. *an input at iteration 2 explains an output demanded at iteration 3; one at iteration 4 does not*). So a future `RowModel` (e.g. a nested-value model) validates against runnable, machine-checked requirements, not just documentation.

## No behavior change

The rewritten explain is **byte-identical** to the original on `ddir_vec --explain` demand-sets across `reach`/`scc`/`stable` × 3 queries × 4 graph sizes (incl. multi-round incremental). All crate tests pass (incl. `folded`'s unit tests and the new contract tests); clean build, no warnings.

Verify:
```
cargo run --release --example ddir_vec -- --explain --query=: --debug-demand \
  ./interactive/examples/programs/reach.ddp 2 8 8 1 1
```

## Notes

- The one remaining flat-specific seam is shape inference (`apply_ops_arity`/`proj_arity` in `ir.rs`): it produces the arities the rules consume and builds no projections — where a nested model would plug its own shape logic. Out of scope here.
- The trait surface tracks the current rules faithfully, including the #758 combined-filter join. (A block/`assemble` algebra could collapse the layout-building methods fur
ther; that was considered and deferred — it trades a documented surface for a new mini-language without making the rules clearer.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)