### PR TITLE
Explain inverse

### DIFF
--- a/interactive/src/explain/decouple.rs
+++ b/interactive/src/explain/decouple.rs
@@ -615,3 +615,71 @@ mod value_contract {
         assert_eq!(rc, vec![(key(5), val(&[9, 1]))]);
     }
 }
+
+#[cfg(test)]
+mod backstop {
+    //! The *universal backstop* reverses `flatmap` — the op the live rewrite
+    //! still `panic!`s on — using only the existing `Dataflow` primitives. The
+    //! forward clone runs the op and keys each output by itself, carrying the
+    //! input (the `(output -> input)` pair table); the reverse is one join on
+    //! the output plus a `REFORM` projection. No op-supplied inverse: the `None`
+    //! endpoint, so `RESIDUAL` is the whole input (here, the list). This pins
+    //! "the gap is closable" before the real rule + wiring are built.
+
+    use super::*;
+    use crate::ir::{eval, Value};
+    use crate::parse::{Projection, Term};
+
+    type Coll = Vec<(Value, Value)>;
+    struct Mem;
+    impl Dataflow for Mem {
+        type Handle = Coll;
+        type Proj = Projection;
+        type Pred = Term;
+        fn project(&mut self, c: &Coll, p: Projection) -> Coll {
+            c.iter().map(|(k, v)| { let mut e = vec![k.clone(), v.clone()]; (eval(&p.key, &mut e), eval(&p.val, &mut e)) }).collect()
+        }
+        fn filter(&mut self, c: &Coll, p: Term) -> Coll {
+            c.iter().filter(|(k, v)| { let mut e = vec![k.clone(), v.clone()]; eval(&p, &mut e).truthy() }).cloned().collect()
+        }
+        fn join(&mut self, l: &Coll, r: &Coll, p: Projection) -> Coll {
+            let mut out = Vec::new();
+            for (lk, lv) in l { for (rk, rv) in r {
+                if lk == rk { let mut e = vec![lk.clone(), lv.clone(), rv.clone()]; out.push((eval(&p.key, &mut e), eval(&p.val, &mut e))); }
+            }}
+            out
+        }
+        fn concat(&mut self, cs: Vec<Coll>) -> Coll { cs.into_iter().flatten().collect() }
+    }
+
+    fn int(n: i64) -> Value { Value::Int(n) }
+    fn list(xs: &[i64]) -> Value { Value::List(xs.iter().map(|&n| int(n)).collect()) }
+    fn tup(xs: Vec<Value>) -> Value { Value::Tuple(xs) }
+    fn f(s: usize, i: usize) -> Term { Term::Proj(Box::new(Term::Var(s)), i) }
+    fn tterm(xs: Vec<Term>) -> Term { Term::Tuple(xs) }
+
+    fn flatmap_forward(k: &Value, lst: &Value) -> Coll {
+        let Value::List(xs) = lst else { panic!("flatmap on non-list") };
+        xs.iter().enumerate().map(|(p, e)| (k.clone(), tup(vec![int(p as i64), e.clone()]))).collect()
+    }
+
+    #[test]
+    fn backstop_reverses_flatmap() {
+        let witness: Coll = vec![
+            (int(1), list(&[10, 20, 30])),
+            (int(1), list(&[40, 50])),
+            (int(2), list(&[30])),
+        ];
+        let pairs: Coll = witness.iter().flat_map(|(k, lst)| {
+            flatmap_forward(k, lst).into_iter().map(move |(ok, ov)| {
+                let Value::Tuple(o) = &ov else { unreachable!() };
+                (tup(vec![ok.clone(), o[0].clone(), o[1].clone()]), tup(vec![k.clone(), lst.clone()]))
+            })
+        }).collect();
+        let demand: Coll = vec![(tup(vec![int(1), int(2), int(30)]), tup(vec![int(9)]))];
+        let reform = Projection { key: f(2, 0), val: tterm(vec![f(2, 1), f(1, 0)]) };
+        let mut df = Mem;
+        let got = df.join(&demand, &pairs, reform);
+        assert_eq!(got, vec![(int(1), tup(vec![list(&[10, 20, 30]), int(9)]))]);
+    }
+}

--- a/interactive/src/explain/mod.rs
+++ b/interactive/src/explain/mod.rs
@@ -481,6 +481,47 @@ impl Sb {
             self, &dep_y, &left.info(), &right.info(), output_shape, out_user_len, projection,
         )
     }
+
+    /// FlatMap's (UNNEST's) backward rule — the universal backstop instantiated
+    /// for a cardinality-changing op. FlatMap is *same-depth* (it doesn't touch
+    /// iteration time) and its list rides as one opaque value, so this needs no
+    /// envelope change: build the `(output -> input)` pair table by running the
+    /// op forward on the input side, join the demand on the output, recover the
+    /// whole input (the `None` endpoint — `RESIDUAL` is the input value).
+    ///
+    /// The one wrinkle is that a plain flatmap drops the source row and the key
+    /// isn't unique, so we **re-key the input by itself** before exploding (the
+    /// source then rides through in the join key) and re-project to the packed
+    /// output afterwards. `output_shape.1 == 2` (the `tuple(pos, elem)` value).
+    fn emit_lookup_flatmap(&mut self, dep_y: Ref, side: &Side, output_shape: (usize, usize), out_user_len: usize, list_term: &Term) -> Ref {
+        let (_, v_in) = side.shape;
+        let v_out = output_shape.1;          // 2: pos, elem
+        let d = out_user_len;                // same depth for input and output
+        // Pair table: re-key the input by the whole input row, explode (the
+        // source survives in the key), then re-key to (k, pos, elem) carrying
+        // the source as the value.
+        let src = self.concat(vec![side.witness.clone(), side.forward.clone()]);
+        let rekeyed = self.project(src, Projection { key: tup(vec![var(0), var(1)]), val: var(1) });
+        let exploded = self.linear(rekeyed, vec![LinearOp::FlatMap(list_term.clone())]);
+        let pair = self.project(exploded, Projection { key: tup(vec![f(0, 0), f(1, 0), f(1, 1)]), val: var(0) });
+        // Re-key the demand by the same packed output; keep its chain ++ q.
+        let dep_keyed = self.project(dep_y, Projection { key: tup(vec![var(0), f(1, 0), f(1, 1)]), val: tup(fidx(1, v_out, v_out + d + 1)) });
+        // Join into a wide row [V_in | chain_in | chain_out | q]. Source is `$2`
+        // = (k, host_val); host_val = [V_in | chain_in]. Dep' is `$1` = [chain_out | q].
+        let mut wide = (0..v_in).map(|c| fld(f(2, 1), c)).collect::<Vec<_>>();   // V_in
+        wide.extend((0..d).map(|c| fld(f(2, 1), v_in + c)));                     // chain_in
+        wide.extend(fidx(1, 0, d));                                             // chain_out
+        wide.push(f(1, d));                                                     // q
+        let joined = self.join(dep_keyed, pair, Projection { key: f(2, 0), val: tup(wide) });
+        // Soundness: chain_in ≤ chain_out (same depth, so coordinate-aligned).
+        let cond = and_all((0..d).map(|c| le(f(1, v_in + c), f(1, v_in + d + c))).collect());
+        let filtered = match cond { Some(c) => self.filter(joined, c), None => joined };
+        // Reform the demanded input (k ; V_in ++ chain_out ++ q).
+        let mut val = fidx(1, 0, v_in);
+        val.extend(fidx(1, v_in + d, v_in + 2 * d));
+        val.push(f(1, v_in + 2 * d));
+        self.project(filtered, Projection { key: var(0), val: tup(val) })
+    }
 }
 
 /// The `Value` data model for explain: a demand row is `(K ; Tuple([V…, chain…,
@@ -963,7 +1004,12 @@ impl<'a> Reverse<'a> {
                         self.push(ex, path, input, dep_this, out_user_len);
                     }
                     LinearOp::LiftIter => panic!("explain: LiftIter in user program"),
-                    LinearOp::FlatMap(_) => panic!("explain: FlatMap (UNNEST) reverse rule not implemented; explain targets flat relational programs"),
+                    LinearOp::FlatMap(list_term) => {
+                        let target = resolve(self.orig, path, input);
+                        let side = self.side(&target);
+                        let contrib = ex.emit_lookup_flatmap(dep_this, &side, out_shape, out_user_len, list_term);
+                        self.contribs.entry(target).or_default().push(contrib);
+                    }
                 }
             }
             Node::Concat(refs) => {

--- a/interactive/tests/explain.rs
+++ b/interactive/tests/explain.rs
@@ -432,3 +432,19 @@ fn fuzz_explanations_sufficient() {
     }
     assert!(queries >= 100, "fuzz swept only {} queries — instances too sparse to mean much", queries);
 }
+
+/// FlatMap (UNNEST): each input edge `(a, b)` rekeys to `(a ; [a, b])` and
+/// explodes to `(a ; (0, a))` and `(a ; (1, b))`. The reverse rule must trace a
+/// demanded exploded output back to the input edge that carried it. This is the
+/// op that used to `panic!` in explain.
+const FLATMAP_ROW: &str = r#"
+    let rows = input 0 | key($0[0] ; list($0[0], $0[1]));
+    export "result" = rows | flatmap($1[0]);
+"#;
+const FLATMAP_SHAPES: &[(usize, usize)] = &[(2, 0)];
+
+#[test]
+fn flatmap_explanations_sufficient_small() {
+    let sizes = assert_all_rows_sufficient(FLATMAP_ROW, FLATMAP_SHAPES, &[gen_edges(20, 22)]);
+    assert!(!sizes.is_empty(), "expected some exploded outputs to explain");
+}

--- a/interactive/tests/explain.rs
+++ b/interactive/tests/explain.rs
@@ -448,3 +448,19 @@ fn flatmap_explanations_sufficient_small() {
     let sizes = assert_all_rows_sufficient(FLATMAP_ROW, FLATMAP_SHAPES, &[gen_edges(20, 22)]);
     assert!(!sizes.is_empty(), "expected some exploded outputs to explain");
 }
+
+/// Collect (NEST): `(a ; b)` rows group to `(a ; [b…])`. Reversing a demanded
+/// list must demand all the members — which is exactly the non-min keyed
+/// lookup ("demand all same-key inputs"), so no new rule is needed; this
+/// confirms the existing path handles a `List`-valued reducer output.
+const COLLECT_ROW: &str = r#"
+    let rows = input 0 | key($0[0] ; $0[1]);
+    export "result" = rows | collect;
+"#;
+const COLLECT_SHAPES: &[(usize, usize)] = &[(2, 0)];
+
+#[test]
+fn collect_explanations_sufficient_small() {
+    let sizes = assert_all_rows_sufficient(COLLECT_ROW, COLLECT_SHAPES, &[gen_edges(20, 22)]);
+    assert!(!sizes.is_empty(), "expected some collected lists to explain");
+}


### PR DESCRIPTION
After #760 (Value/ADT data model), the explain rewrite covered the relational subset but panic!'d on FlatMap — so the new ADT expressiveness wasn't explainable, breaking
  the writable ⟹ explainable invariant. This closes that gap, minimally and additively (no rewrite of the working relational rules, no envelope change).

  - decouple: re-ground with the universal-backstop flatmap test (the proof-of-concept).
  - explain(value): emit_lookup_flatmap — a real reverse rule replacing the panic. FlatMap is same-depth (it doesn't touch iteration time) and its list rides as one opaque
  value, so it slots into the existing flat envelope. The (output → input) pair table is built by running the op forward on the input side; the one wrinkle — a plain
  flatmap drops the source and the key isn't unique — is handled by re-keying the input by itself before exploding (the source rides through in the join key), then
  re-projecting to (k, pos, elem); a chain_in ≤ chain_out filter keeps it sound in iterating scopes. No new primitive.
  - explain(value): confirmed Collect reverses via the existing non-min keyed path ("demand all members") — no new rule.

  Verified: flatmap and collect programs explain end-to-end (demand regenerates the queried output), and the full suite — including the heavy --ignored relational sweeps —
  stays green.

  Deferred (not needed for the invariant): the full (PRESERVED/RESIDUAL/REFORM) inverse-interface unification + opaque-value envelope (which would also delete the
  Term-arity shape pass) — an independent cleanup for later.

  🤖 Generated with Claude Code