### PR TITLE
Generalize join and reduce into navigation-free drivers over pluggable tactics

### DIFF
--- a/differential-dataflow/src/collection.rs
+++ b/differential-dataflow/src/collection.rs
@@ -785,7 +785,7 @@ pub mod vec {
         where
             T2: Trace<Batch: Navigable, Time=T>+'static,
             for<'a> BatchCursor<T2>: Cursor<Key<'a>= &'a K, ValOwn = V, Time = T2::Time, Diff: Abelian>,
-            Bu: Builder<Time=T2::Time, Input = Vec<((K, V), T2::Time, BatchDiff<T2>)>, Output = T2::Batch>,
+            Bu: Builder<Time=T2::Time, Input = Vec<((K, V), T2::Time, BatchDiff<T2>)>, Output = T2::Batch> + 'static,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(V, BatchDiff<T2>)>)+'static,
         {
             self.reduce_core::<_,Bu,T2>(name, move |key, input, output, change| {
@@ -805,7 +805,7 @@ pub mod vec {
             V: Clone+'static,
             T2: Trace<Batch: Navigable, Time=T>+'static,
             for<'a> BatchCursor<T2>: Cursor<Key<'a>=&'a K, ValOwn = V, Time = T2::Time>,
-            Bu: Builder<Time=T2::Time, Input = Vec<((K, V), T2::Time, BatchDiff<T2>)>, Output = T2::Batch>,
+            Bu: Builder<Time=T2::Time, Input = Vec<((K, V), T2::Time, BatchDiff<T2>)>, Output = T2::Batch> + 'static,
             L: FnMut(&K, &[(&V, R)], &mut Vec<(V,BatchDiff<T2>)>, &mut Vec<(V, BatchDiff<T2>)>)+'static,
         {
             self.arrange_by_key_named(&format!("Arrange: {}", name))

--- a/differential-dataflow/src/operators/arrange/agent.rs
+++ b/differential-dataflow/src/operators/arrange/agent.rs
@@ -62,8 +62,8 @@ impl<Tr: TraceReader> TraceReader for TraceAgent<Tr> {
     fn get_physical_compaction(&mut self) -> AntichainRef<'_, Tr::Time> {
         self.physical_compaction.borrow()
     }
-    fn cursor_storage(&mut self, frontier: AntichainRef<'_, Tr::Time>) -> Option<Vec<Self::Batch>> {
-        self.trace.borrow_mut().trace.cursor_storage(frontier)
+    fn batches_through(&mut self, frontier: AntichainRef<'_, Tr::Time>) -> Option<Vec<Self::Batch>> {
+        self.trace.borrow_mut().trace.batches_through(frontier)
     }
     fn map_batches<F: FnMut(&Self::Batch)>(&self, f: F) { self.trace.borrow().trace.map_batches(f) }
 }

--- a/differential-dataflow/src/operators/arrange/arrangement.rs
+++ b/differential-dataflow/src/operators/arrange/arrangement.rs
@@ -268,7 +268,7 @@ impl<'scope, Tr1: TraceReader<Batch: Navigable>+'static> Arranged<'scope, Tr1> {
         Tr2: Trace<Batch: Navigable, Time=Tr1::Time>+'static,
         BatchCursor<Tr1>: Cursor<Time = Tr1::Time>,
         for<'a> BatchCursor<Tr2>: Cursor<Key<'a> = BatchKey<'a, Tr1>, ValOwn: Data, Time = Tr2::Time, Diff: Abelian>,
-        Bu: Builder<Time=Tr1::Time, Output = Tr2::Batch, Input: Default>,
+        Bu: Builder<Time=Tr1::Time, Output = Tr2::Batch, Input: Default> + 'static,
         L: FnMut(BatchKey<'_, Tr1>, &[(BatchVal<'_, Tr1>, BatchDiff<Tr1>)], &mut Vec<(BatchValOwn<Tr2>, BatchDiff<Tr2>)>)+'static,
         P: FnMut(&mut Bu::Input, BatchKey<'_, Tr1>, &mut Vec<(BatchValOwn<Tr2>, Tr2::Time, BatchDiff<Tr2>)>) + 'static,
     {
@@ -287,7 +287,7 @@ impl<'scope, Tr1: TraceReader<Batch: Navigable>+'static> Arranged<'scope, Tr1> {
         Tr2: Trace<Batch: Navigable, Time=Tr1::Time>+'static,
         BatchCursor<Tr1>: Cursor<Time = Tr1::Time>,
         for<'a> BatchCursor<Tr2>: Cursor<Key<'a> = BatchKey<'a, Tr1>, ValOwn: Data, Time = Tr2::Time>,
-        Bu: Builder<Time=Tr1::Time, Output = Tr2::Batch, Input: Default>,
+        Bu: Builder<Time=Tr1::Time, Output = Tr2::Batch, Input: Default> + 'static,
         L: FnMut(BatchKey<'_, Tr1>, &[(BatchVal<'_, Tr1>, BatchDiff<Tr1>)], &mut Vec<(BatchValOwn<Tr2>, BatchDiff<Tr2>)>, &mut Vec<(BatchValOwn<Tr2>, BatchDiff<Tr2>)>)+'static,
         P: FnMut(&mut Bu::Input, BatchKey<'_, Tr1>, &mut Vec<(BatchValOwn<Tr2>, Tr2::Time, BatchDiff<Tr2>)>) + 'static,
     {

--- a/differential-dataflow/src/operators/join.rs
+++ b/differential-dataflow/src/operators/join.rs
@@ -17,6 +17,7 @@ use timely::dataflow::operators::Capability;
 use crate::lattice::Lattice;
 use crate::operators::arrange::Arranged;
 use crate::trace::{BatchCursor, BatchDiff, BatchKey, BatchReader, BatchVal, Cursor, Navigable, TraceReader};
+use crate::trace::cursor::{cursor_list, CursorList};
 use crate::operators::ValueHistory;
 
 /// The session passed to join closures.
@@ -51,6 +52,31 @@ impl<CB: PushInto<D>, D> PushInto<D> for EffortBuilder<CB> {
     }
 }
 
+/// A type that can manage the joining of lists of batches.
+pub trait JoinTactic<B0: BatchReader, B1: BatchReader<Time = B0::Time>, CB: ContainerBuilder> {
+    /// Prepare for work the join of two lists of corresponding batches, against a sufficient capability.
+    ///
+    /// `fresh` names which input contributed the freshly-arrived batch; its times all lie at or beyond
+    /// the capability, so a tactic need not advance that side by the capability's meet.
+    fn defer(&mut self, input0: Vec<B0>, input1: Vec<B1>, fresh: Fresh, capability: Capability<B0::Time>);
+    /// Perform an amount of work that just barely exceeds `fuel`, which is decremented.
+    ///
+    /// Returning with a non-negative fuel indicates that all work was exhausted.
+    fn work(&mut self, fuel: &mut isize, output: &mut OutputBuilderSession<B0::Time, EffortBuilder<CB>>);
+}
+
+/// Which input contributed the freshly-arrived batch of a deferred join unit.
+///
+/// The fresh batch's times all lie at or beyond the capability, so its side is not advanced by the
+/// capability's meet; the opposing accumulated trace is. The marker also selects which queue a unit
+/// joins, so a burst on one input cannot starve the other.
+pub enum Fresh {
+    /// The first input (`B0`) contributed the fresh batch.
+    Input0,
+    /// The second input (`B1`) contributed the fresh batch.
+    Input1,
+}
+
 /// An equijoin of two traces, sharing a common key type.
 ///
 /// This method exists to provide join functionality without opinions on the specific input types, keys and values,
@@ -64,13 +90,29 @@ impl<CB: PushInto<D>, D> PushInto<D> for EffortBuilder<CB> {
 /// The "correctness" of this method depends heavily on the behavior of the supplied `result` function.
 ///
 /// [`AsCollection`]: crate::collection::AsCollection
-pub fn join_traces<'scope, Tr1, Tr2, L, CB>(arranged1: Arranged<'scope, Tr1>, arranged2: Arranged<'scope, Tr2>, mut result: L) -> Stream<'scope, Tr1::Time, CB::Container>
+pub fn join_traces<'scope, Tr1, Tr2, L, CB>(arranged1: Arranged<'scope, Tr1>, arranged2: Arranged<'scope, Tr2>, result: L) -> Stream<'scope, Tr1::Time, CB::Container>
 where
     Tr1: TraceReader<Batch: Navigable>+'static,
     Tr2: TraceReader<Batch: Navigable, Time = Tr1::Time>+'static,
     BatchCursor<Tr1>: Cursor<Time = Tr1::Time>,
     for<'a> BatchCursor<Tr2>: Cursor<Key<'a>=BatchKey<'a, Tr1>, Time = Tr1::Time>,
     L: FnMut(BatchKey<'_, Tr1>,BatchVal<'_, Tr1>,BatchVal<'_, Tr2>,Tr1::Time,&BatchDiff<Tr1>,&BatchDiff<Tr2>,&mut JoinSession<Tr1::Time, CB, Capability<Tr1::Time>>)+'static,
+    CB: ContainerBuilder,
+{
+    join_with_tactic(arranged1, arranged2, cursors::CursorTactic::<Tr1::Batch, Tr2::Batch, _>::new(result))
+}
+
+/// Drives an equijoin of two traces using a supplied [`JoinTactic`].
+///
+/// This is the general join operator: it does the dataflow plumbing (frontiers, capabilities, trace
+/// compaction) and routes the per-batch work through the tactic. It requires only `TraceReader` of its
+/// inputs, never `Navigable`: it extracts trace batches via `batches_through`, and building cursors over
+/// them (if that is how the join proceeds) is the tactic's concern.
+pub fn join_with_tactic<'scope, Tr1, Tr2, T, CB>(arranged1: Arranged<'scope, Tr1>, arranged2: Arranged<'scope, Tr2>, mut tactic: T) -> Stream<'scope, Tr1::Time, CB::Container>
+where
+    Tr1: TraceReader+'static,
+    Tr2: TraceReader<Time = Tr1::Time>+'static,
+    T: JoinTactic<Tr1::Batch, Tr2::Batch, CB>+'static,
     CB: ContainerBuilder,
 {
     // Rename traces for symmetry from here on out.
@@ -99,10 +141,6 @@ where
         let mut acknowledged1 = Antichain::from_elem(Tr1::Time::minimum());
         let mut acknowledged2 = Antichain::from_elem(Tr1::Time::minimum());
 
-        // deferred work of batches from each input.
-        let mut todo1 = std::collections::VecDeque::new();
-        let mut todo2 = std::collections::VecDeque::new();
-
         // We'll unload the initial batches here, to put ourselves in a less non-deterministic state to start.
         trace1.map_batches(|batch1| {
             acknowledged1.clone_from(batch1.upper());
@@ -118,12 +156,12 @@ where
         // TODO: in the case that this does not hold, instead "upgrade" the physical compaction frontier.
         assert!(PartialOrder::less_equal(&trace1.get_physical_compaction(), &acknowledged1.borrow()));
 
-        // We capture batch2 cursors first and establish work second to avoid taking a `RefCell` lock
+        // We capture batch2's batches first and establish work second to avoid taking a `RefCell` lock
         // on both traces at the same time, as they could be the same trace and this would panic.
-        let mut batch2_cursors = Vec::new();
+        let mut batch2_list = Vec::new();
         trace2.map_batches(|batch2| {
             acknowledged2.clone_from(batch2.upper());
-            batch2_cursors.push((batch2.cursor(), batch2.clone()));
+            batch2_list.push(batch2.clone());
         });
         // At this point, `ack2` should exactly equal `trace2.read_upper()`, as they are both determined by
         // iterating through batches and capturing the upper bound. This is a great moment to assert that
@@ -131,15 +169,15 @@ where
         // TODO: in the case that this does not hold, instead "upgrade" the physical compaction frontier.
         assert!(PartialOrder::less_equal(&trace2.get_physical_compaction(), &acknowledged2.borrow()));
 
-        // Load up deferred work using trace2 cursors and batches captured just above.
-        for (batch2_cursor, batch2) in batch2_cursors.into_iter() {
+        // Load up deferred work joining each captured `trace2` batch against `trace1`.
+        for batch2 in batch2_list.into_iter() {
             // It is safe to ask for `ack1` because we have confirmed it to be in advance of `distinguish_since`.
-            let (trace1_cursor, trace1_storage) = trace1.cursor_through(acknowledged1.borrow()).unwrap();
+            let trace1_storage = trace1.batches_through(acknowledged1.borrow()).unwrap();
             // We could downgrade the capability here, but doing so is a bit complicated mathematically.
             // TODO: downgrade the capability by searching out the one time in `batch2.lower()` and not
             // in `batch2.upper()`. Only necessary for non-empty batches, as empty batches may not have
             // that property.
-            todo2.push_back(Deferred::new(trace1_cursor, trace1_storage, batch2_cursor, batch2.clone(), capability.clone()));
+            tactic.defer(trace1_storage, vec![batch2], Fresh::Input1, capability.clone());
         }
 
         // Droppable handles to shared trace data structures.
@@ -172,9 +210,8 @@ where
                             if !batch1.is_empty() {
                                 // It is safe to ask for `ack2` as we validated that it was at least `get_physical_compaction()`
                                 // at start-up, and have held back physical compaction ever since.
-                                let (trace2_cursor, trace2_storage) = trace2.cursor_through(acknowledged2.borrow()).unwrap();
-                                let batch1_cursor = batch1.cursor();
-                                todo1.push_back(Deferred::new(trace2_cursor, trace2_storage, batch1_cursor, batch1.clone(), capability.clone()));
+                                let trace2_storage = trace2.batches_through(acknowledged2.borrow()).unwrap();
+                                tactic.defer(vec![batch1.clone()], trace2_storage, Fresh::Input0, capability.clone());
                             }
 
                             // To update `acknowledged1` we might presume that `batch1.lower` should equal it, but we
@@ -199,9 +236,8 @@ where
                             if !batch2.is_empty() {
                                 // It is safe to ask for `ack1` as we validated that it was at least `get_physical_compaction()`
                                 // at start-up, and have held back physical compaction ever since.
-                                let (trace1_cursor, trace1_storage) = trace1.cursor_through(acknowledged1.borrow()).unwrap();
-                                let batch2_cursor = batch2.cursor();
-                                todo2.push_back(Deferred::new(trace1_cursor, trace1_storage, batch2_cursor, batch2.clone(), capability.clone()));
+                                let trace1_storage = trace1.batches_through(acknowledged1.borrow()).unwrap();
+                                tactic.defer(trace1_storage, vec![batch2.clone()], Fresh::Input1, capability.clone());
                             }
 
                             // To update `acknowledged2` we might presume that `batch2.lower` should equal it, but we
@@ -233,30 +269,13 @@ where
             // which results in unintentionally quadratic processing time (each batch of either
             // input must scan all batches from the other input).
 
-            // Perform some amount of outstanding work.
-            let mut fuel = 1_000_000;
-            while !todo1.is_empty() && fuel > 0 {
-                todo1.front_mut().unwrap().work(
-                    output,
-                    |k,v2,v1,t,r2,r1,c| result(k,v1,v2,t,r1,r2,c),
-                    &mut fuel
-                );
-                if !todo1.front().unwrap().work_remains() { todo1.pop_front(); }
-            }
-
-            // Perform some amount of outstanding work.
-            let mut fuel = 1_000_000;
-            while !todo2.is_empty() && fuel > 0 {
-                todo2.front_mut().unwrap().work(
-                    output,
-                    |k,v1,v2,t,r1,r2,c| result(k,v1,v2,t,r1,r2,c),
-                    &mut fuel
-                );
-                if !todo2.front().unwrap().work_remains() { todo2.pop_front(); }
-            }
-
-            // Re-activate operator if work remains.
-            if !todo1.is_empty() || !todo2.is_empty() {
+            // Perform some amount of outstanding work. The tactic decrements `fuel` as it works, and
+            // leaves it negative exactly when work remains; we reschedule the operator in that case.
+            // The two inputs' work shares this budget, so we set it to `2_000_000` to preserve the
+            // historical `1_000_000` of progress per input each activation.
+            let mut fuel = 2_000_000;
+            tactic.work(&mut fuel, output);
+            if fuel < 0 {
                 activator.activate();
             }
 
@@ -302,144 +321,265 @@ where
     })
 }
 
+/// Cursor-based join: the conventional [`JoinTactic`] implementation and its per-batch worker.
+mod cursors {
+    use super::*;
 
-/// Deferred join computation.
-///
-/// The structure wraps cursors which allow us to play out join computation at whatever rate we like.
-/// This allows us to avoid producing and buffering massive amounts of data, without giving the timely
-/// dataflow system a chance to run operators that can consume and aggregate the data.
-struct Deferred<T, C1, C2>
-where
-    T: Timestamp+Lattice,
-    C1: Cursor<Time=T>,
-    C2: for<'a> Cursor<Key<'a>=C1::Key<'a>, Time=T>,
-{
-    trace: C1,
-    trace_storage: C1::Storage,
-    batch: C2,
-    batch_storage: C2::Storage,
-    capability: Capability<T>,
-    done: bool,
-}
+    /// The conventional cursor-based [`JoinTactic`].
+    ///
+    /// It builds a [`CursorList`] over each input batch list and plays the merge-join out at whatever rate
+    /// the operator's fuel allows. Each unit joins a `B0`-side cursor against a `B1`-side cursor, emitting
+    /// `(val0, val1)` to `logic`. The two arrival directions are queued separately and drained against
+    /// independent fuel, so a burst on one input cannot starve the other.
+    pub struct CursorTactic<B0, B1, L>
+    where
+        B0: BatchReader + Navigable,
+        B1: BatchReader<Time = B0::Time> + Navigable,
+        B0::Cursor: Cursor<Time = B0::Time>,
+        B1::Cursor: for<'a> Cursor<Key<'a> = <B0::Cursor as Cursor>::Key<'a>, Time = B0::Time>,
+    {
+        logic: L,
+        /// Units whose fresh batch arrived on the first input (`B0`); their accumulated side is `B1`.
+        todo0: std::collections::VecDeque<Deferred<B0::Time, CursorList<B0::Cursor>, CursorList<B1::Cursor>>>,
+        /// Units whose fresh batch arrived on the second input (`B1`); their accumulated side is `B0`.
+        todo1: std::collections::VecDeque<Deferred<B0::Time, CursorList<B0::Cursor>, CursorList<B1::Cursor>>>,
+    }
 
-impl<T, C1, C2> Deferred<T, C1, C2>
-where
-    C1: Cursor<Time=T>,
-    C2: for<'a> Cursor<Key<'a>=C1::Key<'a>, Time=T>,
-    T: Timestamp+Lattice,
-{
-    fn new(trace: C1, trace_storage: C1::Storage, batch: C2, batch_storage: C2::Storage, capability: Capability<T>) -> Self {
-        Deferred {
-            trace,
-            trace_storage,
-            batch,
-            batch_storage,
-            capability,
-            done: false,
+    impl<B0, B1, L> CursorTactic<B0, B1, L>
+    where
+        B0: BatchReader + Navigable,
+        B1: BatchReader<Time = B0::Time> + Navigable,
+        B0::Cursor: Cursor<Time = B0::Time>,
+        B1::Cursor: for<'a> Cursor<Key<'a> = <B0::Cursor as Cursor>::Key<'a>, Time = B0::Time>,
+    {
+        /// Construct a tactic that applies `logic` to each matched `(key, val0, val1)`.
+        pub fn new(logic: L) -> Self {
+            CursorTactic { logic, todo0: std::collections::VecDeque::new(), todo1: std::collections::VecDeque::new() }
         }
     }
 
-    fn work_remains(&self) -> bool {
-        !self.done
-    }
-
-    /// Process keys until at least `fuel` output tuples produced, or the work is exhausted.
-    #[inline(never)]
-    fn work<L, CB: ContainerBuilder>(&mut self, output: &mut OutputBuilderSession<T, EffortBuilder<CB>>, mut logic: L, fuel: &mut usize)
+    impl<B0, B1, L, CB> JoinTactic<B0, B1, CB> for CursorTactic<B0, B1, L>
     where
-        L: for<'a> FnMut(C1::Key<'a>, C1::Val<'a>, C2::Val<'a>, T, &C1::Diff, &C2::Diff, &mut JoinSession<T, CB, Capability<T>>),
+        B0: BatchReader + Navigable,
+        B1: BatchReader<Time = B0::Time> + Navigable,
+        B0::Cursor: Cursor<Time = B0::Time>,
+        B1::Cursor: for<'a> Cursor<Key<'a> = <B0::Cursor as Cursor>::Key<'a>, Time = B0::Time>,
+        CB: ContainerBuilder,
+        L: for<'a> FnMut(<B0::Cursor as Cursor>::Key<'a>, <B0::Cursor as Cursor>::Val<'a>, <B1::Cursor as Cursor>::Val<'a>, B0::Time, &<B0::Cursor as Cursor>::Diff, &<B1::Cursor as Cursor>::Diff, &mut JoinSession<B0::Time, CB, Capability<B0::Time>>),
     {
-
-        let meet = self.capability.time();
-
-        let mut effort = 0;
-        let mut session = output.session_with_builder(&self.capability);
-
-        let trace_storage = &self.trace_storage;
-        let batch_storage = &self.batch_storage;
-
-        let trace = &mut self.trace;
-        let batch = &mut self.batch;
-
-        let mut thinker = JoinThinker::new();
-
-        while let (Some(batch_key), Some(trace_key), true) = (batch.get_key(batch_storage), trace.get_key(trace_storage), effort < *fuel) {
-
-            match trace_key.cmp(&batch_key) {
-                Ordering::Less => trace.seek_key(trace_storage, batch_key),
-                Ordering::Greater => batch.seek_key(batch_storage, trace_key),
-                Ordering::Equal => {
-
-                    thinker.history1.edits.load(trace, trace_storage, Some(meet));
-                    thinker.history2.edits.load(batch, batch_storage, None);
-
-                    // populate `temp` with the results in the best way we know how.
-                    thinker.think(|v1,v2,t,r1,r2| {
-                        logic(batch_key, v1, v2, t, r1, r2, &mut session);
-                    });
-
-                    // TODO: Effort isn't perfectly tracked as we might still have some data in the
-                    // session at the moment it's dropped.
-                    effort += session.builder().0.take();
-                    batch.step_key(batch_storage);
-                    trace.step_key(trace_storage);
-
-                    thinker.history1.clear();
-                    thinker.history2.clear();
+        fn defer(&mut self, input0: Vec<B0>, input1: Vec<B1>, fresh: Fresh, capability: Capability<B0::Time>) {
+            // Advance the accumulated trace's history by `meet` to consolidate it before the cross-product;
+            // leave the fresh batch, whose times already lie at or beyond `meet` (the capability is held at
+            // or below them). `fresh` also selects the queue, so the two arrival directions drain against
+            // independent fuel and neither can starve the other.
+            //
+            // We advance the accumulated side unconditionally. The advance is output-neutral either way (the
+            // fresh side's times are at or beyond `meet`, so the joined time is too), so this is purely a
+            // consolidation: it pays off when the accumulated side carries times below `meet`, and is a wasted
+            // scan when it does not. A more precise rule would skip the scan when the side is already entirely
+            // at or beyond `meet`, but detecting that needs both frontiers, not just `lower`: a batch's times
+            // lie at or beyond both its `lower` and its `since`, so the side is entirely beyond `meet` exactly
+            // when `meet <= lower` or `meet <= since`. A fresh batch is caught by `lower` (its `since` is
+            // `minimum`), a compacted trace by `since` (its `lower` is `minimum`); checking `lower` alone would
+            // wrongly advance a compacted trace whose times are all already at or beyond `meet`. We keep the
+            // simpler fresh-based choice and accept the occasional no-op scan.
+            let (cursor0, storage0) = cursor_list(input0);
+            let (cursor1, storage1) = cursor_list(input1);
+            match fresh {
+                Fresh::Input0 => {
+                    let deferred = Deferred::new(cursor0, storage0, cursor1, storage1, capability, false, true);
+                    self.todo0.push_back(deferred);
+                }
+                Fresh::Input1 => {
+                    let deferred = Deferred::new(cursor0, storage0, cursor1, storage1, capability, true, false);
+                    self.todo1.push_back(deferred);
                 }
             }
         }
-        self.done = !batch.key_valid(batch_storage) || !trace.key_valid(trace_storage);
 
-        if effort > *fuel { *fuel = 0; }
-        else              { *fuel -= effort; }
-    }
-}
-
-struct JoinThinker<V1, V2, T, D1, D2> {
-    pub history1: ValueHistory<V1, T, D1>,
-    pub history2: ValueHistory<V2, T, D2>,
-}
-
-impl<V1, V2, T, D1, D2> JoinThinker<V1, V2, T, D1, D2>
-where
-    V1: Copy + Ord,
-    V2: Copy + Ord,
-    T: Ord + Clone + Lattice,
-    D1: Clone + crate::difference::Semigroup,
-    D2: Clone + crate::difference::Semigroup,
-{
-    fn new() -> Self {
-        JoinThinker {
-            history1: ValueHistory::new(),
-            history2: ValueHistory::new(),
+        fn work(&mut self, fuel: &mut isize, output: &mut OutputBuilderSession<B0::Time, EffortBuilder<CB>>) {
+            // Drain each direction against its own half of the budget, so a burst on one input cannot starve
+            // the other. Within a direction the front unit decrements its sub-budget (possibly below zero)
+            // and we stop that direction once it goes negative. If either queue still has work afterward we
+            // drive `fuel` negative so the operator reschedules; an empty pair leaves it non-negative.
+            let mut fuel0 = *fuel / 2;
+            while fuel0 >= 0 {
+                let Some(front) = self.todo0.front_mut() else { break };
+                front.work(output, &mut self.logic, &mut fuel0);
+                if !front.work_remains() { self.todo0.pop_front(); }
+            }
+            let mut fuel1 = *fuel / 2;
+            while fuel1 >= 0 {
+                let Some(front) = self.todo1.front_mut() else { break };
+                front.work(output, &mut self.logic, &mut fuel1);
+                if !front.work_remains() { self.todo1.pop_front(); }
+            }
+            *fuel = if self.todo0.is_empty() && self.todo1.is_empty() { 0 } else { -1 };
         }
     }
 
-    fn think<F: FnMut(V1, V2, T, &D1, &D2)>(&mut self, mut results: F) {
+    /// Deferred join computation.
+    ///
+    /// The structure wraps cursors which allow us to play out join computation at whatever rate we like.
+    /// This allows us to avoid producing and buffering massive amounts of data, without giving the timely
+    /// dataflow system a chance to run operators that can consume and aggregate the data.
+    struct Deferred<T, C1, C2>
+    where
+        T: Timestamp+Lattice,
+        C1: Cursor<Time=T>,
+        C2: for<'a> Cursor<Key<'a>=C1::Key<'a>, Time=T>,
+    {
+        cursor1: C1,
+        storage1: C1::Storage,
+        cursor2: C2,
+        storage2: C2::Storage,
+        capability: Capability<T>,
+        /// Whether to advance each side's history by the capability's meet before consolidation.
+        advance1: bool,
+        advance2: bool,
+        done: bool,
+    }
 
-        // for reasonably sized edits, do the dead-simple thing.
-        if self.history1.edits.len() < 10 || self.history2.edits.len() < 10 {
-            self.history1.edits.map(|v1, t1, d1| {
-                self.history2.edits.map(|v2, t2, d2| {
-                    results(v1, v2, t1.join(t2), d1, d2);
+    impl<T, C1, C2> Deferred<T, C1, C2>
+    where
+        C1: Cursor<Time=T>,
+        C2: for<'a> Cursor<Key<'a>=C1::Key<'a>, Time=T>,
+        T: Timestamp+Lattice,
+    {
+        fn new(cursor1: C1, storage1: C1::Storage, cursor2: C2, storage2: C2::Storage, capability: Capability<T>, advance1: bool, advance2: bool) -> Self {
+            Deferred {
+                cursor1,
+                storage1,
+                cursor2,
+                storage2,
+                capability,
+                advance1,
+                advance2,
+                done: false,
+            }
+        }
+
+        fn work_remains(&self) -> bool {
+            !self.done
+        }
+
+        /// Process keys until `fuel` is driven below zero, or the work is exhausted.
+        #[inline(never)]
+        fn work<L, CB: ContainerBuilder>(&mut self, output: &mut OutputBuilderSession<T, EffortBuilder<CB>>, logic: &mut L, fuel: &mut isize)
+        where
+            L: for<'a> FnMut(C1::Key<'a>, C1::Val<'a>, C2::Val<'a>, T, &C1::Diff, &C2::Diff, &mut JoinSession<T, CB, Capability<T>>),
+        {
+
+            let meet = self.capability.time();
+
+            // Advance the accumulated side by `meet` to consolidate its history; leave the fresh side, whose
+            // times already lie at or beyond `meet`. The choice was fixed per side at construction, from
+            // which input carried the fresh batch.
+            let meet1 = if self.advance1 { Some(meet) } else { None };
+            let meet2 = if self.advance2 { Some(meet) } else { None };
+
+            let mut session = output.session_with_builder(&self.capability);
+
+            let storage1 = &self.storage1;
+            let storage2 = &self.storage2;
+
+            let cursor1 = &mut self.cursor1;
+            let cursor2 = &mut self.cursor2;
+
+            let mut thinker = JoinThinker::new();
+
+            while let (Some(key1), Some(key2), true) = (cursor1.get_key(storage1), cursor2.get_key(storage2), *fuel >= 0) {
+
+                match key1.cmp(&key2) {
+                    Ordering::Less => cursor1.seek_key(storage1, key2),
+                    Ordering::Greater => cursor2.seek_key(storage2, key1),
+                    Ordering::Equal => {
+
+                        thinker.history1.edits.load(cursor1, storage1, meet1);
+                        thinker.history2.edits.load(cursor2, storage2, meet2);
+
+                        // populate `temp` with the results in the best way we know how.
+                        thinker.think(|v1,v2,t,r1,r2| {
+                            logic(key1, v1, v2, t, r1, r2, &mut session);
+                        });
+
+                        // TODO: Effort isn't perfectly tracked as we might still have some data in the
+                        // session at the moment it's dropped.
+                        *fuel -= session.builder().0.take() as isize;
+                        cursor1.step_key(storage1);
+                        cursor2.step_key(storage2);
+
+                        thinker.history1.clear();
+                        thinker.history2.clear();
+                    }
+                }
+            }
+            self.done = !cursor1.key_valid(storage1) || !cursor2.key_valid(storage2);
+        }
+    }
+
+    struct JoinThinker<V1, V2, T, D1, D2> {
+        pub history1: ValueHistory<V1, T, D1>,
+        pub history2: ValueHistory<V2, T, D2>,
+    }
+
+    impl<V1, V2, T, D1, D2> JoinThinker<V1, V2, T, D1, D2>
+    where
+        V1: Copy + Ord,
+        V2: Copy + Ord,
+        T: Ord + Clone + Lattice,
+        D1: Clone + crate::difference::Semigroup,
+        D2: Clone + crate::difference::Semigroup,
+    {
+        fn new() -> Self {
+            JoinThinker {
+                history1: ValueHistory::new(),
+                history2: ValueHistory::new(),
+            }
+        }
+
+        fn think<F: FnMut(V1, V2, T, &D1, &D2)>(&mut self, mut results: F) {
+
+            // for reasonably sized edits, do the dead-simple thing.
+            if self.history1.edits.len() < 10 || self.history2.edits.len() < 10 {
+                self.history1.edits.map(|v1, t1, d1| {
+                    self.history2.edits.map(|v2, t2, d2| {
+                        results(v1, v2, t1.join(t2), d1, d2);
+                    })
                 })
-            })
-        }
-        else {
+            }
+            else {
 
-            let mut replay1 = self.history1.replay();
-            let mut replay2 = self.history2.replay();
+                let mut replay1 = self.history1.replay();
+                let mut replay2 = self.history2.replay();
 
-            // TODO: It seems like there is probably a good deal of redundant `advance_buffer_by`
-            //       in here. If a time is ever repeated, for example, the call will be identical
-            //       and accomplish nothing. If only a single record has been added, it may not
-            //       be worth the time to collapse (advance, re-sort) the data when a linear scan
-            //       is sufficient.
+                // TODO: It seems like there is probably a good deal of redundant `advance_buffer_by`
+                //       in here. If a time is ever repeated, for example, the call will be identical
+                //       and accomplish nothing. If only a single record has been added, it may not
+                //       be worth the time to collapse (advance, re-sort) the data when a linear scan
+                //       is sufficient.
 
-            while !replay1.is_done() && !replay2.is_done() {
+                while !replay1.is_done() && !replay2.is_done() {
 
-                if replay1.time().unwrap().cmp(replay2.time().unwrap()) == ::std::cmp::Ordering::Less {
+                    if replay1.time().unwrap().cmp(replay2.time().unwrap()) == ::std::cmp::Ordering::Less {
+                        replay2.advance_buffer_by(replay1.meet().unwrap());
+                        for &((val2, ref time2), ref diff2) in replay2.buffer().iter() {
+                            let (val1, time1, diff1) = replay1.edit().unwrap();
+                            results(val1, val2, time1.join(time2), diff1, diff2);
+                        }
+                        replay1.step();
+                    }
+                    else {
+                        replay1.advance_buffer_by(replay2.meet().unwrap());
+                        for &((val1, ref time1), ref diff1) in replay1.buffer().iter() {
+                            let (val2, time2, diff2) = replay2.edit().unwrap();
+                            results(val1, val2, time1.join(time2), diff1, diff2);
+                        }
+                        replay2.step();
+                    }
+                }
+
+                while !replay1.is_done() {
                     replay2.advance_buffer_by(replay1.meet().unwrap());
                     for &((val2, ref time2), ref diff2) in replay2.buffer().iter() {
                         let (val1, time1, diff1) = replay1.edit().unwrap();
@@ -447,7 +587,7 @@ where
                     }
                     replay1.step();
                 }
-                else {
+                while !replay2.is_done() {
                     replay1.advance_buffer_by(replay2.meet().unwrap());
                     for &((val1, ref time1), ref diff1) in replay1.buffer().iter() {
                         let (val2, time2, diff2) = replay2.edit().unwrap();
@@ -455,23 +595,6 @@ where
                     }
                     replay2.step();
                 }
-            }
-
-            while !replay1.is_done() {
-                replay2.advance_buffer_by(replay1.meet().unwrap());
-                for &((val2, ref time2), ref diff2) in replay2.buffer().iter() {
-                    let (val1, time1, diff1) = replay1.edit().unwrap();
-                    results(val1, val2, time1.join(time2), diff1, diff2);
-                }
-                replay1.step();
-            }
-            while !replay2.is_done() {
-                replay1.advance_buffer_by(replay2.meet().unwrap());
-                for &((val1, ref time1), ref diff1) in replay1.buffer().iter() {
-                    let (val2, time2, diff2) = replay2.edit().unwrap();
-                    results(val1, val2, time1.join(time2), diff1, diff2);
-                }
-                replay2.step();
             }
         }
     }

--- a/differential-dataflow/src/operators/join.rs
+++ b/differential-dataflow/src/operators/join.rs
@@ -53,7 +53,7 @@ impl<CB: PushInto<D>, D> PushInto<D> for EffortBuilder<CB> {
 }
 
 /// A type that can manage the joining of lists of batches.
-pub trait JoinTactic<B0: BatchReader, B1: BatchReader<Time = B0::Time>, CB: ContainerBuilder> {
+pub(crate) trait JoinTactic<B0: BatchReader, B1: BatchReader<Time = B0::Time>, CB: ContainerBuilder> {
     /// Prepare for work the join of two lists of corresponding batches, against a sufficient capability.
     ///
     /// `fresh` names which input contributed the freshly-arrived batch; its times all lie at or beyond
@@ -70,7 +70,7 @@ pub trait JoinTactic<B0: BatchReader, B1: BatchReader<Time = B0::Time>, CB: Cont
 /// The fresh batch's times all lie at or beyond the capability, so its side is not advanced by the
 /// capability's meet; the opposing accumulated trace is. The marker also selects which queue a unit
 /// joins, so a burst on one input cannot starve the other.
-pub enum Fresh {
+pub(crate) enum Fresh {
     /// The first input (`B0`) contributed the fresh batch.
     Input0,
     /// The second input (`B1`) contributed the fresh batch.
@@ -108,7 +108,7 @@ where
 /// compaction) and routes the per-batch work through the tactic. It requires only `TraceReader` of its
 /// inputs, never `Navigable`: it extracts trace batches via `batches_through`, and building cursors over
 /// them (if that is how the join proceeds) is the tactic's concern.
-pub fn join_with_tactic<'scope, Tr1, Tr2, T, CB>(arranged1: Arranged<'scope, Tr1>, arranged2: Arranged<'scope, Tr2>, mut tactic: T) -> Stream<'scope, Tr1::Time, CB::Container>
+pub(crate) fn join_with_tactic<'scope, Tr1, Tr2, T, CB>(arranged1: Arranged<'scope, Tr1>, arranged2: Arranged<'scope, Tr2>, mut tactic: T) -> Stream<'scope, Tr1::Time, CB::Container>
 where
     Tr1: TraceReader+'static,
     Tr2: TraceReader<Time = Tr1::Time>+'static,

--- a/differential-dataflow/src/operators/reduce.rs
+++ b/differential-dataflow/src/operators/reduce.rs
@@ -25,7 +25,7 @@ use crate::trace::implementations::containers::BatchContainer;
 /// Unlike join, reduce does not suspend: its output is at most linear in its input, so a single
 /// `retire` runs the whole `[lower, upper)` interval to completion rather than yielding under a fuel
 /// budget.
-pub trait ReduceTactic<B1: BatchReader, B2: BatchReader<Time = B1::Time>> {
+pub(crate) trait ReduceTactic<B1: BatchReader, B2: BatchReader<Time = B1::Time>> {
     /// Retire the interval `[lower, upper)`, producing the output batches it informs.
     ///
     /// It is presented with the pre-existing input batches and output batches (those before `lower`),
@@ -76,7 +76,7 @@ where
 /// `TraceReader` of its input and `Trace` of its output, never `Navigable`: it extracts batches via
 /// `batches_through`, and building cursors over them (if that is how the reduce proceeds) is the
 /// tactic's concern.
-pub fn reduce_with_tactic<'scope, Tr1, Tr2, T>(trace: Arranged<'scope, Tr1>, name: &str, mut tactic: T) -> Arranged<'scope, TraceAgent<Tr2>>
+pub(crate) fn reduce_with_tactic<'scope, Tr1, Tr2, T>(trace: Arranged<'scope, Tr1>, name: &str, mut tactic: T) -> Arranged<'scope, TraceAgent<Tr2>>
 where
     Tr1: TraceReader + 'static,
     Tr2: Trace<Time = Tr1::Time> + 'static,

--- a/differential-dataflow/src/operators/reduce.rs
+++ b/differential-dataflow/src/operators/reduce.rs
@@ -7,14 +7,41 @@
 
 use crate::Data;
 
+use std::marker::PhantomData;
+
 use timely::progress::frontier::Antichain;
 use timely::progress::Timestamp;
 use timely::dataflow::operators::Operator;
+use timely::dataflow::operators::CapabilitySet;
 use timely::dataflow::channels::pact::Pipeline;
 
 use crate::operators::arrange::{Arranged, TraceAgent};
 use crate::trace::{BatchCursor, BatchDiff, BatchKey, BatchReader, BatchVal, BatchValOwn, Builder, Cursor, Description, ExertionLogic, Navigable, Trace, TraceReader};
+use crate::trace::cursor::cursor_list;
 use crate::trace::implementations::containers::BatchContainer;
+
+/// A type that resolves a key-wise reduction over batches arriving on the input.
+///
+/// Unlike join, reduce does not suspend: its output is at most linear in its input, so a single
+/// `retire` runs the whole `[lower, upper)` interval to completion rather than yielding under a fuel
+/// budget.
+pub trait ReduceTactic<B1: BatchReader, B2: BatchReader<Time = B1::Time>> {
+    /// Retire the interval `[lower, upper)`, producing the output batches it informs.
+    ///
+    /// It is presented with the pre-existing input batches and output batches (those before `lower`),
+    /// the new input batches, and `held`: the times the operator currently holds capabilities for. It
+    /// reasons only about times, returning the output batches to ship — each tagged with the time at
+    /// which to ship it — and the new frontier of interesting times for the operator to hold.
+    fn retire(
+        &mut self,
+        source_batches: Vec<B1>,
+        output_batches: Vec<B2>,
+        input_batches: Vec<B1>,
+        lower: &Antichain<B1::Time>,
+        upper: &Antichain<B1::Time>,
+        held: &Antichain<B1::Time>,
+    ) -> (Vec<(B1::Time, B2)>, Antichain<B1::Time>);
+}
 
 /// A key-wise reduction of values in an input trace.
 ///
@@ -29,15 +56,31 @@ use crate::trace::implementations::containers::BatchContainer;
 /// the value updates, as appropriate for the container. It is critical that it clear the container as
 /// the operator has no ability to do this otherwise, and failing to do so represents a leak from one
 /// key's computation to another, and will likely introduce non-determinism.
-pub fn reduce_trace<'scope, Tr1, Bu, Tr2, L, P>(trace: Arranged<'scope, Tr1>, name: &str, mut logic: L, mut push: P) -> Arranged<'scope, TraceAgent<Tr2>>
+pub fn reduce_trace<'scope, Tr1, Bu, Tr2, L, P>(trace: Arranged<'scope, Tr1>, name: &str, logic: L, push: P) -> Arranged<'scope, TraceAgent<Tr2>>
 where
     Tr1: TraceReader<Batch: Navigable> + 'static,
     Tr2: Trace<Batch: Navigable, Time = Tr1::Time> + 'static,
     BatchCursor<Tr1>: Cursor<Time = Tr1::Time>,
     for<'a> BatchCursor<Tr2>: Cursor<Key<'a> = BatchKey<'a, Tr1>, ValOwn: Data, Time = Tr2::Time>,
-    Bu: Builder<Time=Tr2::Time, Output = Tr2::Batch, Input: Default>,
+    Bu: Builder<Time=Tr2::Time, Output = Tr2::Batch, Input: Default> + 'static,
     L: FnMut(BatchKey<'_, Tr1>, &[(BatchVal<'_, Tr1>, BatchDiff<Tr1>)], &mut Vec<(BatchValOwn<Tr2>, BatchDiff<Tr2>)>, &mut Vec<(BatchValOwn<Tr2>, BatchDiff<Tr2>)>)+'static,
     P: FnMut(&mut Bu::Input, BatchKey<'_, Tr1>, &mut Vec<(BatchValOwn<Tr2>, Tr2::Time, BatchDiff<Tr2>)>) + 'static,
+{
+    reduce_with_tactic(trace, name, cursors::CursorTactic::<Tr1::Batch, Tr2::Batch, Bu, L, P>::new(logic, push))
+}
+
+/// Drives a key-wise reduction using a supplied [`ReduceTactic`].
+///
+/// This is the general reduce operator: it does the dataflow plumbing (frontiers, capabilities, output
+/// trace maintenance) and routes the per-interval work through the tactic. It requires only
+/// `TraceReader` of its input and `Trace` of its output, never `Navigable`: it extracts batches via
+/// `batches_through`, and building cursors over them (if that is how the reduce proceeds) is the
+/// tactic's concern.
+pub fn reduce_with_tactic<'scope, Tr1, Tr2, T>(trace: Arranged<'scope, Tr1>, name: &str, mut tactic: T) -> Arranged<'scope, TraceAgent<Tr2>>
+where
+    Tr1: TraceReader + 'static,
+    Tr2: Trace<Time = Tr1::Time> + 'static,
+    T: ReduceTactic<Tr1::Batch, Tr2::Batch> + 'static,
 {
     let mut result_trace = None;
 
@@ -63,26 +106,12 @@ where
 
             *result_trace = Some(output_reader.clone());
 
-            let mut new_interesting_times = Vec::<Tr1::Time>::new();
-
-            // Our implementation maintains a list of outstanding `(key, time)` synthetic interesting times,
-            // sorted by (key, time), as well as capabilities for the lower envelope of the times.
-            let mut pending_keys = <BatchCursor<Tr1> as Cursor>::KeyContainer::with_capacity(0);
-            let mut pending_time = <BatchCursor<Tr1> as Cursor>::TimeContainer::with_capacity(0);
-            let mut next_pending_keys = <BatchCursor<Tr1> as Cursor>::KeyContainer::with_capacity(0);
-            let mut next_pending_time = <BatchCursor<Tr1> as Cursor>::TimeContainer::with_capacity(0);
-            let mut capabilities = timely::dataflow::operators::CapabilitySet::<Tr1::Time>::default();
-
-            // buffers and logic for computing per-key interesting times "efficiently".
-            let mut interesting_times = Vec::<Tr1::Time>::new();
+            // Capabilities for the lower envelope of the interesting times the operator holds.
+            let mut capabilities = CapabilitySet::<Tr1::Time>::default();
 
             // Upper and lower frontiers for the pending input and output batches to process.
-            let mut upper_limit = Antichain::from_elem(<Tr1::Time as timely::progress::Timestamp>::minimum());
-            let mut lower_limit = Antichain::from_elem(<Tr1::Time as timely::progress::Timestamp>::minimum());
-
-            // Output batches may need to be built piecemeal, and these temp storage help there.
-            let mut output_upper = Antichain::from_elem(<Tr1::Time as timely::progress::Timestamp>::minimum());
-            let mut output_lower = Antichain::from_elem(<Tr1::Time as timely::progress::Timestamp>::minimum());
+            let mut upper_limit = Antichain::from_elem(<Tr1::Time as Timestamp>::minimum());
+            let mut lower_limit = Antichain::from_elem(<Tr1::Time as Timestamp>::minimum());
 
             move |(input, frontier), output| {
 
@@ -119,162 +148,28 @@ where
                 // We plan to retire the interval [lower_limit, upper_limit), which should be non-empty to proceed.
                 if upper_limit != lower_limit {
 
-                    // If we hold no capabilities in the interval [lower_limit, upper_limit) then we have no compute needs,
-                    // and could not transmit the outputs even if they were (incorrectly) non-zero.
-                    // We do have maintenance work after this logic, and should not fuse this test with the above test.
-                    if capabilities.iter().any(|c| !upper_limit.less_equal(c.time())) {
+                    // Acquire the pre-existing input and output batches preceding the interval. Batch handles
+                    // are cheap to clone, so we fetch them whether or not the tactic finds work to do.
+                    let source_batches = source_trace.batches_through(lower_limit.borrow()).expect("failed to acquire source batches");
+                    let output_batches = output_reader.batches_through(lower_limit.borrow()).expect("failed to acquire output batches");
 
-                        // cursors for navigating input and output traces.
-                        let (mut source_cursor, ref source_storage) = source_trace.cursor_through(lower_limit.borrow()).expect("failed to acquire source cursor");
-                        let (mut output_cursor, ref output_storage) = output_reader.cursor_through(lower_limit.borrow()).expect("failed to acquire output cursor");
-                        let (mut batch_cursor, ref batch_storage) = crate::trace::cursor::cursor_list(batch_storage);
+                    // The times the operator currently holds capabilities for, as an antichain.
+                    let held: Antichain<Tr1::Time> = capabilities.iter().map(|c| c.time().clone()).collect();
 
-                        // Prepare an output buffer and builder for each capability.
-                        // TODO: It would be better if all updates went into one batch, but timely dataflow prevents
-                        //       this as long as it requires that there is only one capability for each message.
-                        let mut buffers = Vec::<(Tr1::Time, Vec<(BatchValOwn<Tr2>, Tr1::Time, BatchDiff<Tr2>)>)>::new();
-                        let mut builders = Vec::new();
-                        for cap in capabilities.iter() {
-                            buffers.push((cap.time().clone(), Vec::new()));
-                            builders.push(Bu::new());
-                        }
-                        // Temporary staging for output building.
-                        let mut buffer = Bu::Input::default();
+                    // Retire the interval. The tactic reasons only about times: it returns output batches
+                    // each tagged with the time to ship it at, and the new frontier of interesting times.
+                    let (produced, new_frontier) = tactic.retire(source_batches, output_batches, batch_storage, &lower_limit, &upper_limit, &held);
 
-                        // Reuseable state for performing the computation.
-                        let mut thinker = history_replay::HistoryReplayer::new();
-
-                        // Merge the received batch cursor with our list of interesting (key, time) moments.
-                        // The interesting moments need to be in the interval to prompt work.
-
-                        // March through the keys we must work on, merging `batch_cursors` and `exposed`.
-                        let mut pending_pos = 0;
-                        while batch_cursor.key_valid(batch_storage) || pending_pos < pending_keys.len() {
-
-                            // Determine the next key we will work on; could be synthetic, could be from a batch.
-                            let key1 = pending_keys.get(pending_pos);
-                            let key2 = batch_cursor.get_key(batch_storage);
-                            let key = match (key1, key2) {
-                                (Some(key1), Some(key2)) => ::std::cmp::min(key1, key2),
-                                (Some(key1), None)       => key1,
-                                (None, Some(key2))       => key2,
-                                (None, None)             => unreachable!(),
-                            };
-
-                            // Populate `interesting_times` with interesting times not beyond `upper_limit`.
-                            // TODO: This could just be `pending_time` and indexes within `lower .. upper`.
-                            let prior_pos = pending_pos;
-                            interesting_times.clear();
-                            while pending_keys.get(pending_pos) == Some(key) {
-                                let owned_time = <BatchCursor<Tr1> as Cursor>::owned_time(pending_time.index(pending_pos));
-                                if !upper_limit.less_equal(&owned_time) { interesting_times.push(owned_time); }
-                                pending_pos += 1;
-                            }
-
-                            // tidy up times, removing redundancy.
-                            sort_dedup(&mut interesting_times);
-
-                            // If there are new updates, or pending times, we must investigate!
-                            if batch_cursor.get_key(batch_storage) == Some(key) || !interesting_times.is_empty() {
-
-                                // do the per-key computation.
-                                thinker.compute(
-                                    key,
-                                    (&mut source_cursor, source_storage),
-                                    (&mut output_cursor, output_storage),
-                                    (&mut batch_cursor, batch_storage),
-                                    &interesting_times,
-                                    &mut logic,
-                                    &upper_limit,
-                                    &mut buffers[..],
-                                    &mut new_interesting_times,
-                                );
-
-                                // Advance the cursor if this key, so that the loop's validity check registers the work as done.
-                                if batch_cursor.get_key(batch_storage) == Some(key) { batch_cursor.step_key(batch_storage); }
-
-                                // Merge novel pending times with any prior pending times we did not process.
-                                // TODO: This could be a merge, not a sort_dedup, because both lists should be sorted.
-                                for pos in prior_pos .. pending_pos {
-                                    let owned_time = <BatchCursor<Tr1> as Cursor>::owned_time(pending_time.index(pos));
-                                    if upper_limit.less_equal(&owned_time) { new_interesting_times.push(owned_time); }
-                                }
-                                sort_dedup(&mut new_interesting_times);
-                                for time in new_interesting_times.drain(..) {
-                                    next_pending_keys.push_ref(key);
-                                    next_pending_time.push_own(&time);
-                                }
-
-                                // Sort each buffer by value and move into the corresponding builder.
-                                // TODO: This makes assumptions about at least one of (i) the stability of `sort_by`,
-                                //       (ii) that the buffers are time-ordered, and (iii) that the builders accept
-                                //       arbitrarily ordered times.
-                                for index in 0 .. buffers.len() {
-                                    buffers[index].1.sort_by(|x,y| x.0.cmp(&y.0));
-                                    push(&mut buffer, key, &mut buffers[index].1);
-                                    buffers[index].1.clear();
-                                    builders[index].push(&mut buffer);
-
-                                }
-                            }
-                            else {
-                                // copy over the pending key and times.
-                                for pos in prior_pos .. pending_pos {
-                                    next_pending_keys.push_ref(pending_keys.index(pos));
-                                    next_pending_time.push_ref(pending_time.index(pos));
-                                }
-                            }
-                        }
-                        // Drop to avoid lifetime issues that would lock `pending_{keys, time}`.
-                        drop(thinker);
-
-                        // We start sealing output batches from the lower limit (previous upper limit).
-                        // In principle, we could update `lower_limit` itself, and it should arrive at
-                        // `upper_limit` by the end of the process.
-                        output_lower.clear();
-                        output_lower.extend(lower_limit.borrow().iter().cloned());
-
-                        // build and ship each batch (because only one capability per message).
-                        for (index, builder) in builders.drain(..).enumerate() {
-
-                            // Form the upper limit of the next batch, which includes all times greater
-                            // than the input batch, or the capabilities from i + 1 onward.
-                            output_upper.clear();
-                            output_upper.extend(upper_limit.borrow().iter().cloned());
-                            for capability in &capabilities[index + 1 ..] {
-                                output_upper.insert_ref(capability.time());
-                            }
-
-                            if output_upper.borrow() != output_lower.borrow() {
-
-                                let description = Description::new(output_lower.clone(), output_upper.clone(), Antichain::from_elem(Tr1::Time::minimum()));
-                                let batch = builder.done(description);
-
-                                // ship batch to the output, and commit to the output trace.
-                                output.session(&capabilities[index]).give(batch.clone());
-                                output_writer.insert(batch, Some(capabilities[index].time().clone()));
-
-                                output_lower.clear();
-                                output_lower.extend(output_upper.borrow().iter().cloned());
-                            }
-                        }
-                        // This should be true, as the final iteration introduces no capabilities, and
-                        // uses exactly `upper_limit` to determine the upper bound. Good to check though.
-                        assert!(output_upper.borrow() == upper_limit.borrow());
-
-                        // Refresh pending keys and times, then downgrade capabilities to the frontier of times.
-                        pending_keys.clear(); std::mem::swap(&mut next_pending_keys, &mut pending_keys);
-                        pending_time.clear(); std::mem::swap(&mut next_pending_time, &mut pending_time);
-
-                        // Update `capabilities` to reflect pending times.
-                        let mut frontier = Antichain::<Tr1::Time>::new();
-                        let mut owned_time = Tr1::Time::minimum();
-                        for pos in 0 .. pending_time.len() {
-                            <BatchCursor<Tr1> as Cursor>::clone_time_onto(pending_time.index(pos), &mut owned_time);
-                            frontier.insert_ref(&owned_time);
-                        }
-                        capabilities.downgrade(frontier);
+                    // Ship each batch at a capability minted from the set at its time, and commit it to the
+                    // output trace. The times are elements of `held`, so they stay valid until we downgrade.
+                    for (time, batch) in produced {
+                        let capability = capabilities.delayed(&time);
+                        output.session(&capability).give(batch.clone());
+                        output_writer.insert(batch, Some(time));
                     }
+
+                    // Downgrade to the frontier the tactic handed back (a no-op when it found no work).
+                    capabilities.downgrade(new_frontier);
 
                     // ensure that observed progress is reflected in the output.
                     output_writer.seal(upper_limit.clone());
@@ -298,322 +193,566 @@ where
     Arranged { stream, trace: result_trace.unwrap() }
 }
 
+/// The conventional cursor-based [`ReduceTactic`].
+///
+/// It builds a [`CursorList`](crate::trace::cursor::CursorList) over the input, output, and new-batch
+/// updates and replays them together per key, applying `logic` and shaping output with `push`. It holds
+/// the outstanding synthetic interesting `(key, time)` moments across activations, and reasons only
+/// about times: capabilities are the driver's concern.
+mod cursors {
 
-#[inline(never)]
-fn sort_dedup<T: Ord>(list: &mut Vec<T>) {
-    list.dedup();
-    list.sort();
-    list.dedup();
-}
+    use super::*;
 
-/// Implementation based on replaying historical and new updates together.
-mod history_replay {
-
-    use timely::progress::Antichain;
-
-    use crate::lattice::Lattice;
-    use crate::trace::Cursor;
-    use crate::operators::ValueHistory;
-
-    use super::sort_dedup;
-
-    /// The `HistoryReplayer` is a compute strategy based on moving through existing inputs, interesting times, etc in
-    /// time order, maintaining consolidated representations of updates with respect to future interesting times.
-    pub struct HistoryReplayer<V1, V2, V, T, D1, D2> {
-        input_history: ValueHistory<V1, T, D1>,
-        output_history: ValueHistory<V2, T, D2>,
-        batch_history: ValueHistory<V1, T, D1>,
-        input_buffer: Vec<(V1, D1)>,
-        output_buffer: Vec<(V, D2)>,
-        update_buffer: Vec<(V, D2)>,
-        output_produced: Vec<((V, T), D2)>,
-        synth_times: Vec<T>,
-        meets: Vec<T>,
-        times_current: Vec<T>,
-        temporary: Vec<T>,
+    /// The conventional cursor-based [`ReduceTactic`].
+    pub struct CursorTactic<B1, B2, Bu, L, P>
+    where
+        B1: BatchReader + Navigable,
+        B2: BatchReader<Time = B1::Time> + Navigable,
+        B1::Cursor: Cursor<Time = B1::Time>,
+        for<'a> B2::Cursor: Cursor<Key<'a> = <B1::Cursor as Cursor>::Key<'a>, ValOwn: Data, Time = B1::Time>,
+    {
+        logic: L,
+        push: P,
+        // Outstanding `(key, time)` synthetic interesting moments, sorted by `(key, time)`, and the
+        // buffers into which we assemble the next round's moments.
+        pending_keys: <B1::Cursor as Cursor>::KeyContainer,
+        pending_time: <B1::Cursor as Cursor>::TimeContainer,
+        next_pending_keys: <B1::Cursor as Cursor>::KeyContainer,
+        next_pending_time: <B1::Cursor as Cursor>::TimeContainer,
+        // Buffers reused across activations.
+        interesting_times: Vec<B1::Time>,
+        new_interesting_times: Vec<B1::Time>,
+        // Output batches may need to be built piecemeal, and these temp storage help there.
+        output_upper: Antichain<B1::Time>,
+        output_lower: Antichain<B1::Time>,
+        _marker: PhantomData<(B2, Bu)>,
     }
 
-    impl<V1, V2, V, T, D1, D2> HistoryReplayer<V1, V2, V, T, D1, D2>
+    impl<B1, B2, Bu, L, P> CursorTactic<B1, B2, Bu, L, P>
     where
-        V1: Copy + Ord,
-        V2: Copy + Ord,
-        V: Clone + Ord,
-        T: Ord + Clone + Lattice,
-        D1: Clone + crate::difference::Semigroup,
-        D2: Clone + crate::difference::Semigroup,
+        B1: BatchReader + Navigable,
+        B2: BatchReader<Time = B1::Time> + Navigable,
+        B1::Cursor: Cursor<Time = B1::Time>,
+        for<'a> B2::Cursor: Cursor<Key<'a> = <B1::Cursor as Cursor>::Key<'a>, ValOwn: Data, Time = B1::Time>,
     {
-        pub fn new() -> Self {
-            HistoryReplayer {
-                input_history: ValueHistory::new(),
-                output_history: ValueHistory::new(),
-                batch_history: ValueHistory::new(),
-                input_buffer: Vec::new(),
-                output_buffer: Vec::new(),
-                update_buffer: Vec::new(),
-                output_produced: Vec::new(),
-                synth_times: Vec::new(),
-                meets: Vec::new(),
-                times_current: Vec::new(),
-                temporary: Vec::new(),
+        /// Construct a tactic that applies `logic` to each key and shapes output with `push`.
+        pub fn new(logic: L, push: P) -> Self {
+            CursorTactic {
+                logic,
+                push,
+                pending_keys: <B1::Cursor as Cursor>::KeyContainer::with_capacity(0),
+                pending_time: <B1::Cursor as Cursor>::TimeContainer::with_capacity(0),
+                next_pending_keys: <B1::Cursor as Cursor>::KeyContainer::with_capacity(0),
+                next_pending_time: <B1::Cursor as Cursor>::TimeContainer::with_capacity(0),
+                interesting_times: Vec::new(),
+                new_interesting_times: Vec::new(),
+                output_upper: Antichain::from_elem(<B1::Time as Timestamp>::minimum()),
+                output_lower: Antichain::from_elem(<B1::Time as Timestamp>::minimum()),
+                _marker: PhantomData,
             }
         }
-        #[inline(never)]
-        pub fn compute<'a, K, C1, C2, C3, L>(
+    }
+
+    impl<B1, B2, Bu, L, P> ReduceTactic<B1, B2> for CursorTactic<B1, B2, Bu, L, P>
+    where
+        B1: BatchReader + Navigable,
+        B2: BatchReader<Time = B1::Time> + Navigable,
+        B1::Cursor: Cursor<Time = B1::Time>,
+        for<'a> B2::Cursor: Cursor<Key<'a> = <B1::Cursor as Cursor>::Key<'a>, ValOwn: Data, Time = B1::Time>,
+        Bu: Builder<Time = B1::Time, Output = B2, Input: Default>,
+        L: FnMut(<B1::Cursor as Cursor>::Key<'_>, &[(<B1::Cursor as Cursor>::Val<'_>, <B1::Cursor as Cursor>::Diff)], &mut Vec<(<B2::Cursor as Cursor>::ValOwn, <B2::Cursor as Cursor>::Diff)>, &mut Vec<(<B2::Cursor as Cursor>::ValOwn, <B2::Cursor as Cursor>::Diff)>),
+        P: FnMut(&mut Bu::Input, <B1::Cursor as Cursor>::Key<'_>, &mut Vec<(<B2::Cursor as Cursor>::ValOwn, B1::Time, <B2::Cursor as Cursor>::Diff)>),
+    {
+        fn retire(
             &mut self,
-            key: K,
-            (source_cursor, source_storage): (&mut C1, &'a C1::Storage),
-            (output_cursor, output_storage): (&mut C2, &'a C2::Storage),
-            (batch_cursor, batch_storage): (&mut C3, &'a C3::Storage),
-            times: &Vec<T>,
-            logic: &mut L,
-            upper_limit: &Antichain<T>,
-            outputs: &mut [(T, Vec<(V, T, D2)>)],
-            new_interesting: &mut Vec<T>)
-        where
-            C1: Cursor<Key<'a> = K, Val<'a> = V1, Time = T, Diff = D1>,
-            C2: Cursor<Key<'a> = K, Val<'a> = V2, ValOwn = V, Time = T, Diff = D2>,
-            C3: Cursor<Key<'a> = K, Val<'a> = V1, Time = T, Diff = D1>,
-            K: Copy + Ord,
-            L: FnMut(K, &[(V1, D1)], &mut Vec<(V, D2)>, &mut Vec<(V, D2)>),
+            source_batches: Vec<B1>,
+            output_batches: Vec<B2>,
+            input_batches: Vec<B1>,
+            lower: &Antichain<B1::Time>,
+            upper: &Antichain<B1::Time>,
+            held: &Antichain<B1::Time>,
+        ) -> (Vec<(B1::Time, B2)>, Antichain<B1::Time>)
         {
+            let mut produced = Vec::new();
 
-            // The work we need to perform is at times defined principally by the contents of `batch_cursor`
-            // and `times`, respectively "new work we just received" and "old times we were warned about".
-            //
-            // Our first step is to identify these times, so that we can use them to restrict the amount of
-            // information we need to recover from `input` and `output`; as all times of interest will have
-            // some time from `batch_cursor` or `times`, we can compute their meet and advance all other
-            // loaded times by performing the lattice `join` with this value.
+            // We have compute needs only if we hold a time in the interval [lower, upper); otherwise we
+            // could not transmit outputs even if they were (incorrectly) non-zero, and we leave the held
+            // times unchanged.
+            if held.elements().iter().any(|time| !upper.less_equal(time)) {
 
-            // Load the batch contents.
-            let mut batch_replay = self.batch_history.replay_key(batch_cursor, batch_storage, key, None);
+                // cursors for navigating input, output, and new-batch updates.
+                let (mut source_cursor, ref source_storage) = cursor_list(source_batches);
+                let (mut output_cursor, ref output_storage) = cursor_list(output_batches);
+                let (mut batch_cursor, ref batch_storage) = cursor_list(input_batches);
 
-            // We determine the meet of times we must reconsider (those from `batch` and `times`). This meet
-            // can be used to advance other historical times, which may consolidate their representation. As
-            // a first step, we determine the meets of each *suffix* of `times`, which we will use as we play
-            // history forward.
+                // Prepare an output buffer and builder for each held time.
+                // TODO: It would be better if all updates went into one batch, but timely dataflow prevents
+                //       this as long as it requires that there is only one capability for each message.
+                let mut buffers = Vec::<(B1::Time, Vec<(<B2::Cursor as Cursor>::ValOwn, B1::Time, <B2::Cursor as Cursor>::Diff)>)>::new();
+                let mut builders = Vec::new();
+                for time in held.elements().iter() {
+                    buffers.push((time.clone(), Vec::new()));
+                    builders.push(Bu::new());
+                }
+                // Temporary staging for output building.
+                let mut buffer = Bu::Input::default();
 
-            self.meets.clear();
-            self.meets.extend(times.iter().cloned());
-            for index in (1 .. self.meets.len()).rev() {
-                self.meets[index-1] = self.meets[index-1].meet(&self.meets[index]);
+                // Reuseable state for performing the computation.
+                let mut thinker = history_replay::HistoryReplayer::new();
+
+                // March through the keys we must work on, merging `batch_cursor` and pending keys.
+                // The interesting moments need to be in the interval to prompt work.
+                let mut pending_pos = 0;
+                while batch_cursor.key_valid(batch_storage) || pending_pos < self.pending_keys.len() {
+
+                    // Determine the next key we will work on; could be synthetic, could be from a batch.
+                    let key1 = self.pending_keys.get(pending_pos);
+                    let key2 = batch_cursor.get_key(batch_storage);
+                    let key = match (key1, key2) {
+                        (Some(key1), Some(key2)) => ::std::cmp::min(key1, key2),
+                        (Some(key1), None)       => key1,
+                        (None, Some(key2))       => key2,
+                        (None, None)             => unreachable!(),
+                    };
+
+                    // Populate `interesting_times` with interesting times not beyond `upper`.
+                    // TODO: This could just be `pending_time` and indexes within `lower .. upper`.
+                    let prior_pos = pending_pos;
+                    self.interesting_times.clear();
+                    while self.pending_keys.get(pending_pos) == Some(key) {
+                        let owned_time = <B1::Cursor as Cursor>::owned_time(self.pending_time.index(pending_pos));
+                        if !upper.less_equal(&owned_time) { self.interesting_times.push(owned_time); }
+                        pending_pos += 1;
+                    }
+
+                    // tidy up times, removing redundancy.
+                    sort_dedup(&mut self.interesting_times);
+
+                    // If there are new updates, or pending times, we must investigate!
+                    if batch_cursor.get_key(batch_storage) == Some(key) || !self.interesting_times.is_empty() {
+
+                        // do the per-key computation.
+                        thinker.compute(
+                            key,
+                            (&mut source_cursor, source_storage),
+                            (&mut output_cursor, output_storage),
+                            (&mut batch_cursor, batch_storage),
+                            &self.interesting_times,
+                            &mut self.logic,
+                            upper,
+                            &mut buffers[..],
+                            &mut self.new_interesting_times,
+                        );
+
+                        // Advance the cursor if this key, so that the loop's validity check registers the work as done.
+                        if batch_cursor.get_key(batch_storage) == Some(key) { batch_cursor.step_key(batch_storage); }
+
+                        // Merge novel pending times with any prior pending times we did not process.
+                        // TODO: This could be a merge, not a sort_dedup, because both lists should be sorted.
+                        for pos in prior_pos .. pending_pos {
+                            let owned_time = <B1::Cursor as Cursor>::owned_time(self.pending_time.index(pos));
+                            if upper.less_equal(&owned_time) { self.new_interesting_times.push(owned_time); }
+                        }
+                        sort_dedup(&mut self.new_interesting_times);
+                        for time in self.new_interesting_times.drain(..) {
+                            self.next_pending_keys.push_ref(key);
+                            self.next_pending_time.push_own(&time);
+                        }
+
+                        // Sort each buffer by value and move into the corresponding builder.
+                        // TODO: This makes assumptions about at least one of (i) the stability of `sort_by`,
+                        //       (ii) that the buffers are time-ordered, and (iii) that the builders accept
+                        //       arbitrarily ordered times.
+                        for index in 0 .. buffers.len() {
+                            buffers[index].1.sort_by(|x,y| x.0.cmp(&y.0));
+                            (self.push)(&mut buffer, key, &mut buffers[index].1);
+                            buffers[index].1.clear();
+                            builders[index].push(&mut buffer);
+
+                        }
+                    }
+                    else {
+                        // copy over the pending key and times.
+                        for pos in prior_pos .. pending_pos {
+                            self.next_pending_keys.push_ref(self.pending_keys.index(pos));
+                            self.next_pending_time.push_ref(self.pending_time.index(pos));
+                        }
+                    }
+                }
+                // Drop to avoid lifetime issues that would lock `pending_{keys, time}`.
+                drop(thinker);
+
+                // We start sealing output batches from the lower limit (previous upper limit).
+                // In principle, we could update `lower` itself, and it should arrive at `upper` by the
+                // end of the process.
+                self.output_lower.clear();
+                self.output_lower.extend(lower.borrow().iter().cloned());
+
+                // build each batch (because only one capability per message).
+                for (index, builder) in builders.drain(..).enumerate() {
+
+                    // Form the upper limit of the next batch, which includes all times greater
+                    // than the input batch, or the held times from i + 1 onward.
+                    self.output_upper.clear();
+                    self.output_upper.extend(upper.borrow().iter().cloned());
+                    for time in &held.elements()[index + 1 ..] {
+                        self.output_upper.insert_ref(time);
+                    }
+
+                    if self.output_upper.borrow() != self.output_lower.borrow() {
+
+                        let description = Description::new(self.output_lower.clone(), self.output_upper.clone(), Antichain::from_elem(<B1::Time as Timestamp>::minimum()));
+                        let batch = builder.done(description);
+
+                        // hand the batch back to the driver to ship and commit, tagged with its time.
+                        produced.push((held.elements()[index].clone(), batch));
+
+                        self.output_lower.clear();
+                        self.output_lower.extend(self.output_upper.borrow().iter().cloned());
+                    }
+                }
+                // This should be true, as the final iteration introduces no held times, and
+                // uses exactly `upper` to determine the upper bound. Good to check though.
+                assert!(self.output_upper.borrow() == upper.borrow());
+
+                // Refresh pending keys and times.
+                self.pending_keys.clear(); std::mem::swap(&mut self.next_pending_keys, &mut self.pending_keys);
+                self.pending_time.clear(); std::mem::swap(&mut self.next_pending_time, &mut self.pending_time);
+
+                // Compute the new frontier of interesting times for the operator to hold.
+                let mut frontier = Antichain::<B1::Time>::new();
+                let mut owned_time = <B1::Time as Timestamp>::minimum();
+                for pos in 0 .. self.pending_time.len() {
+                    <B1::Cursor as Cursor>::clone_time_onto(self.pending_time.index(pos), &mut owned_time);
+                    frontier.insert_ref(&owned_time);
+                }
+
+                (produced, frontier)
             }
+            else {
+                // No work: leave the held times unchanged, so the driver's downgrade is a no-op.
+                (produced, held.clone())
+            }
+        }
+    }
 
-            // Determine the meet of times in `batch` and `times`.
-            let mut meet = None;
-            update_meet(&mut meet, self.meets.get(0));
-            update_meet(&mut meet, batch_replay.meet());
 
-            // Having determined the meet, we can load the input and output histories, where we
-            // advance all times by joining them with `meet`. The resulting times are more compact
-            // and guaranteed to accumulate identically for times greater or equal to `meet`.
+    #[inline(never)]
+    fn sort_dedup<T: Ord>(list: &mut Vec<T>) {
+        list.dedup();
+        list.sort();
+        list.dedup();
+    }
 
-            // Load the input and output histories.
-            let mut input_replay =
-            self.input_history.replay_key(source_cursor, source_storage, key, meet.as_ref());
-            let mut output_replay =
-            self.output_history.replay_key(output_cursor, output_storage, key, meet.as_ref());
+    /// Implementation based on replaying historical and new updates together.
+    mod history_replay {
 
-            self.synth_times.clear();
-            self.times_current.clear();
-            self.output_produced.clear();
+        use timely::progress::Antichain;
 
-            // The frontier of times we may still consider.
-            // Derived from frontiers of our update histories, supplied times, and synthetic times.
+        use crate::lattice::Lattice;
+        use crate::trace::Cursor;
+        use crate::operators::ValueHistory;
 
-            let mut times_slice = &times[..];
-            let mut meets_slice = &self.meets[..];
+        use super::sort_dedup;
 
-            // We have candidate times from `batch` and `times`, as well as times identified by either
-            // `input` or `output`. Finally, we may have synthetic times produced as the join of times
-            // we consider in the course of evaluation. As long as any of these times exist, we need to
-            // keep examining times.
-            while let Some(next_time) = [   batch_replay.time(),
-                                            times_slice.first(),
-                                            input_replay.time(),
-                                            output_replay.time(),
-                                            self.synth_times.last(),
-                                        ].into_iter().flatten().min().cloned() {
+        /// The `HistoryReplayer` is a compute strategy based on moving through existing inputs, interesting times, etc in
+        /// time order, maintaining consolidated representations of updates with respect to future interesting times.
+        pub struct HistoryReplayer<V1, V2, V, T, D1, D2> {
+            input_history: ValueHistory<V1, T, D1>,
+            output_history: ValueHistory<V2, T, D2>,
+            batch_history: ValueHistory<V1, T, D1>,
+            input_buffer: Vec<(V1, D1)>,
+            output_buffer: Vec<(V, D2)>,
+            update_buffer: Vec<(V, D2)>,
+            output_produced: Vec<((V, T), D2)>,
+            synth_times: Vec<T>,
+            meets: Vec<T>,
+            times_current: Vec<T>,
+            temporary: Vec<T>,
+        }
 
-                // Advance input and output history replayers. This marks applicable updates as active.
-                input_replay.step_while_time_is(&next_time);
-                output_replay.step_while_time_is(&next_time);
-
-                // One of our goals is to determine if `next_time` is "interesting", meaning whether we
-                // have any evidence that we should re-evaluate the user logic at this time. For a time
-                // to be "interesting" it would need to be the join of times that include either a time
-                // from `batch`, `times`, or `synth`. Neither `input` nor `output` times are sufficient.
-
-                // Advance batch history, and capture whether an update exists at `next_time`.
-                let mut interesting = batch_replay.step_while_time_is(&next_time);
-                if interesting { if let Some(meet) = meet.as_ref() { batch_replay.advance_buffer_by(meet); } }
-
-                // advance both `synth_times` and `times_slice`, marking this time interesting if in either.
-                while self.synth_times.last() == Some(&next_time) {
-                    // We don't know enough about `next_time` to avoid putting it in to `times_current`.
-                    // TODO: If we knew that the time derived from a canceled batch update, we could remove the time.
-                    self.times_current.push(self.synth_times.pop().expect("failed to pop from synth_times")); // <-- TODO: this could be a min-heap.
-                    interesting = true;
+        impl<V1, V2, V, T, D1, D2> HistoryReplayer<V1, V2, V, T, D1, D2>
+        where
+            V1: Copy + Ord,
+            V2: Copy + Ord,
+            V: Clone + Ord,
+            T: Ord + Clone + Lattice,
+            D1: Clone + crate::difference::Semigroup,
+            D2: Clone + crate::difference::Semigroup,
+        {
+            pub fn new() -> Self {
+                HistoryReplayer {
+                    input_history: ValueHistory::new(),
+                    output_history: ValueHistory::new(),
+                    batch_history: ValueHistory::new(),
+                    input_buffer: Vec::new(),
+                    output_buffer: Vec::new(),
+                    update_buffer: Vec::new(),
+                    output_produced: Vec::new(),
+                    synth_times: Vec::new(),
+                    meets: Vec::new(),
+                    times_current: Vec::new(),
+                    temporary: Vec::new(),
                 }
-                while times_slice.first() == Some(&next_time) {
-                    // We know nothing about why we were warned about `next_time`, and must include it to scare future times.
-                    self.times_current.push(times_slice[0].clone());
-                    times_slice = &times_slice[1..];
-                    meets_slice = &meets_slice[1..];
-                    interesting = true;
-                }
+            }
+            #[inline(never)]
+            pub fn compute<'a, K, C1, C2, C3, L>(
+                &mut self,
+                key: K,
+                (source_cursor, source_storage): (&mut C1, &'a C1::Storage),
+                (output_cursor, output_storage): (&mut C2, &'a C2::Storage),
+                (batch_cursor, batch_storage): (&mut C3, &'a C3::Storage),
+                times: &Vec<T>,
+                logic: &mut L,
+                upper_limit: &Antichain<T>,
+                outputs: &mut [(T, Vec<(V, T, D2)>)],
+                new_interesting: &mut Vec<T>)
+            where
+                C1: Cursor<Key<'a> = K, Val<'a> = V1, Time = T, Diff = D1>,
+                C2: Cursor<Key<'a> = K, Val<'a> = V2, ValOwn = V, Time = T, Diff = D2>,
+                C3: Cursor<Key<'a> = K, Val<'a> = V1, Time = T, Diff = D1>,
+                K: Copy + Ord,
+                L: FnMut(K, &[(V1, D1)], &mut Vec<(V, D2)>, &mut Vec<(V, D2)>),
+            {
 
-                // Times could also be interesting if an interesting time is less than them, as they would join
-                // and become the time itself. They may not equal the current time because whatever frontier we
-                // are tracking may not have advanced far enough.
-                // TODO: `batch_history` may or may not be super compact at this point, and so this check might
-                //       yield false positives if not sufficiently compact. Maybe we should look into this and see.
-                interesting = interesting || batch_replay.buffer().iter().any(|&((_, ref t),_)| t.less_equal(&next_time));
-                interesting = interesting || self.times_current.iter().any(|t| t.less_equal(&next_time));
-
-                // We should only process times that are not in advance of `upper_limit`.
+                // The work we need to perform is at times defined principally by the contents of `batch_cursor`
+                // and `times`, respectively "new work we just received" and "old times we were warned about".
                 //
-                // We have no particular guarantee that known times will not be in advance of `upper_limit`.
-                // We may have the guarantee that synthetic times will not be, as we test against the limit
-                // before we add the time to `synth_times`.
-                if !upper_limit.less_equal(&next_time) {
+                // Our first step is to identify these times, so that we can use them to restrict the amount of
+                // information we need to recover from `input` and `output`; as all times of interest will have
+                // some time from `batch_cursor` or `times`, we can compute their meet and advance all other
+                // loaded times by performing the lattice `join` with this value.
 
-                    // We should re-evaluate the computation if this is an interesting time.
-                    // If the time is uninteresting (and our logic is sound) it is not possible for there to be
-                    // output produced. This sounds like a good test to have for debug builds!
-                    if interesting {
+                // Load the batch contents.
+                let mut batch_replay = self.batch_history.replay_key(batch_cursor, batch_storage, key, None);
 
-                        // Assemble the input collection at `next_time`. (`self.input_buffer` cleared just after use).
-                        debug_assert!(self.input_buffer.is_empty());
-                        if let Some(meet) = meet.as_ref() { input_replay.advance_buffer_by(meet) };
-                        for ((value, time), diff) in input_replay.buffer().iter() {
-                            if time.less_equal(&next_time) { self.input_buffer.push((*value, diff.clone())); }
-                            else { self.temporary.push(next_time.join(time)); }
-                        }
-                        for ((value, time), diff) in batch_replay.buffer().iter() {
-                            if time.less_equal(&next_time) { self.input_buffer.push((*value, diff.clone())); }
-                            else { self.temporary.push(next_time.join(time)); }
-                        }
-                        crate::consolidation::consolidate(&mut self.input_buffer);
+                // We determine the meet of times we must reconsider (those from `batch` and `times`). This meet
+                // can be used to advance other historical times, which may consolidate their representation. As
+                // a first step, we determine the meets of each *suffix* of `times`, which we will use as we play
+                // history forward.
 
-                        // Assemble the output collection at `next_time`. (`self.output_buffer` cleared just after use).
-                        if let Some(meet) = meet.as_ref() { output_replay.advance_buffer_by(meet) };
-                        for ((value, time), diff) in output_replay.buffer().iter() {
-                            if time.less_equal(&next_time) { self.output_buffer.push((C2::owned_val(*value), diff.clone())); }
-                            else { self.temporary.push(next_time.join(time)); }
-                        }
-                        for ((value, time), diff) in self.output_produced.iter() {
-                            if time.less_equal(&next_time) { self.output_buffer.push(((*value).to_owned(), diff.clone())); }
-                            else { self.temporary.push(next_time.join(time)); }
-                        }
-                        crate::consolidation::consolidate(&mut self.output_buffer);
+                self.meets.clear();
+                self.meets.extend(times.iter().cloned());
+                for index in (1 .. self.meets.len()).rev() {
+                    self.meets[index-1] = self.meets[index-1].meet(&self.meets[index]);
+                }
 
-                        // Apply user logic if non-empty input or output and see what happens!
-                        if !self.input_buffer.is_empty() || !self.output_buffer.is_empty() {
-                            logic(key, &self.input_buffer[..], &mut self.output_buffer, &mut self.update_buffer);
-                            self.input_buffer.clear();
-                            self.output_buffer.clear();
+                // Determine the meet of times in `batch` and `times`.
+                let mut meet = None;
+                update_meet(&mut meet, self.meets.get(0));
+                update_meet(&mut meet, batch_replay.meet());
 
-                            // Having subtracted output updates from user output, consolidate the results to determine
-                            // if there is anything worth reporting. Note: this also orders the results by value, so
-                            // that could make the above merging plan even easier.
-                            //
-                            // Stash produced updates into both capability-indexed buffers and `output_produced`.
-                            // The two locations are important, in that we will compact `output_produced` as we move
-                            // through times, but we cannot compact the output buffers because we need their actual
-                            // times.
-                            crate::consolidation::consolidate(&mut self.update_buffer);
-                            if !self.update_buffer.is_empty() {
+                // Having determined the meet, we can load the input and output histories, where we
+                // advance all times by joining them with `meet`. The resulting times are more compact
+                // and guaranteed to accumulate identically for times greater or equal to `meet`.
 
-                                // We *should* be able to find a capability for `next_time`. Any thing else would
-                                // indicate a logical error somewhere along the way; either we release a capability
-                                // we should have kept, or we have computed the output incorrectly (or both!)
-                                let idx = outputs.iter().rev().position(|(time, _)| time.less_equal(&next_time));
-                                let idx = outputs.len() - idx.expect("failed to find index") - 1;
-                                for (val, diff) in self.update_buffer.drain(..) {
-                                    self.output_produced.push(((val.clone(), next_time.clone()), diff.clone()));
-                                    outputs[idx].1.push((val, next_time.clone(), diff));
+                // Load the input and output histories.
+                let mut input_replay =
+                self.input_history.replay_key(source_cursor, source_storage, key, meet.as_ref());
+                let mut output_replay =
+                self.output_history.replay_key(output_cursor, output_storage, key, meet.as_ref());
+
+                self.synth_times.clear();
+                self.times_current.clear();
+                self.output_produced.clear();
+
+                // The frontier of times we may still consider.
+                // Derived from frontiers of our update histories, supplied times, and synthetic times.
+
+                let mut times_slice = &times[..];
+                let mut meets_slice = &self.meets[..];
+
+                // We have candidate times from `batch` and `times`, as well as times identified by either
+                // `input` or `output`. Finally, we may have synthetic times produced as the join of times
+                // we consider in the course of evaluation. As long as any of these times exist, we need to
+                // keep examining times.
+                while let Some(next_time) = [   batch_replay.time(),
+                                                times_slice.first(),
+                                                input_replay.time(),
+                                                output_replay.time(),
+                                                self.synth_times.last(),
+                                            ].into_iter().flatten().min().cloned() {
+
+                    // Advance input and output history replayers. This marks applicable updates as active.
+                    input_replay.step_while_time_is(&next_time);
+                    output_replay.step_while_time_is(&next_time);
+
+                    // One of our goals is to determine if `next_time` is "interesting", meaning whether we
+                    // have any evidence that we should re-evaluate the user logic at this time. For a time
+                    // to be "interesting" it would need to be the join of times that include either a time
+                    // from `batch`, `times`, or `synth`. Neither `input` nor `output` times are sufficient.
+
+                    // Advance batch history, and capture whether an update exists at `next_time`.
+                    let mut interesting = batch_replay.step_while_time_is(&next_time);
+                    if interesting { if let Some(meet) = meet.as_ref() { batch_replay.advance_buffer_by(meet); } }
+
+                    // advance both `synth_times` and `times_slice`, marking this time interesting if in either.
+                    while self.synth_times.last() == Some(&next_time) {
+                        // We don't know enough about `next_time` to avoid putting it in to `times_current`.
+                        // TODO: If we knew that the time derived from a canceled batch update, we could remove the time.
+                        self.times_current.push(self.synth_times.pop().expect("failed to pop from synth_times")); // <-- TODO: this could be a min-heap.
+                        interesting = true;
+                    }
+                    while times_slice.first() == Some(&next_time) {
+                        // We know nothing about why we were warned about `next_time`, and must include it to scare future times.
+                        self.times_current.push(times_slice[0].clone());
+                        times_slice = &times_slice[1..];
+                        meets_slice = &meets_slice[1..];
+                        interesting = true;
+                    }
+
+                    // Times could also be interesting if an interesting time is less than them, as they would join
+                    // and become the time itself. They may not equal the current time because whatever frontier we
+                    // are tracking may not have advanced far enough.
+                    // TODO: `batch_history` may or may not be super compact at this point, and so this check might
+                    //       yield false positives if not sufficiently compact. Maybe we should look into this and see.
+                    interesting = interesting || batch_replay.buffer().iter().any(|&((_, ref t),_)| t.less_equal(&next_time));
+                    interesting = interesting || self.times_current.iter().any(|t| t.less_equal(&next_time));
+
+                    // We should only process times that are not in advance of `upper_limit`.
+                    //
+                    // We have no particular guarantee that known times will not be in advance of `upper_limit`.
+                    // We may have the guarantee that synthetic times will not be, as we test against the limit
+                    // before we add the time to `synth_times`.
+                    if !upper_limit.less_equal(&next_time) {
+
+                        // We should re-evaluate the computation if this is an interesting time.
+                        // If the time is uninteresting (and our logic is sound) it is not possible for there to be
+                        // output produced. This sounds like a good test to have for debug builds!
+                        if interesting {
+
+                            // Assemble the input collection at `next_time`. (`self.input_buffer` cleared just after use).
+                            debug_assert!(self.input_buffer.is_empty());
+                            if let Some(meet) = meet.as_ref() { input_replay.advance_buffer_by(meet) };
+                            for ((value, time), diff) in input_replay.buffer().iter() {
+                                if time.less_equal(&next_time) { self.input_buffer.push((*value, diff.clone())); }
+                                else { self.temporary.push(next_time.join(time)); }
+                            }
+                            for ((value, time), diff) in batch_replay.buffer().iter() {
+                                if time.less_equal(&next_time) { self.input_buffer.push((*value, diff.clone())); }
+                                else { self.temporary.push(next_time.join(time)); }
+                            }
+                            crate::consolidation::consolidate(&mut self.input_buffer);
+
+                            // Assemble the output collection at `next_time`. (`self.output_buffer` cleared just after use).
+                            if let Some(meet) = meet.as_ref() { output_replay.advance_buffer_by(meet) };
+                            for ((value, time), diff) in output_replay.buffer().iter() {
+                                if time.less_equal(&next_time) { self.output_buffer.push((C2::owned_val(*value), diff.clone())); }
+                                else { self.temporary.push(next_time.join(time)); }
+                            }
+                            for ((value, time), diff) in self.output_produced.iter() {
+                                if time.less_equal(&next_time) { self.output_buffer.push(((*value).to_owned(), diff.clone())); }
+                                else { self.temporary.push(next_time.join(time)); }
+                            }
+                            crate::consolidation::consolidate(&mut self.output_buffer);
+
+                            // Apply user logic if non-empty input or output and see what happens!
+                            if !self.input_buffer.is_empty() || !self.output_buffer.is_empty() {
+                                logic(key, &self.input_buffer[..], &mut self.output_buffer, &mut self.update_buffer);
+                                self.input_buffer.clear();
+                                self.output_buffer.clear();
+
+                                // Having subtracted output updates from user output, consolidate the results to determine
+                                // if there is anything worth reporting. Note: this also orders the results by value, so
+                                // that could make the above merging plan even easier.
+                                //
+                                // Stash produced updates into both capability-indexed buffers and `output_produced`.
+                                // The two locations are important, in that we will compact `output_produced` as we move
+                                // through times, but we cannot compact the output buffers because we need their actual
+                                // times.
+                                crate::consolidation::consolidate(&mut self.update_buffer);
+                                if !self.update_buffer.is_empty() {
+
+                                    // We *should* be able to find a capability for `next_time`. Any thing else would
+                                    // indicate a logical error somewhere along the way; either we release a capability
+                                    // we should have kept, or we have computed the output incorrectly (or both!)
+                                    let idx = outputs.iter().rev().position(|(time, _)| time.less_equal(&next_time));
+                                    let idx = outputs.len() - idx.expect("failed to find index") - 1;
+                                    for (val, diff) in self.update_buffer.drain(..) {
+                                        self.output_produced.push(((val.clone(), next_time.clone()), diff.clone()));
+                                        outputs[idx].1.push((val, next_time.clone(), diff));
+                                    }
+
+                                    // Advance times in `self.output_produced` and consolidate the representation.
+                                    // NOTE: We only do this when we add records; it could be that there are situations
+                                    //       where we want to consolidate even without changes (because an initially
+                                    //       large collection can now be collapsed).
+                                    if let Some(meet) = meet.as_ref() { for entry in &mut self.output_produced { (entry.0).1.join_assign(meet); } }
+                                    crate::consolidation::consolidate(&mut self.output_produced);
                                 }
-
-                                // Advance times in `self.output_produced` and consolidate the representation.
-                                // NOTE: We only do this when we add records; it could be that there are situations
-                                //       where we want to consolidate even without changes (because an initially
-                                //       large collection can now be collapsed).
-                                if let Some(meet) = meet.as_ref() { for entry in &mut self.output_produced { (entry.0).1.join_assign(meet); } }
-                                crate::consolidation::consolidate(&mut self.output_produced);
                             }
                         }
-                    }
 
-                    // Determine synthetic interesting times.
-                    //
-                    // Synthetic interesting times are produced differently for interesting and uninteresting
-                    // times. An uninteresting time must join with an interesting time to become interesting,
-                    // which means joins with `self.batch_history` and  `self.times_current`. I think we can
-                    // skip `self.synth_times` as we haven't gotten to them yet, but we will and they will be
-                    // joined against everything.
+                        // Determine synthetic interesting times.
+                        //
+                        // Synthetic interesting times are produced differently for interesting and uninteresting
+                        // times. An uninteresting time must join with an interesting time to become interesting,
+                        // which means joins with `self.batch_history` and  `self.times_current`. I think we can
+                        // skip `self.synth_times` as we haven't gotten to them yet, but we will and they will be
+                        // joined against everything.
 
-                    // Any time, even uninteresting times, must be joined with the current accumulation of
-                    // batch times as well as the current accumulation of `times_current`.
-                    self.temporary.extend(batch_replay.buffer().iter().map(|((_,time),_)| time).filter(|time| !time.less_equal(&next_time)).map(|time| time.join(&next_time)));
-                    self.temporary.extend(self.times_current.iter().filter(|time| !time.less_equal(&next_time)).map(|time| time.join(&next_time)));
-                    sort_dedup(&mut self.temporary);
+                        // Any time, even uninteresting times, must be joined with the current accumulation of
+                        // batch times as well as the current accumulation of `times_current`.
+                        self.temporary.extend(batch_replay.buffer().iter().map(|((_,time),_)| time).filter(|time| !time.less_equal(&next_time)).map(|time| time.join(&next_time)));
+                        self.temporary.extend(self.times_current.iter().filter(|time| !time.less_equal(&next_time)).map(|time| time.join(&next_time)));
+                        sort_dedup(&mut self.temporary);
 
-                    // Introduce synthetic times, and re-organize if we add any.
-                    let synth_len = self.synth_times.len();
-                    for time in self.temporary.drain(..) {
-                        // We can either service `join` now, or must delay for the future.
-                        if upper_limit.less_equal(&time) {
-                            debug_assert!(outputs.iter().any(|(t,_)| t.less_equal(&time)));
-                            new_interesting.push(time);
+                        // Introduce synthetic times, and re-organize if we add any.
+                        let synth_len = self.synth_times.len();
+                        for time in self.temporary.drain(..) {
+                            // We can either service `join` now, or must delay for the future.
+                            if upper_limit.less_equal(&time) {
+                                debug_assert!(outputs.iter().any(|(t,_)| t.less_equal(&time)));
+                                new_interesting.push(time);
+                            }
+                            else {
+                                self.synth_times.push(time);
+                            }
                         }
-                        else {
-                            self.synth_times.push(time);
+                        if self.synth_times.len() > synth_len {
+                            self.synth_times.sort_by(|x,y| y.cmp(x));
+                            self.synth_times.dedup();
                         }
                     }
-                    if self.synth_times.len() > synth_len {
-                        self.synth_times.sort_by(|x,y| y.cmp(x));
-                        self.synth_times.dedup();
+                    else if interesting {
+                        // We cannot process `next_time` now, and must delay it.
+                        //
+                        // I think we are probably only here because of an uninteresting time declared interesting,
+                        // as initial interesting times are filtered to be in interval, and synthetic times are also
+                        // filtered before introducing them to `self.synth_times`.
+                        new_interesting.push(next_time.clone());
+                        debug_assert!(outputs.iter().any(|(t,_)| t.less_equal(&next_time)))
                     }
-                }
-                else if interesting {
-                    // We cannot process `next_time` now, and must delay it.
-                    //
-                    // I think we are probably only here because of an uninteresting time declared interesting,
-                    // as initial interesting times are filtered to be in interval, and synthetic times are also
-                    // filtered before introducing them to `self.synth_times`.
-                    new_interesting.push(next_time.clone());
-                    debug_assert!(outputs.iter().any(|(t,_)| t.less_equal(&next_time)))
-                }
 
-                // Update `meet` to track the meet of each source of times.
-                meet = None;
-                update_meet(&mut meet, batch_replay.meet());
-                update_meet(&mut meet, input_replay.meet());
-                update_meet(&mut meet, output_replay.meet());
-                for time in self.synth_times.iter() { update_meet(&mut meet, Some(time)); }
-                update_meet(&mut meet, meets_slice.first());
+                    // Update `meet` to track the meet of each source of times.
+                    meet = None;
+                    update_meet(&mut meet, batch_replay.meet());
+                    update_meet(&mut meet, input_replay.meet());
+                    update_meet(&mut meet, output_replay.meet());
+                    for time in self.synth_times.iter() { update_meet(&mut meet, Some(time)); }
+                    update_meet(&mut meet, meets_slice.first());
 
-                // Update `times_current` by the frontier.
-                if let Some(meet) = meet.as_ref() {
-                    for time in self.times_current.iter_mut() {
-                        *time = time.join(meet);
+                    // Update `times_current` by the frontier.
+                    if let Some(meet) = meet.as_ref() {
+                        for time in self.times_current.iter_mut() {
+                            *time = time.join(meet);
+                        }
                     }
+
+                    sort_dedup(&mut self.times_current);
                 }
 
-                sort_dedup(&mut self.times_current);
+                // Normalize the representation of `new_interesting`, deduplicating and ordering.
+                sort_dedup(new_interesting);
             }
-
-            // Normalize the representation of `new_interesting`, deduplicating and ordering.
-            sort_dedup(new_interesting);
         }
-    }
 
-    /// Updates an optional meet by an optional time.
-    fn update_meet<T: Lattice+Clone>(meet: &mut Option<T>, other: Option<&T>) {
-        if let Some(time) = other {
-            if let Some(meet) = meet.as_mut() { meet.meet_assign(time); }
-            else { *meet = Some(time.clone()); }
+        /// Updates an optional meet by an optional time.
+        fn update_meet<T: Lattice+Clone>(meet: &mut Option<T>, other: Option<&T>) {
+            if let Some(time) = other {
+                if let Some(meet) = meet.as_mut() { meet.meet_assign(time); }
+                else { *meet = Some(time.clone()); }
+            }
         }
     }
 }

--- a/differential-dataflow/src/trace/cursor/cursor_list.rs
+++ b/differential-dataflow/src/trace/cursor/cursor_list.rs
@@ -40,21 +40,27 @@ impl<C: Cursor> CursorList<C> {
         self.min_key.clear();
 
         // We'll visit each non-`None` key, maintaining the indexes of the least keys in `self.min_key`.
-        let mut iter = self.cursors.iter().enumerate().flat_map(|(idx, cur)| cur.get_key(&storage[idx]).map(|key| (idx, key)));
-        if let Some((idx, key)) = iter.next() {
-            let mut min_key = key;
-            self.min_key.push(idx);
-            for (idx, key) in iter {
-                match key.cmp(&min_key) {
-                    std::cmp::Ordering::Less => {
-                        self.min_key.clear();
+        // An explicit min-tracking loop rather than `flat_map`: the adapter's inner `next` fails to
+        // inline in hot callers (e.g. reduce's per-key replay) and surfaces as a hot `FlattenCompat::next`.
+        let mut min_key = None;
+        for (idx, cursor) in self.cursors.iter().enumerate() {
+            if let Some(key) = cursor.get_key(&storage[idx]) {
+                match min_key {
+                    None => {
                         self.min_key.push(idx);
-                        min_key = key;
+                        min_key = Some(key);
                     }
-                    std::cmp::Ordering::Equal => {
-                        self.min_key.push(idx);
+                    Some(min) => match key.cmp(&min) {
+                        std::cmp::Ordering::Less => {
+                            self.min_key.clear();
+                            self.min_key.push(idx);
+                            min_key = Some(key);
+                        }
+                        std::cmp::Ordering::Equal => {
+                            self.min_key.push(idx);
+                        }
+                        std::cmp::Ordering::Greater => { }
                     }
-                    std::cmp::Ordering::Greater => { }
                 }
             }
         }
@@ -73,21 +79,26 @@ impl<C: Cursor> CursorList<C> {
         self.min_val.clear();
 
         // We'll visit each non-`None` value, maintaining the indexes of the least values in `self.min_val`.
-        let mut iter = self.min_key.iter().cloned().flat_map(|idx| self.cursors[idx].get_val(&storage[idx]).map(|val| (idx, val)));
-        if let Some((idx, val)) = iter.next() {
-            let mut min_val = val;
-            self.min_val.push(idx);
-            for (idx, val) in iter {
-                match val.cmp(&min_val) {
-                    std::cmp::Ordering::Less => {
-                        self.min_val.clear();
+        // Explicit loop rather than `flat_map`, for the inlining reason noted in `minimize_keys`.
+        let mut min_val = None;
+        for idx in self.min_key.iter().cloned() {
+            if let Some(val) = self.cursors[idx].get_val(&storage[idx]) {
+                match min_val {
+                    None => {
                         self.min_val.push(idx);
-                        min_val = val;
+                        min_val = Some(val);
                     }
-                    std::cmp::Ordering::Equal => {
-                        self.min_val.push(idx);
+                    Some(min) => match val.cmp(&min) {
+                        std::cmp::Ordering::Less => {
+                            self.min_val.clear();
+                            self.min_val.push(idx);
+                            min_val = Some(val);
+                        }
+                        std::cmp::Ordering::Equal => {
+                            self.min_val.push(idx);
+                        }
+                        std::cmp::Ordering::Greater => { }
                     }
-                    std::cmp::Ordering::Greater => { }
                 }
             }
         }

--- a/differential-dataflow/src/trace/cursor/mod.rs
+++ b/differential-dataflow/src/trace/cursor/mod.rs
@@ -18,7 +18,7 @@ use crate::trace::implementations::containers::BatchContainer;
 ///
 /// This is the entry point for accessing batch data through cursors, and the place that opinions
 /// about keys and values are introduced (via the `Cursor` associated type). Cut-and-merge assembly
-/// is the trace's concern: [`TraceReader::cursor_storage`](crate::trace::TraceReader::cursor_storage)
+/// is the trace's concern: [`TraceReader::batches_through`](crate::trace::TraceReader::batches_through)
 /// selects the batches and the defaulted
 /// [`TraceReader::cursor_through`](crate::trace::TraceReader::cursor_through) builds a [`CursorList`]
 /// over their per-batch cursors.

--- a/differential-dataflow/src/trace/implementations/spine_fueled.rs
+++ b/differential-dataflow/src/trace/implementations/spine_fueled.rs
@@ -102,7 +102,7 @@ impl<B: Batch+Clone+'static> TraceReader for Spine<B> {
     type Time = B::Time;
     type Batch = B;
 
-    fn cursor_storage(&mut self, upper: AntichainRef<Self::Time>) -> Option<Vec<Self::Batch>> {
+    fn batches_through(&mut self, upper: AntichainRef<Self::Time>) -> Option<Vec<Self::Batch>> {
 
         // If `upper` is the minimum frontier, we can return an empty cursor.
         // This can happen with operators that are written to expect the ability to acquire cursors

--- a/differential-dataflow/src/trace/mod.rs
+++ b/differential-dataflow/src/trace/mod.rs
@@ -47,18 +47,18 @@ pub trait TraceReader {
         Clone +
         BatchReader<Time = Self::Time>;
 
-    /// Acquires the non-empty sequence of batches a cursor would draw from, restricted to updates
-    /// at times not greater or equal to an element of `upper`.
+    /// Acquires the non-empty sequence of batches covering updates at times not greater or equal to an
+    /// element of `upper`.
     ///
     /// This is the sole primitive each `TraceReader` must implement to expose its contents: the
-    /// `cursor` and `cursor_through` methods assemble a [`CursorList`] over these batches' cursors.
-    /// The returned `Vec` plays the role of the cursor's storage (the cursor borrows from it).
+    /// `cursor` and `cursor_through` methods assemble a [`CursorList`] over these batches' cursors,
+    /// for which the returned `Vec` serves as storage (the cursor borrows from it).
     ///
     /// This method is expected to work if called with an `upper` that (i) was an observed bound in batches from
     /// the trace, and (ii) the trace has not been advanced beyond `upper`. Practically, the implementation should
     /// be expected to look for a "clean cut" using `upper`, and if it finds such a cut can return the batches. This
     /// should allow `upper` such as `&[]` as used by `self.cursor()`, though it is difficult to imagine other uses.
-    fn cursor_storage(&mut self, upper: AntichainRef<Self::Time>) -> Option<Vec<Self::Batch>>;
+    fn batches_through(&mut self, upper: AntichainRef<Self::Time>) -> Option<Vec<Self::Batch>>;
 
     /// Provides a cursor over updates contained in the trace.
     fn cursor(&mut self) -> (CursorList<<Self::Batch as Navigable>::Cursor>, Vec<Self::Batch>) where Self::Batch: Navigable {
@@ -74,9 +74,9 @@ pub trait TraceReader {
     /// equal to an element of `upper`.
     ///
     /// The cursor is a [`CursorList`] that merges the cursors of the batches returned by
-    /// [`cursor_storage`](TraceReader::cursor_storage); see that method for the contract on `upper`.
+    /// [`batches_through`](TraceReader::batches_through); see that method for the contract on `upper`.
     fn cursor_through(&mut self, upper: AntichainRef<Self::Time>) -> Option<(CursorList<<Self::Batch as Navigable>::Cursor>, Vec<Self::Batch>)> where Self::Batch: Navigable {
-        Some(self::cursor::cursor_list(self.cursor_storage(upper)?))
+        Some(self::cursor::cursor_list(self.batches_through(upper)?))
     }
 
     /// Advances the frontier that constrains logical compaction.

--- a/differential-dataflow/src/trace/wrappers/enter.rs
+++ b/differential-dataflow/src/trace/wrappers/enter.rs
@@ -69,12 +69,12 @@ where
         self.stash2.borrow()
     }
 
-    fn cursor_storage(&mut self, upper: AntichainRef<TInner>) -> Option<Vec<Self::Batch>> {
+    fn batches_through(&mut self, upper: AntichainRef<TInner>) -> Option<Vec<Self::Batch>> {
         self.stash1.clear();
         for time in upper.iter() {
             self.stash1.insert(time.clone().to_outer());
         }
-        let storage = self.trace.cursor_storage(self.stash1.borrow())?;
+        let storage = self.trace.batches_through(self.stash1.borrow())?;
         Some(storage.into_iter().map(|batch| BatchEnter::make_from(batch)).collect())
     }
 }

--- a/differential-dataflow/src/trace/wrappers/enter_at.rs
+++ b/differential-dataflow/src/trace/wrappers/enter_at.rs
@@ -88,13 +88,13 @@ where
         self.stash2.borrow()
     }
 
-    fn cursor_storage(&mut self, upper: AntichainRef<TInner>) -> Option<Vec<Self::Batch>> {
+    fn batches_through(&mut self, upper: AntichainRef<TInner>) -> Option<Vec<Self::Batch>> {
         self.stash1.clear();
         for time in upper.iter() {
             self.stash1.insert(time.clone().to_outer());
         }
         let logic = self.logic.clone();
-        let storage = self.trace.cursor_storage(self.stash1.borrow())?;
+        let storage = self.trace.batches_through(self.stash1.borrow())?;
         Some(storage.into_iter().map(|batch| BatchEnter::make_from(batch, logic.clone())).collect())
     }
 }

--- a/differential-dataflow/src/trace/wrappers/frontier.rs
+++ b/differential-dataflow/src/trace/wrappers/frontier.rs
@@ -48,8 +48,8 @@ impl<Tr: TraceReader> TraceReader for TraceFrontier<Tr> {
     fn set_physical_compaction(&mut self, frontier: AntichainRef<'_, Tr::Time>) { self.trace.set_physical_compaction(frontier) }
     fn get_physical_compaction(&mut self) -> AntichainRef<'_, Tr::Time> { self.trace.get_physical_compaction() }
 
-    fn cursor_storage(&mut self, upper: AntichainRef<'_, Tr::Time>) -> Option<Vec<Self::Batch>> {
-        let storage = self.trace.cursor_storage(upper)?;
+    fn batches_through(&mut self, upper: AntichainRef<'_, Tr::Time>) -> Option<Vec<Self::Batch>> {
+        let storage = self.trace.batches_through(upper)?;
         let since = self.since.borrow();
         let until = self.until.borrow();
         Some(storage.into_iter().map(|batch| BatchFrontier::make_from(batch, since, until)).collect())


### PR DESCRIPTION
## Summary

Generalizes `join` and `reduce` so each depends only on a pluggable *tactic*, with cursor-based navigation as one tactic rather than the blessed mechanism.

Builds on #771 and #772 (cursor-optional `Trace`/`Batch`), so it targets `master-next`.

### Join (`695253a7`)

`join_traces` splits into a general driver, `join_with_tactic`, that needs only `TraceReader` of its inputs, and a `JoinTactic` trait that resolves the per-batch work.
The conventional cursor-based implementation, `CursorTactic`, becomes one tactic in a private `mod cursors`.
The driver extracts batches via the navigation-free `TraceReader::batches_through` (renamed from `cursor_storage`), so building and walking cursors is the tactic's concern.
A `Fresh` marker names the freshly-arrived input; it selects the accumulated side to advance by `meet` and routes the unit to one of two per-direction queues, preserving the fairness that keeps a burst on one input from starving the other.

### Reduce (`5ae94076`)

The same shape: `reduce_with_tactic` is the navigation-free driver, `ReduceTactic` the trait, `CursorTactic` the implementor in `mod cursors`.
Reduce does not suspend: its output is at most linear in its input, so one `retire` runs the whole interval to completion (no fuel, no queue).
Capabilities stay with the operator and out of the trait — `retire` is handed the frontier of held times and returns output batches tagged with their times plus the new frontier of interesting times; the driver mints capabilities, ships, and downgrades.

Both `JoinTactic` and `ReduceTactic` are object-safe, so a non-cursor tactic could be boxed and selected at runtime.

## Tests

`cargo build --workspace` and `cargo test -p differential-dataflow` are clean; `join`, `reduce`, and `scc` suites pass; the `bfs` example runs clean across update rounds.

## Open for review

- `reduce` adds a `Bu: 'static` bound to `reduce_abelian`/`reduce_core` (the cursor tactic carries the builder type to call its constructor). It is additive and every concrete builder satisfies it, but it is Mz-facing.
- The tactic traits and drivers are `pub`; tightening to `pub(crate)` until a non-cursor consumer exists is an open call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)