### PR TITLE
One `Batcher` trait, shaped like the one half_join had to write

### DIFF
--- a/differential-dataflow/examples/columnar/main.rs
+++ b/differential-dataflow/examples/columnar/main.rs
@@ -129,17 +129,17 @@ mod reachability {
 
             let edges_arr = arrange_core::<_, _,
                 ValChunker<(Node, Node, IterTime, Diff)>,
-                ValBatcher<Node, Node, IterTime, Diff>,
+                _,
                 ValBuilder<Node, Node, IterTime, Diff>,
                 ValSpine<Node, Node, IterTime, Diff>,
-            >(edges_inner.inner, edges_pact, "Edges");
+            >(edges_inner.inner, edges_pact, "Edges", ValBatcher::new);
 
             let reach_arr = arrange_core::<_, _,
                 ValChunker<(Node, (), IterTime, Diff)>,
-                ValBatcher<Node, (), IterTime, Diff>,
+                _,
                 ValBuilder<Node, (), IterTime, Diff>,
                 ValSpine<Node, (), IterTime, Diff>,
-            >(reach.inner, reach_pact, "Reach");
+            >(reach.inner, reach_pact, "Reach", ValBatcher::new);
 
             // join_traces with ValColBuilder: produces Stream<_, RecordedUpdates<...>>.
             let proposed =
@@ -162,10 +162,10 @@ mod reachability {
             let combined_pact = ValPact { hashfunc: |k: columnar::Ref<'_, Node>| *k as u64 };
             let combined_arr = arrange_core::<_, _,
                 ValChunker<(Node, (), IterTime, Diff)>,
-                ValBatcher<Node, (), IterTime, Diff>,
+                _,
                 ValBuilder<Node, (), IterTime, Diff>,
                 ValSpine<Node, (), IterTime, Diff>,
-            >(combined.inner, combined_pact, "Combined");
+            >(combined.inner, combined_pact, "Combined", ValBatcher::new);
 
             // reduce_abelian on the columnar arrangement.
             let result = combined_arr.reduce_abelian::<_,

--- a/differential-dataflow/examples/columnar_spill.rs
+++ b/differential-dataflow/examples/columnar_spill.rs
@@ -239,10 +239,10 @@ fn run_timely_dataflow(times: u64, keys_per_time: u64, workers: usize, sample_se
             let arranged = arrange_core::<
                 _, _,
                 ValChunker<(u64, u64, u64, i64)>,
-                ValBatcher<u64, u64, u64, i64>,
+                _,
                 ValBuilder<u64, u64, u64, i64>,
                 ValSpine<u64, u64, u64, i64>,
-            >(stream, Pipeline, "ColumnarSpillArrange");
+            >(stream, Pipeline, "ColumnarSpillArrange", ValBatcher::new);
             arranged.stream.probe_with(&mut probe);
         });
 

--- a/differential-dataflow/examples/spines.rs
+++ b/differential-dataflow/examples/spines.rs
@@ -58,8 +58,8 @@ fn main() {
                     use differential_dataflow::trace::implementations::ord_neu::{OrdKeyBatcher, VecOrdKeyBuilder, OrdKeySpine};
                     let (data_input, data) = scope.new_collection::<String, isize>();
                     let (keys_input, keys) = scope.new_collection::<String, isize>();
-                    let data = data.map(|k| (k, ())).arrange::<OrdKeyBatcher<String,_,isize>, VecOrdKeyBuilder<String,_,isize>, OrdKeySpine<String,_,isize>>();
-                    let keys = keys.map(|k| (k, ())).arrange::<OrdKeyBatcher<String,_,isize>, VecOrdKeyBuilder<String,_,isize>, OrdKeySpine<String,_,isize>>();
+                    let data = data.map(|k| (k, ())).arrange::<_, VecOrdKeyBuilder<String,_,isize>, OrdKeySpine<String,_,isize>>(OrdKeyBatcher::new);
+                    let keys = keys.map(|k| (k, ())).arrange::<_, VecOrdKeyBuilder<String,_,isize>, OrdKeySpine<String,_,isize>>(OrdKeyBatcher::new);
                     keys.join_core(data, |_k, &(), &()| Option::<()>::None)
                         .probe_with(&mut probe);
                     Workload { data_input, keys_input }
@@ -68,8 +68,8 @@ fn main() {
                     use differential_dataflow::trace::implementations::ord_neu::{OrdValBatcher, VecOrdValBuilder, OrdValSpine};
                     let (data_input, data) = scope.new_collection::<String, isize>();
                     let (keys_input, keys) = scope.new_collection::<String, isize>();
-                    let data = data.map(|x| (x, ())).arrange::<OrdValBatcher<String,(),_,isize>, VecOrdValBuilder<String,(),_,isize>, OrdValSpine<String,(),_,isize>>();
-                    let keys = keys.map(|x| (x, ())).arrange::<OrdValBatcher<String,(),_,isize>, VecOrdValBuilder<String,(),_,isize>, OrdValSpine<String,(),_,isize>>();
+                    let data = data.map(|x| (x, ())).arrange::<_, VecOrdValBuilder<String,(),_,isize>, OrdValSpine<String,(),_,isize>>(OrdValBatcher::new);
+                    let keys = keys.map(|x| (x, ())).arrange::<_, VecOrdValBuilder<String,(),_,isize>, OrdValSpine<String,(),_,isize>>(OrdValBatcher::new);
                     keys.join_core(data, |_k, &(), &()| Option::<()>::None)
                         .probe_with(&mut probe);
                     Workload { data_input, keys_input }
@@ -94,8 +94,8 @@ fn main() {
                     type Sp = Spine<String, (), u64, isize>;
                     type Chu = ContainerChunker<ColChunk<(String, (), u64, isize)>>;
                     let exchange = || Exchange::new(|u: &((String, ()), u64, isize)| (u.0).0.hashed().into());
-                    let data = arrange_core::<_, _, Chu, Ba, Bu, Sp>(data.inner, exchange(), "DataArrange");
-                    let keys = arrange_core::<_, _, Chu, Ba, Bu, Sp>(keys.inner, exchange(), "KeysArrange");
+                    let data = arrange_core::<_, _, Chu, Ba, Bu, Sp>(data.inner, exchange(), "DataArrange", Ba::new);
+                    let keys = arrange_core::<_, _, Chu, Ba, Bu, Sp>(keys.inner, exchange(), "KeysArrange", Ba::new);
                     // `ColChunk`'s cursor yields `Val = columnar::Ref<()> = ()`, not `&()`.
                     keys.join_core(data, |_k, _, _| Option::<()>::None)
                         .probe_with(&mut probe);
@@ -121,8 +121,8 @@ fn main() {
                     type Sp = ChunkSpine<String, (), u64, isize>;
                     type Chu = ContainerChunker<VecChunk<String, (), u64, isize>>;
                     let exchange = || Exchange::new(|u: &((String, ()), u64, isize)| (u.0).0.hashed().into());
-                    let data = arrange_core::<_, _, Chu, Ba, Bu, Sp>(data.inner, exchange(), "DataArrange");
-                    let keys = arrange_core::<_, _, Chu, Ba, Bu, Sp>(keys.inner, exchange(), "KeysArrange");
+                    let data = arrange_core::<_, _, Chu, Ba, Bu, Sp>(data.inner, exchange(), "DataArrange", Ba::new);
+                    let keys = arrange_core::<_, _, Chu, Ba, Bu, Sp>(keys.inner, exchange(), "KeysArrange", Ba::new);
                     keys.join_core(data, |_k, &(), &()| Option::<()>::None)
                         .probe_with(&mut probe);
                     Workload { data_input, keys_input }

--- a/differential-dataflow/src/collection.rs
+++ b/differential-dataflow/src/collection.rs
@@ -958,21 +958,21 @@ pub mod vec {
         /// ```
         pub fn consolidate(self) -> Self {
             use crate::trace::implementations::{KeyBatcher, KeyBuilder, KeySpine};
-            self.consolidate_named::<KeyBatcher<_, _, _>,KeyBuilder<_,_,_>, KeySpine<_,_,_>,_>("Consolidate", |key,&()| key.clone())
+            self.consolidate_named::<_,KeyBuilder<_,_,_>, KeySpine<_,_,_>,_>("Consolidate", KeyBatcher::new, |key,&()| key.clone())
         }
 
         /// As `consolidate` but with the ability to name the operator, specify the trace type,
         /// and provide the function `reify` to produce owned keys and values..
-        pub fn consolidate_named<Ba, Bu, Tr, F>(self, name: &str, reify: F) -> Self
+        pub fn consolidate_named<Ba, Bu, Tr, F>(self, name: &str, batcher: impl FnOnce(Option<crate::logging::Logger>, usize) -> Ba, reify: F) -> Self
         where
-            Ba: crate::trace::Batcher<Output=Vec<((D, ()), T, R)>, Time=T> + 'static,
+            Ba: crate::trace::Batcher<T, Vec<((D, ()), T, R)>, Vec<Vec<((D, ()), T, R)>>> + 'static,
             Tr: crate::trace::Trace<Batch: Navigable, Time=T>+'static,
             for<'a> BatchCursor<Tr>: Cursor<Time=Tr::Time, Diff=R>,
             Bu: crate::trace::Builder<Time=Tr::Time, Input=Vec<((D, ()), T, R)>, Output: Into<Tr::Batch>>,
             F: Fn(BatchKey<'_, Tr>, BatchVal<'_, Tr>) -> D + 'static,
         {
             self.map(|k| (k, ()))
-                .arrange_named::<Ba, Bu, Tr>(name)
+                .arrange_named::<Ba, Bu, Tr>(name, batcher)
                 .as_collection(reify)
         }
 
@@ -1032,28 +1032,28 @@ pub mod vec {
     {
         /// Arranges updates into a shared trace, exchanged by a hash of the key.
         ///
-        /// The batcher's output container must equal the stream container; the default chunker
-        /// only consolidates same-type containers. For chunker setups that convert between
-        /// container types (e.g. columnar layouts), call
-        /// [`arrange_core`](crate::operators::arrange::arrangement::arrange_core) directly.
-        pub fn arrange<Ba, Bu, Tr>(self) -> Arranged<'scope, TraceAgent<Tr>>
+        /// The batcher must accept the stream container; the default chunker only consolidates
+        /// same-type containers. For chunker setups that convert between container types (e.g.
+        /// columnar layouts), call [`arrange_core`](crate::operators::arrange::arrangement::arrange_core)
+        /// directly.
+        pub fn arrange<Ba, Bu, Tr>(self, batcher: impl FnOnce(Option<crate::logging::Logger>, usize) -> Ba) -> Arranged<'scope, TraceAgent<Tr>>
         where
-            Ba: crate::trace::Batcher<Output=Vec<((K, V), T, R)>, Time=T> + 'static,
-            Bu: crate::trace::Builder<Time=T, Input=Vec<((K, V), T, R)>, Output: Into<Tr::Batch>>,
+            Ba: crate::trace::Batcher<T, Vec<((K, V), T, R)>, Vec<Bu::Input>> + 'static,
+            Bu: crate::trace::Builder<Time=T, Output: Into<Tr::Batch>>,
             Tr: crate::trace::Trace<Time=T> + 'static,
         {
-            self.arrange_named::<Ba, Bu, Tr>("Arrange")
+            self.arrange_named::<Ba, Bu, Tr>("Arrange", batcher)
         }
 
         /// As [`Collection::arrange`] but with the ability to name the operator.
-        pub fn arrange_named<Ba, Bu, Tr>(self, name: &str) -> Arranged<'scope, TraceAgent<Tr>>
+        pub fn arrange_named<Ba, Bu, Tr>(self, name: &str, batcher: impl FnOnce(Option<crate::logging::Logger>, usize) -> Ba) -> Arranged<'scope, TraceAgent<Tr>>
         where
-            Ba: crate::trace::Batcher<Output=Vec<((K, V), T, R)>, Time=T> + 'static,
-            Bu: crate::trace::Builder<Time=T, Input=Vec<((K, V), T, R)>, Output: Into<Tr::Batch>>,
+            Ba: crate::trace::Batcher<T, Vec<((K, V), T, R)>, Vec<Bu::Input>> + 'static,
+            Bu: crate::trace::Builder<Time=T, Output: Into<Tr::Batch>>,
             Tr: crate::trace::Trace<Time=T> + 'static,
         {
             let exchange = timely::dataflow::channels::pact::Exchange::new(move |update: &((K,V),T,R)| (update.0).0.hashed().into());
-            crate::operators::arrange::arrangement::arrange_core::<_, _, ContainerChunker<Vec<((K, V), T, R)>>, Ba, Bu, _>(self.inner, exchange, name)
+            crate::operators::arrange::arrangement::arrange_core::<_, _, ContainerChunker<Vec<((K, V), T, R)>>, Ba, Bu, _>(self.inner, exchange, name, batcher)
         }
     }
 
@@ -1072,7 +1072,7 @@ pub mod vec {
 
         /// As `arrange_by_key` but with the ability to name the arrangement.
         pub fn arrange_by_key_named(self, name: &str) -> Arranged<'scope, TraceAgent<ValSpine<K, V, T, R>>> {
-            self.arrange_named::<ValBatcher<_,_,_,_>,ValBuilder<_,_,_,_>,_>(name)
+            self.arrange_named::<_,ValBuilder<_,_,_,_>,_>(name, ValBatcher::new)
         }
     }
 
@@ -1092,7 +1092,7 @@ pub mod vec {
         /// As `arrange_by_self` but with the ability to name the arrangement.
         pub fn arrange_by_self_named(self, name: &str) -> Arranged<'scope, TraceAgent<KeySpine<K, T, R>>> {
             self.map(|k| (k, ()))
-                .arrange_named::<KeyBatcher<_,_,_>,KeyBuilder<_,_,_>,_>(name)
+                .arrange_named::<_,KeyBuilder<_,_,_>,_>(name, KeyBatcher::new)
         }
     }
 

--- a/differential-dataflow/src/operators/arrange/arrangement.rs
+++ b/differential-dataflow/src/operators/arrange/arrangement.rs
@@ -31,7 +31,8 @@ use timely::progress::Stamp;
 use crate::{Data, VecCollection, AsCollection};
 use crate::difference::Semigroup;
 use crate::lattice::Lattice;
-use crate::trace::{self, SpanOf, Trace, TraceReader, Navigable, Batcher, Builder, Cursor, BatchCursor, BatchDiff, BatchKey, BatchVal, BatchValOwn};
+use crate::logging::Logger;
+use crate::trace::{self, Description, SpanOf, Trace, TraceReader, Navigable, Batcher, Builder, Cursor, BatchCursor, BatchDiff, BatchKey, BatchVal, BatchValOwn};
 
 use trace::wrappers::enter::{TraceEnter, enter_span};
 
@@ -302,13 +303,18 @@ impl<'scope, Tr: TraceReader> Arranged<'scope, Tr> {
 /// This operator arranges a stream of values into a shared trace, whose contents it maintains.
 /// It uses the supplied parallelization contract to distribute the data, which does not need to
 /// be consistently by key (though this is the most common).
-pub fn arrange_core<'scope, P, C, Chu, Ba, Bu, Tr>(stream: Stream<'scope, Tr::Time, C>, pact: P, name: &str) -> Arranged<'scope, TraceAgent<Tr>>
+pub fn arrange_core<'scope, P, C, Chu, Ba, Bu, Tr>(
+    stream: Stream<'scope, Tr::Time, C>,
+    pact: P,
+    name: &str,
+    batcher: impl FnOnce(Option<Logger>, usize) -> Ba,
+) -> Arranged<'scope, TraceAgent<Tr>>
 where
     C: Container + Clone + 'static,
     P: ParallelizationContract<Tr::Time, C>,
-    Chu: ContainerBuilder<Container=Ba::Output> + for<'a> PushInto<&'a mut C> + 'static,
-    Ba: Batcher<Time=Tr::Time> + 'static,
-    Bu: Builder<Time=Tr::Time, Input=Ba::Output, Output: Into<Tr::Batch>>,
+    Chu: ContainerBuilder + for<'a> PushInto<&'a mut C> + 'static,
+    Ba: Batcher<Tr::Time, Chu::Container, Vec<Bu::Input>> + 'static,
+    Bu: Builder<Time=Tr::Time, Output: Into<Tr::Batch>>,
     Tr: Trace+'static,
 {
     // The `Arrange` operator is tasked with reacting to an advancing input
@@ -338,7 +344,7 @@ where
         let logger = scope.worker().logger_for::<crate::logging::DifferentialEventBuilder>("differential/arrange").map(Into::into);
 
         // Where we will deposit received updates, and from which we extract batches.
-        let mut batcher = Ba::new(logger.clone(), info.global_id);
+        let mut batcher = batcher(logger.clone(), info.global_id);
 
         // Capabilities for the lower envelope of updates in `batcher`.
         let mut capabilities = Antichain::<Capability<Tr::Time>>::new();
@@ -371,7 +377,7 @@ where
                 }
                 chunker.push_into(data);
                 while let Some(chunk) = chunker.extract() {
-                    batcher.push_into(std::mem::take(chunk));
+                    batcher.insert(chunk);
                 }
             });
 
@@ -391,7 +397,7 @@ where
                 // seal. The batcher only sees chunks the chunker has emitted; without this drain
                 // a partial final chunk would never reach the batcher.
                 while let Some(chunk) = chunker.finish() {
-                    batcher.push_into(std::mem::take(chunk));
+                    batcher.insert(chunk);
                 }
 
                 // There are two cases to handle with some care:
@@ -409,7 +415,7 @@ where
                 if capabilities.elements().iter().any(|c| !frontier.less_equal(c.time())) {
 
                     // The capabilities to retire: those not in advance of the input frontier.
-                    // Each update sealed below is greater or equal to one of them, as updates
+                    // Each update extracted below is greater or equal to one of them, as updates
                     // supported only by the remaining capabilities are in advance of the input
                     // frontier and remain in the batcher.
                     let retired = capabilities
@@ -420,8 +426,16 @@ where
                         .collect::<CapabilitySet<_>>();
 
                     // Extract all updates not in advance of the input frontier, as one batch.
-                    let (mut chain, description) = batcher.seal(frontier.frontier().to_owned());
-                    let batch = trace::Span::new(description, Bu::seal(&mut chain).map(Into::into));
+                    // The batch spans the interval from the previously reported frontier to the
+                    // current one, which is exactly the interval the batcher carves out.
+                    let description = Description::new(
+                        prev_frontier.clone(),
+                        frontier.frontier().to_owned(),
+                        Antichain::from_elem(Tr::Time::minimum()),
+                    );
+                    let (chain, retained) = batcher.extract(frontier.frontier());
+
+                    let batch = trace::Span::new(description, chain.and_then(|mut chain| Bu::seal(&mut chain)).map(Into::into));
 
                     let stamp = retired.iter().map(|c| c.time().clone()).collect::<Stamp<_>>();
                     writer.insert(batch.clone(), stamp);
@@ -436,7 +450,7 @@ where
                     // in messages with new capabilities.
 
                     let mut new_capabilities = Antichain::new();
-                    for time in batcher.frontier().iter() {
+                    for time in retained.iter() {
                         if let Some(capability) = capabilities.elements().iter().find(|c| c.time().less_equal(time)) {
                             new_capabilities.insert(capability.delayed(time));
                         }
@@ -448,10 +462,9 @@ where
                     capabilities = new_capabilities;
                 }
                 else {
-                    // Announce progress updates, even without data. We seal the batcher to
-                    // advance its lower bound and frontier, but discard the readied updates
-                    // rather than building a batch we would immediately drop.
-                    let _ = batcher.seal(frontier.frontier().to_owned());
+                    // Announce progress updates, even without data. No held capability precedes
+                    // the input frontier, so no update does either, and the batcher has nothing
+                    // to extract.
                     writer.seal(frontier.frontier().to_owned());
                 }
 

--- a/differential-dataflow/src/trace/implementations/merge_batcher.rs
+++ b/differential-dataflow/src/trace/implementations/merge_batcher.rs
@@ -4,16 +4,15 @@
 //! hooks for manipulating sorted "chains" of chunks as needed by the merge batcher: merging
 //! chunks and also splitting them apart based on time.
 //!
-//! Callers feed already-chunked, sorted-and-consolidated input into the batcher via [`PushInto`].
+//! Callers feed already-chunked, sorted-and-consolidated input into the batcher via [`Batcher::insert`].
 //! Forming such chunks from raw data is the responsibility of the caller (typically a chunker
 //! living in the surrounding dataflow operator).
 
 use timely::progress::frontier::AntichainRef;
 use timely::progress::{frontier::Antichain, Timestamp};
-use timely::container::PushInto;
 
 use crate::logging::{BatcherEvent, Logger};
-use crate::trace::{Batcher, Description};
+use crate::trace::Batcher;
 
 /// Creates batches from chunks of sorted, consolidated tuples.
 pub struct MergeBatcher<M: Merger> {
@@ -29,9 +28,7 @@ pub struct MergeBatcher<M: Merger> {
     stash: Vec<M::Chunk>,
     /// Merges consolidated chunks, and extracts the subset of an update chain that lies in an interval of time.
     merger: M,
-    /// Current lower frontier, we sealed up to here.
-    lower: Antichain<M::Time>,
-    /// The lower-bound frontier of the data, after the last call to seal.
+    /// The lower-bound frontier of the data, after the last call to extract.
     frontier: Antichain<M::Time>,
     /// Logger for size accounting.
     logger: Option<Logger>,
@@ -39,30 +36,19 @@ pub struct MergeBatcher<M: Merger> {
     operator_id: usize,
 }
 
-impl<M> Batcher for MergeBatcher<M>
+impl<M> Batcher<M::Time, M::Chunk, Vec<M::Chunk>> for MergeBatcher<M>
 where
     M: Merger<Time: Timestamp>,
 {
-    type Time = M::Time;
-    type Output = M::Chunk;
-
-    fn new(logger: Option<Logger>, operator_id: usize) -> Self {
-        Self {
-            logger,
-            operator_id,
-            merger: M::default(),
-            chains: Vec::new(),
-            stash: Vec::new(),
-            frontier: Antichain::new(),
-            lower: Antichain::from_elem(M::Time::minimum()),
-        }
+    fn insert(&mut self, chunk: &mut M::Chunk) {
+        self.insert_chain(vec![std::mem::take(chunk)]);
     }
 
-    // Sealing a batch means finding those updates with times not greater or equal to any time
-    // in `upper`. All updates must have time greater or equal to the previously used `upper`,
-    // which we call `lower`, by assumption that after sealing a batcher we receive no more
-    // updates with times not greater or equal to `upper`.
-    fn seal(&mut self, upper: Antichain<M::Time>) -> (Vec<Self::Output>, Description<M::Time>) {
+    // Extraction means finding those updates with times not greater or equal to any time in
+    // `upper`. All updates must have time greater or equal to the previously used `upper`, by
+    // assumption that after extracting from a batcher we receive no more updates with times not
+    // greater or equal to `upper`.
+    fn extract<'a>(&'a mut self, upper: AntichainRef<'_, M::Time>) -> (Option<Vec<M::Chunk>>, AntichainRef<'a, M::Time>) {
         // Merge all remaining chains into a single chain.
         while self.chains.len() > 1 {
             let list1 = self.chain_pop().unwrap();
@@ -77,7 +63,7 @@ where
         let mut readied = Vec::new();
         self.frontier.clear();
 
-        self.merger.extract(merged, upper.borrow(), &mut self.frontier, &mut readied, &mut kept, &mut self.stash);
+        self.merger.extract(merged, upper, &mut self.frontier, &mut readied, &mut kept, &mut self.stash);
 
         if !kept.is_empty() {
             self.chain_push(kept);
@@ -85,25 +71,27 @@ where
 
         self.stash.clear();
 
-        let description = Description::new(self.lower.clone(), upper.clone(), Antichain::from_elem(M::Time::minimum()));
-        self.lower = upper;
-        (readied, description)
-    }
-
-    /// The frontier of elements remaining after the most recent call to `self.seal`.
-    #[inline]
-    fn frontier(&mut self) -> AntichainRef<'_, M::Time> {
-        self.frontier.borrow()
-    }
-}
-
-impl<M: Merger> PushInto<M::Chunk> for MergeBatcher<M> {
-    fn push_into(&mut self, chunk: M::Chunk) {
-        self.insert_chain(vec![chunk]);
+        let readied = if readied.is_empty() { None } else { Some(readied) };
+        (readied, self.frontier.borrow())
     }
 }
 
 impl<M: Merger> MergeBatcher<M> {
+    /// Allocates a new empty batcher.
+    ///
+    /// The logger and operator identifier are used to report the batcher's memory footprint,
+    /// attributed to the operator that owns it.
+    pub fn new(logger: Option<Logger>, operator_id: usize) -> Self {
+        Self {
+            logger,
+            operator_id,
+            merger: M::default(),
+            chains: Vec::new(),
+            stash: Vec::new(),
+            frontier: Antichain::new(),
+        }
+    }
+
     /// Insert a chain and maintain chain properties: Chains are geometrically sized
     /// (by summed updates) and ordered by decreasing update weight.
     fn insert_chain(&mut self, chain: Vec<M::Chunk>) {
@@ -392,7 +380,7 @@ mod test {
 
     /// The sealed frontier must reflect the POST-CONSOLIDATION set of distinct kept times:
     /// two chains carry cancelling updates at a kept time (`t=5`), plus a survivor at a later
-    /// kept time (`t=7`). After `seal(upper=[3])` the frontier must be `{7}` — `(100, 5)` nets
+    /// kept time (`t=7`). After `extract(upper=[3])` the frontier must be `{7}` — `(100, 5)` nets
     /// to zero and needs no capability. (A per-chain extract that folds the frontier before
     /// consolidating would wrongly report `{5}`.)
     #[test]
@@ -400,8 +388,8 @@ mod test {
         let mut b = Bt::new(None, 0);
         b.chain_push(vec![vec![(100u64, 5u64, 1i64), (200u64, 7u64, 1i64)]]);
         b.chain_push(vec![vec![(100u64, 5u64, -1i64)]]);
-        let _ = b.seal(Antichain::from_elem(3));
-        let got: Vec<u64> = b.frontier().iter().cloned().collect();
+        let (_, retained) = b.extract(Antichain::from_elem(3).borrow());
+        let got: Vec<u64> = retained.iter().cloned().collect();
         assert_eq!(got, vec![7u64],
             "frontier held a capability at t=5, which consolidates to zero (got {got:?})");
     }
@@ -412,8 +400,8 @@ mod test {
         let mut b = Bt::new(None, 0);
         b.chain_push(vec![vec![(100u64, 5u64, 1i64)]]);
         b.chain_push(vec![vec![(200u64, 7u64, 1i64)]]);
-        let _ = b.seal(Antichain::from_elem(3));
-        let got: Vec<u64> = b.frontier().iter().cloned().collect();
+        let (_, retained) = b.extract(Antichain::from_elem(3).borrow());
+        let got: Vec<u64> = retained.iter().cloned().collect();
         assert_eq!(got, vec![5u64]);
     }
 }

--- a/differential-dataflow/src/trace/mod.rs
+++ b/differential-dataflow/src/trace/mod.rs
@@ -13,12 +13,10 @@ pub mod description;
 pub mod implementations;
 pub mod wrappers;
 
-use timely::container::PushInto;
 use timely::progress::{Antichain, frontier::AntichainRef};
 use timely::progress::Timestamp;
 use crate::lattice::Lattice;
 
-use crate::logging::Logger;
 pub use self::cursor::Cursor;
 pub use self::cursor::Navigable;
 pub use self::cursor::{BatchCursor, BatchKey, BatchVal, BatchValOwn, BatchDiff, BatchDiffGat, BatchTimeGat};
@@ -227,25 +225,31 @@ pub trait Trace : TraceReader {
     fn close(&mut self);
 }
 
-/// Functionality for collecting and batching updates.
+/// A type capable of accepting containers of updates, and carving them out by time as batches.
 ///
-/// Accepts containers of type `Output` via [`PushInto`] and produces output batches of the same
-/// type. Callers are responsible for converting raw input data into `Output` containers (e.g.
-/// using a chunker) before pushing into the batcher.
-pub trait Batcher: PushInto<Self::Output> {
-    /// Type produced by the batcher, and also the type it consumes.
-    type Output: Default;
-    /// Times at which batches are formed.
-    type Time: Timestamp;
-    /// Allocates a new empty batcher.
-    fn new(logger: Option<Logger>, operator_id: usize) -> Self;
-    /// Returns all updates not greater or equal to an element of `upper`, as a sorted and
-    /// consolidated chain together with the description that bounds them.
+/// Updates are accepted as `C0`, the containers that arrive on the dataflow edge, and released as
+/// `C1`, whatever the consumer means by a batch. The two need not agree: an implementor staging
+/// updates in a form of its own can release that form directly. A consumer whose batch is a
+/// sequence of chunks names a sequence as `C1`.
+///
+/// The implementor determines the meaning of extraction by a frontier; it is not required to be by
+/// antichain partial order.
+pub trait Batcher<T, C0, C1> {
+    /// Takes the updates in `container`, leaving it in an undefined state.
     ///
-    /// The returned chain is suitable to hand directly to [`Builder::seal`].
-    fn seal(&mut self, upper: Antichain<Self::Time>) -> (Vec<Self::Output>, Description<Self::Time>);
-    /// Returns the lower envelope of contained update times.
-    fn frontier(&mut self) -> AntichainRef<'_, Self::Time>;
+    /// The implementor decides whether to claim the container's allocation or to drain it and
+    /// leave the allocation with the caller, who is free to reuse the container either way.
+    fn insert(&mut self, container: &mut C0);
+    /// Extracts the updates `upper` unblocks as a batch, and lower bounds the times of those retained.
+    ///
+    /// What `upper` unblocks is the implementor's to decide. It can be based on the antichain up
+    /// set, or it can be based on the total order of times (as used in delta join constructions).
+    /// Absent a batch, `upper` unblocked no updates.
+    ///
+    /// The reported lower bound should accurately reflect the times of all accepted updates that
+    /// have not been extracted. Over approximation can result in stalling dataflows, and under
+    /// approximation is simply incorrect.
+    fn extract<'a>(&'a mut self, upper: AntichainRef<'_, T>) -> (Option<C1>, AntichainRef<'a, T>);
 }
 
 /// Functionality for building batches from ordered update sequences.

--- a/differential-dataflow/tests/columnar.rs
+++ b/differential-dataflow/tests/columnar.rs
@@ -30,10 +30,10 @@ fn arrange_reaches_one(config: Config, diffs: &'static [i64]) -> bool {
                 _,
                 _,
                 Chunker<Upd>,
-                Batcher<u64, (), u64, i64>,
+                _,
                 Builder<u64, (), u64, i64>,
                 Spine<u64, (), u64, i64>,
-            >(stream, pact, "Arrange")
+            >(stream, pact, "Arrange", Batcher::new)
             .stream
             .probe_with(&mut probe);
         });

--- a/differential-dataflow/tests/int_proxy.rs
+++ b/differential-dataflow/tests/int_proxy.rs
@@ -139,7 +139,7 @@ fn proxy_matches_mainline(updates: Vec<((u64, u64), u64, i64)>, window: usize) {
         worker.dataflow::<u64, _, _>(|scope| {
             let coll = updates.clone().to_stream(scope).as_collection();
             let hashed = coll.clone().map(|(k, v)| (k.hashed(), (k, v)));
-            let arr = arrange_core::<Pipeline, Vec<((u64, (u64, u64)), u64, i64)>, ContainerChunker<VecChunk<u64, (u64, u64), u64, i64>>, VChunkBatcher<u64, (u64, u64), u64, i64>, VChunkBuilder<u64, (u64, u64), u64, i64>, VChunkSpine<u64, (u64, u64), u64, i64>>(hashed.inner, Pipeline, "Arrange");
+            let arr = arrange_core::<Pipeline, Vec<((u64, (u64, u64)), u64, i64)>, ContainerChunker<VecChunk<u64, (u64, u64), u64, i64>>, _, VChunkBuilder<u64, (u64, u64), u64, i64>, VChunkSpine<u64, (u64, u64), u64, i64>>(hashed.inner, Pipeline, "Arrange", VChunkBatcher::new);
             reduce_with_tactic::<_, VChunkSpine<u64, (u64, u64), u64, i64>, _>(arr, "VecReduce", ProxyReduceTactic::new(VecReduceBackend::with_window(max_logic, window)))
                 .as_collection(|_h, kw: &(u64, u64)| (kw.0, kw.1))
                 .inspect(move |(d, t, r)| ts.lock().unwrap().push((*d, *t, *r)));
@@ -202,7 +202,7 @@ fn reduce_string_values_matches_mainline() {
         worker.dataflow::<u64, _, _>(|scope| {
             let coll = updates.clone().to_stream(scope).as_collection();
             let hashed = coll.clone().map(|(k, v): (u64, String)| (k.hashed(), (k, v)));
-            let arr = arrange_core::<Pipeline, Vec<((u64, (u64, String)), u64, i64)>, ContainerChunker<VecChunk<u64, (u64, String), u64, i64>>, VChunkBatcher<u64, (u64, String), u64, i64>, VChunkBuilder<u64, (u64, String), u64, i64>, VChunkSpine<u64, (u64, String), u64, i64>>(hashed.inner, Pipeline, "Arrange");
+            let arr = arrange_core::<Pipeline, Vec<((u64, (u64, String)), u64, i64)>, ContainerChunker<VecChunk<u64, (u64, String), u64, i64>>, _, VChunkBuilder<u64, (u64, String), u64, i64>, VChunkSpine<u64, (u64, String), u64, i64>>(hashed.inner, Pipeline, "Arrange", VChunkBatcher::new);
             reduce_with_tactic::<_, VChunkSpine<u64, (u64, String), u64, i64>, _>(arr, "VecReduceStr", ProxyReduceTactic::new(VecReduceBackend::with_window(
                 |_k: &u64, input: &[(String, i64)], current: &mut Vec<(String, i64)>, updates: &mut Vec<(String, i64)>| {
                     if let Some(m) = input.iter().filter(|(_, d)| *d > 0).map(|(v, _)| v.clone()).max() { updates.push((m, 1)); }
@@ -236,7 +236,7 @@ fn reduce_inside_iterate() {
             let input = updates.clone().to_stream(scope).as_collection();
             let result = input.iterate(|_scope, inner| {
                 let hashed = inner.map(|(k, v)| (k.hashed(), (k, v)));
-                let arr = arrange_core::<Pipeline, Vec<((u64, (u64, u64)), Product<u64, u64>, i64)>, ContainerChunker<VecChunk<u64, (u64, u64), Product<u64, u64>, i64>>, VChunkBatcher<u64, (u64, u64), Product<u64, u64>, i64>, VChunkBuilder<u64, (u64, u64), Product<u64, u64>, i64>, VChunkSpine<u64, (u64, u64), Product<u64, u64>, i64>>(hashed.inner, Pipeline, "ArrIter");
+                let arr = arrange_core::<Pipeline, Vec<((u64, (u64, u64)), Product<u64, u64>, i64)>, ContainerChunker<VecChunk<u64, (u64, u64), Product<u64, u64>, i64>>, _, VChunkBuilder<u64, (u64, u64), Product<u64, u64>, i64>, VChunkSpine<u64, (u64, u64), Product<u64, u64>, i64>>(hashed.inner, Pipeline, "ArrIter", VChunkBatcher::new);
                 reduce_with_tactic::<_, VChunkSpine<u64, (u64, u64), Product<u64, u64>, i64>, _>(arr, "IterReduce", ProxyReduceTactic::new(VecReduceBackend::with_window(max_logic, 1)))
                     .as_collection(|_h, kw: &(u64, u64)| (kw.0, kw.1))
             });
@@ -311,7 +311,7 @@ fn reduce_collision_inside_iterate() {
             let input = updates.clone().to_stream(scope).as_collection();
             let result = input.iterate(|_scope, inner| {
                 let hashed = inner.map(|(k, v)| (k % 2, (k, v)));
-                let arr = arrange_core::<Pipeline, Vec<((u64, (u64, u64)), Product<u64, u64>, i64)>, ContainerChunker<VecChunk<u64, (u64, u64), Product<u64, u64>, i64>>, VChunkBatcher<u64, (u64, u64), Product<u64, u64>, i64>, VChunkBuilder<u64, (u64, u64), Product<u64, u64>, i64>, VChunkSpine<u64, (u64, u64), Product<u64, u64>, i64>>(hashed.inner, Pipeline, "ArrCollide");
+                let arr = arrange_core::<Pipeline, Vec<((u64, (u64, u64)), Product<u64, u64>, i64)>, ContainerChunker<VecChunk<u64, (u64, u64), Product<u64, u64>, i64>>, _, VChunkBuilder<u64, (u64, u64), Product<u64, u64>, i64>, VChunkSpine<u64, (u64, u64), Product<u64, u64>, i64>>(hashed.inner, Pipeline, "ArrCollide", VChunkBatcher::new);
                 reduce_with_tactic::<_, VChunkSpine<u64, (u64, u64), Product<u64, u64>, i64>, _>(arr, "CollideReduce", ProxyReduceTactic::new(VecReduceBackend::with_window(max_logic, 1)))
                     .as_collection(|_h, kw: &(u64, u64)| (kw.0, kw.1))
             });

--- a/differential-dataflow/tests/int_proxy_bench.rs
+++ b/differential-dataflow/tests/int_proxy_bench.rs
@@ -57,10 +57,10 @@ macro_rules! harrange {
             Pipeline,
             Vec<((u64, (u64, u64)), $t, isize)>,
             ContainerChunker<VecChunk<u64, (u64, u64), $t, isize>>,
-            VChunkBatcher<u64, (u64, u64), $t, isize>,
+            _,
             VChunkBuilder<u64, (u64, u64), $t, isize>,
             VChunkSpine<u64, (u64, u64), $t, isize>,
-        >(hashed.inner, Pipeline, $name)
+        >(hashed.inner, Pipeline, $name, VChunkBatcher::new)
     }};
 }
 
@@ -148,9 +148,9 @@ fn run_wide(mode: Mode) -> f64 {
                     let hashed = coll.map(|(k, v)| (k.hashed(), (k, v)));
                     let arr = arrange_core::<Pipeline, Vec<((u64, (u64, String)), u64, isize)>,
                         ContainerChunker<VecChunk<u64, (u64, String), u64, isize>>,
-                        VChunkBatcher<u64, (u64, String), u64, isize>,
+                        _,
                         VChunkBuilder<u64, (u64, String), u64, isize>,
-                        VChunkSpine<u64, (u64, String), u64, isize>>(hashed.inner, Pipeline, "ArrW");
+                        VChunkSpine<u64, (u64, String), u64, isize>>(hashed.inner, Pipeline, "ArrW", VChunkBatcher::new);
                     arr.reduce_core::<_, VChunkBuilder<u64, (u64, String), u64, isize>,
                         VChunkSpine<u64, (u64, String), u64, isize>,
                         <VecChunkCursor<u64, (u64, String), u64, isize> as Cursor>::KeyContainer, _>(
@@ -172,9 +172,9 @@ fn run_wide(mode: Mode) -> f64 {
                     let hashed = coll.map(|(k, v)| (k.hashed(), (k, v)));
                     let arr = arrange_core::<Pipeline, Vec<((u64, (u64, String)), u64, isize)>,
                         ContainerChunker<VecChunk<u64, (u64, String), u64, isize>>,
-                        VChunkBatcher<u64, (u64, String), u64, isize>,
+                        _,
                         VChunkBuilder<u64, (u64, String), u64, isize>,
-                        VChunkSpine<u64, (u64, String), u64, isize>>(hashed.inner, Pipeline, "ArrW");
+                        VChunkSpine<u64, (u64, String), u64, isize>>(hashed.inner, Pipeline, "ArrW", VChunkBatcher::new);
                     reduce_with_tactic::<_, VChunkSpine<u64, (u64, String), u64, isize>, _>(
                         arr, "ProxyWide",
                         ProxyReduceTactic::new(VecReduceBackend::new(

--- a/differential-dataflow/tests/trace.rs
+++ b/differential-dataflow/tests/trace.rs
@@ -1,9 +1,8 @@
-use timely::container::PushInto;
 use timely::dataflow::operators::generic::OperatorInfo;
 use timely::progress::{Antichain, frontier::AntichainRef};
 
 use differential_dataflow::trace::implementations::{ValBatcher, ValBuilder, ValSpine};
-use differential_dataflow::trace::{Span, Trace, TraceReader, Batcher, Builder};
+use differential_dataflow::trace::{Description, Span, Trace, TraceReader, Batcher, Builder};
 use differential_dataflow::trace::cursor::{Cursor, cursor_list};
 
 type IntegerTrace = ValSpine<u64, u64, usize, i64>;
@@ -15,16 +14,21 @@ fn get_trace() -> ValSpine<u64, u64, usize, i64> {
     {
         let mut batcher = ValBatcher::<u64,u64,usize,i64>::new(None, 0);
 
-        batcher.push_into(vec![
+        batcher.insert(&mut vec![
             ((1, 2), 0, 1),
             ((2, 3), 1, 1),
             ((2, 3), 2, -1),
         ]);
 
         let batch_ts = &[1, 2, 3];
+        let mut lower = Antichain::from_elem(0);
         for i in batch_ts {
-            let (mut chain, description) = batcher.seal(Antichain::from_elem(*i));
-            trace.insert(Span::new(description, IntegerBuilder::seal(&mut chain).map(Into::into)));
+            let upper = Antichain::from_elem(*i);
+            let (chain, _retained) = batcher.extract(upper.borrow());
+            let description = Description::new(lower, upper.clone(), Antichain::from_elem(0));
+            let batch = chain.and_then(|mut chain| IntegerBuilder::seal(&mut chain));
+            trace.insert(Span::new(description, batch.map(Into::into)));
+            lower = upper;
         }
     }
     trace

--- a/dogsdogsdogs/src/operators/half_join.rs
+++ b/dogsdogsdogs/src/operators/half_join.rs
@@ -33,7 +33,7 @@ use differential_dataflow::{ExchangeData, VecCollection, AsCollection, Hashable}
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::Arranged;
-use differential_dataflow::trace::{BatchCursor, BatchDiff, BatchVal, Cursor, Navigable, TraceReader};
+use differential_dataflow::trace::{BatchCursor, BatchDiff, BatchVal, Batcher, Cursor, Navigable, TraceReader};
 use differential_dataflow::trace::cursor::cursor_list;
 use differential_dataflow::consolidation::{consolidate, consolidate_updates};
 use differential_dataflow::trace::implementations::BatchContainer;
@@ -49,28 +49,6 @@ pub trait HalfJoinTactic<T, B, C0, C1> {
     /// The `lower` argument lower bounds the times in `chunks`, and may be used to load `batches`
     /// compacted, or to bound the arrangement times the join must consider.
     fn prep(&mut self, chunks: Vec<C0>, batches: Vec<B>, lower: Antichain<T>) -> Box<dyn Iterator<Item = (C1, T)>>;
-}
-
-/// A type capable of accepting containers of updates, and carving them out by time.
-///
-/// The implementor is able to determine the meaning of extraction by a frontier;
-/// it is not required to be by antichain partial order.
-///
-/// Updates are accepted as `C0`, the containers that arrive on the dataflow edge, and released as
-/// `C1`, whatever a [`HalfJoinTactic`] would rather consume. The two need not agree: an implementor
-/// staging updates in a form of its own can release that form directly.
-pub trait Batcher<T: Timestamp, C0, C1> {
-    /// Moves responsibility for `container` into the implementor.
-    fn insert(&mut self, container: C0);
-    /// Extracts updates `frontier` unblocks, and lower bounds the time of retained updates.
-    ///
-    /// What `frontier` unblocks is the implementor's to decide. It can be based on the antichain up set,
-    /// or it can be based on the total order of times (as used in delta join constructions).
-    ///
-    /// The reported lower bound antichain should accurately reflect the times of all accepted updates
-    /// that have not been extracted. Over approximation can result in stalling dataflows, and under
-    /// approximation is simply incorrect.
-    fn extract(&mut self, frontier: AntichainRef<'_, T>) -> (Vec<C1>, &MutableAntichain<T>);
 }
 
 /// A `half_join` driven by a [`Batcher`] and a [`HalfJoinTactic`].
@@ -99,7 +77,7 @@ where
     FF: Fn(&Tr::Time, &mut Antichain<Tr::Time>) + 'static,
     P: ParallelizationContract<Tr::Time, CIn>,
     Y: Fn(std::time::Instant, usize) -> bool + 'static,
-    Bat: Batcher<Tr::Time, CIn, CMid> + 'static,
+    Bat: Batcher<Tr::Time, CIn, Vec<CMid>> + 'static,
     Tac: HalfJoinTactic<Tr::Time, Tr::Batch, CMid, C> + 'static,
     CIn: Container,
     C: Container + 'static,
@@ -133,7 +111,7 @@ where
             // TODO: Tolerate multi-capability inputs.
             input1.for_each(|capability, data| {
                 caps.insert(capability.retain(0));
-                batcher.insert(std::mem::take(data));
+                batcher.insert(data);
             });
 
             // Drain input batches. We do not capture the batches, but we do use the frontier.
@@ -143,7 +121,7 @@ where
 
                 // Look for updates that are newly eligible against the current frontier.
                 let (chunks, retained) = batcher.extract(frontier2.frontier());
-                if !chunks.is_empty() {
+                if let Some(chunks) = chunks {
                     // The batches are handed to the tactic, which holds them for as long as the
                     // work item lives; what it joins against cannot change underneath it.
                     let batches = trace.batches_through(Antichain::new().borrow()).unwrap();
@@ -153,7 +131,7 @@ where
                 }
 
                 // Downgrade capabilities to those held by `batcher`.
-                caps.downgrade(retained.frontier().iter());
+                caps.downgrade(retained.iter());
             }
 
             // Perform some amount of outstanding work, shipping each container at a capability
@@ -506,11 +484,11 @@ pub mod cursors {
         }
     }
 
-    impl<D: Ord, T: Timestamp, R: Semigroup> Batcher<T, Vec<(D, T, R)>, Vec<(D, T, R)>> for BlobList<D, T, R> {
-        fn insert(&mut self, container: Vec<(D, T, R)>) {
-            self.stage.extend(container.into_iter().map(|(d,t,r)| (t,d,r)));
+    impl<D: Ord, T: Timestamp, R: Semigroup> Batcher<T, Vec<(D, T, R)>, Vec<Vec<(D, T, R)>>> for BlobList<D, T, R> {
+        fn insert(&mut self, container: &mut Vec<(D, T, R)>) {
+            self.stage.extend(container.drain(..).map(|(d,t,r)| (t,d,r)));
         }
-        fn extract(&mut self, frontier: AntichainRef<'_, T>) -> (Vec<Vec<(D, T, R)>>, &MutableAntichain<T>) {
+        fn extract<'a>(&'a mut self, frontier: AntichainRef<'_, T>) -> (Option<Vec<Vec<(D, T, R)>>>, AntichainRef<'a, T>) {
             // Handle any staged updates first.
             consolidate_updates(&mut self.stage);
             if !self.stage.is_empty() {
@@ -545,7 +523,8 @@ pub mod cursors {
             self.blobs.retain(|b| !b.is_empty());
 
             self.lower.update_iter(result.iter().flat_map(|l| l.iter().map(|x| (x.1.clone(), -1))));
-            (result, &self.lower)
+            let result = if result.is_empty() { None } else { Some(result) };
+            (result, self.lower.frontier())
         }
     }
 

--- a/experiments/src/bin/deals.rs
+++ b/experiments/src/bin/deals.rs
@@ -39,7 +39,7 @@ fn main() {
             let (input, graph) = scope.new_collection();
 
             // each edge should exist in both directions.
-            let graph = graph.arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>();
+            let graph = graph.arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new);
 
             match program.as_str() {
                 "tc"    => tc(graph.clone()).filter(move |_| inspect).map(|_| ()).consolidate().inspect(|x| println!("tc count: {:?}", x)).probe(),
@@ -93,7 +93,7 @@ fn tc<'s, T: timely::progress::Timestamp + Lattice + Default + timely::order::Em
             let result =
             inner_collection
                 .map(|(x,y)| (y,x))
-                .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
+                .arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new)
                 .join_core(edges.clone(), |_y,&x,&z| Some((x, z)))
                 .concat(edges.as_collection(|&k,&v| (k,v)))
                 .arrange_by_self()
@@ -121,9 +121,9 @@ fn sg<'s, T: timely::progress::Timestamp + Lattice + Default + timely::order::Em
 
             let result =
             inner_collection
-                .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
+                .arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new)
                 .join_core(edges.clone(), |_,&x,&z| Some((x, z)))
-                .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
+                .arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new)
                 .join_core(edges, |_,&x,&z| Some((x, z)))
                 .concat(peers)
                 .arrange_by_self()

--- a/experiments/src/bin/graspan1.rs
+++ b/experiments/src/bin/graspan1.rs
@@ -29,7 +29,7 @@ fn main() {
             let (n_handle, nodes) = scope.new_collection();
             let (e_handle, edges) = scope.new_collection();
 
-            let edges = edges.arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>();
+            let edges = edges.arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new);
 
             // a N c  <-  a N b && b E c
             // N(a,c) <-  N(a,b), E(b, c)
@@ -46,7 +46,7 @@ fn main() {
                 labels_collection.join_core(edges, |_b, a, c| Some((*c, *a)))
                       .concat(nodes)
                       .map(|k| (k, ()))
-                      .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
+                      .arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new)
                     //   .distinct_total_core::<Diff>();
                       .threshold_semigroup(|_,_,x: Option<&Present>| if x.is_none() { Some(Present) } else { None });
 

--- a/experiments/src/bin/graspan2.rs
+++ b/experiments/src/bin/graspan2.rs
@@ -45,7 +45,7 @@ fn unoptimized() {
                 .flat_map(|(a,b)| vec![a,b])
                 .concat(dereference.clone().flat_map(|(a,b)| vec![a,b]));
 
-            let dereference = dereference.arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>();
+            let dereference = dereference.arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new);
 
             let (value_flow, memory_alias, value_alias) =
             scope
@@ -58,14 +58,14 @@ fn unoptimized() {
                     let (value_flow, value_flow_collection) = Variable::new(inner_scope, Product::new(Default::default(), 1));
                     let (memory_alias, memory_alias_collection) = Variable::new(inner_scope, Product::new(Default::default(), 1));
 
-                    let value_flow_arranged = value_flow_collection.arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>();
-                    let memory_alias_arranged = memory_alias_collection.arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>();
+                    let value_flow_arranged = value_flow_collection.arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new);
+                    let memory_alias_arranged = memory_alias_collection.arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new);
 
                     // VA(a,b) <- VF(x,a),VF(x,b)
                     // VA(a,b) <- VF(x,a),MA(x,y),VF(y,b)
                     let value_alias_next = value_flow_arranged.clone().join_core(value_flow_arranged.clone(), |_,&a,&b| Some((a,b)));
                     let value_alias_next = value_flow_arranged.clone().join_core(memory_alias_arranged.clone(), |_,&a,&b| Some((b,a)))
-                                                              .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
+                                                              .arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new)
                                                               .join_core(value_flow_arranged.clone(), |_,&a,&b| Some((a,b)))
                                                               .concat(value_alias_next);
 
@@ -75,10 +75,10 @@ fn unoptimized() {
                     let value_flow_next =
                     assignment.clone()
                         .map(|(a,b)| (b,a))
-                        .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
+                        .arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new)
                         .join_core(memory_alias_arranged, |_,&a,&b| Some((b,a)))
                         .concat(assignment.map(|(a,b)| (b,a)))
-                        .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
+                        .arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new)
                         .join_core(value_flow_arranged, |_,&a,&b| Some((a,b)))
                         .concat(nodes.map(|n| (n,n)));
 
@@ -93,7 +93,7 @@ fn unoptimized() {
                     let memory_alias_next: VecCollection<_,_,Present> =
                     value_alias_next.clone()
                         .join_core(dereference.clone(), |_x,&y,&a| Some((y,a)))
-                        .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
+                        .arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new)
                         .join_core(dereference, |_y,&a,&b| Some((a,b)));
 
                     let memory_alias_next: VecCollection<_,_,Present>  =
@@ -170,7 +170,7 @@ fn optimized() {
                 .flat_map(|(a,b)| vec![a,b])
                 .concat(dereference.clone().flat_map(|(a,b)| vec![a,b]));
 
-            let dereference = dereference.arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>();
+            let dereference = dereference.arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new);
 
             let (value_flow, memory_alias) =
             scope
@@ -183,8 +183,8 @@ fn optimized() {
                     let (value_flow, value_flow_collection) = Variable::new(inner_scope, Product::new(Default::default(), 1));
                     let (memory_alias, memory_alias_collection) = Variable::new(inner_scope, Product::new(Default::default(), 1));
 
-                    let value_flow_arranged = value_flow_collection.clone().arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>();
-                    let memory_alias_arranged = memory_alias_collection.arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>();
+                    let value_flow_arranged = value_flow_collection.clone().arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new);
+                    let memory_alias_arranged = memory_alias_collection.arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new);
 
                     // VF(a,a) <-
                     // VF(a,b) <- A(a,x),VF(x,b)
@@ -192,10 +192,10 @@ fn optimized() {
                     let value_flow_next =
                     assignment.clone()
                         .map(|(a,b)| (b,a))
-                        .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
+                        .arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new)
                         .join_core(memory_alias_arranged.clone(), |_,&a,&b| Some((b,a)))
                         .concat(assignment.map(|(a,b)| (b,a)))
-                        .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
+                        .arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new)
                         .join_core(value_flow_arranged, |_,&a,&b| Some((a,b)))
                         .concat(nodes.map(|n| (n,n)))
                         .arrange_by_self()
@@ -207,9 +207,9 @@ fn optimized() {
                     let value_flow_deref =
                     value_flow_collection
                         .map(|(a,b)| (b,a))
-                        .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
+                        .arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new)
                         .join_core(dereference, |_x,&a,&b| Some((a,b)))
-                        .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>();
+                        .arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new);
 
                     // MA(a,b) <- VFD(x,a),VFD(y,b)
                     // MA(a,b) <- VFD(x,a),MA(x,y),VFD(y,b)
@@ -220,7 +220,7 @@ fn optimized() {
                     let memory_alias_next =
                     memory_alias_arranged
                         .join_core(value_flow_deref.clone(), |_x,&y,&a| Some((y,a)))
-                        .arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
+                        .arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new)
                         .join_core(value_flow_deref, |_y,&a,&b| Some((a,b)))
                         .concat(memory_alias_next)
                         .arrange_by_self()

--- a/interactive/src/backend/corgi.rs
+++ b/interactive/src/backend/corgi.rs
@@ -295,10 +295,11 @@ impl Backend for CorgiBackend {
         // Column-native ingest: `CorgiChunker` sort-consolidates each input `CorgiContainer`'s
         // columns straight into a `CorgiChunk` (no drain-to-rows), then the standard chunk batcher +
         // builder. No columns→rows→columns round-trip at the arrangement boundary.
-        arrange_core::<_, CC, CorgiChunker<Time, Diff>, ChunkBatcher<CorgiChunk<Time, Diff>>, ChunkBuilder<CorgiChunk<Time, Diff>>, CTrace>(
+        arrange_core::<_, CC, CorgiChunker<Time, Diff>, _, ChunkBuilder<CorgiChunk<Time, Diff>>, CTrace>(
             c.inner,
             Pipeline,
             "CorgiArrange",
+            ChunkBatcher::new,
         )
     }
 


### PR DESCRIPTION
`dogsdogsdogs::half_join` declared its own `Batcher` trait, because `trace::Batcher` did not fit a consumer that stages updates in a form of its own and releases them by a total order rather than an antichain. Two traits with the same name and the same job, one of them half the size. This adopts the smaller one and deletes the duplicate.

```rust
pub trait Batcher<T, C0, C1> {
    fn insert(&mut self, container: C0);
    fn extract<'a>(&'a mut self, upper: AntichainRef<'_, T>)
        -> (Option<C1>, AntichainRef<'a, T>);
}
```

Four consequences, in rough order of how much they matter.

**Input and output types are now distinct.** `trace::Batcher` pinned them to one associated type, which is why `arrange_core` carried a chunker whose container had to equal `Ba::Output`, and why `arrange` needed a doc caveat telling you to call `arrange_core` directly when they differ. A batcher may now release whatever its consumer means by a batch. half_join's is a sequence of chunks; arrange's is a chain it still hands to a `Builder`, which a following commit narrows to the batch itself.

**Construction leaves the trait.** This is the piece that looks like churn and isn't. A trait meant to cover both a merge batcher and — later — a builder-shaped one cannot mandate a `new(logger, operator_id)` constructor, because only the arrange path has a differential logger or a timely operator id to give. `arrange_core` takes the constructor as an argument, and `MergeBatcher::new` becomes inherent. Call sites move the batcher from turbofish to argument position:

```rust
// before
.arrange::<ValBatcher<_,_,_,_>, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>()
// after
.arrange::<_, ValBuilder<_,_,_,_>, ValSpine<_,_,_,_>>(ValBatcher::new)
```

**The `Description` leaves too.** `MergeBatcher::lower` existed only to manufacture one, duplicating `arrange_core`'s `prev_frontier`. The operator now builds the description from the frontiers it already tracks, and the field is gone.

**`seal` and `frontier` collapse into one call,** so the invariant between them — "the frontier of elements remaining after the most recent call to `seal`" — no longer needs stating. The retained frontier is reported by the extraction that determines it.

### One behaviour change

The empty-batch branch used to call `seal` and discard the result, to advance the lower bound that no longer exists. Dropping that call also drops the full chain merge it performed on every empty frontier advance. Correctness is unaffected: no held capability precedes the input frontier in that branch, so no update does either, and nothing was extractable. It is the one thing here a benchmark could notice, in either direction.

+181 −194. Whole workspace builds warning-free and the test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)