### PR TITLE
Split `Builder` along the seam its two users already follow

### DIFF
--- a/differential-dataflow/src/operators/arrange/upsert.rs
+++ b/differential-dataflow/src/operators/arrange/upsert.rs
@@ -233,7 +233,7 @@ where
                                 // new stuff that we add.
                                 let batches = reader_local.batches_through(Antichain::new().borrow()).unwrap();
                                 let (mut trace_cursor, trace_storage) = crate::trace::cursor::cursor_list(batches);
-                                let mut builder = Bu::new();
+                                let mut builder = Bu::default();
                                 let mut key_con = <BatchCursor<Tr> as Cursor>::KeyContainer::with_capacity(1);
                                 for (key, mut list) in to_process {
 

--- a/differential-dataflow/src/operators/reduce.rs
+++ b/differential-dataflow/src/operators/reduce.rs
@@ -335,7 +335,7 @@ mod cursors {
                 // Prepare one output buffer and builder: the batch spans [lower, upper) and
                 // ships stamped with the held times that justify its contents.
                 let mut output_updates = Vec::<(<B2::Cursor as Cursor>::ValOwn, TimeOf<B1>, <B2::Cursor as Cursor>::Diff)>::new();
-                let mut builder = Bu::new();
+                let mut builder = Bu::default();
                 // Temporary staging for output building.
                 let mut buffer = Bu::Input::default();
 
@@ -883,7 +883,7 @@ pub(crate) mod reference {
                 let (mut batch_cursor, ref batch_storage) = cursor_list(input_batches);
 
                 let mut output_updates = Vec::<(<B2::Cursor as Cursor>::ValOwn, TimeOf<B1>, <B2::Cursor as Cursor>::Diff)>::new();
-                let mut builder = Bu::new();
+                let mut builder = Bu::default();
                 let mut buffer = Bu::Input::default();
 
                 // Reuseable state for performing the computation.

--- a/differential-dataflow/src/trace/chunk/mod.rs
+++ b/differential-dataflow/src/trace/chunk/mod.rs
@@ -656,6 +656,12 @@ pub struct ChunkBatchBuilder<C: Chunk> {
     output: VecDeque<C>,
 }
 
+impl<C: Chunk> Default for ChunkBatchBuilder<C> {
+    fn default() -> Self {
+        Self { input: VecDeque::new(), output: VecDeque::new() }
+    }
+}
+
 impl<C> crate::trace::Builder for ChunkBatchBuilder<C>
 where
     C: Chunk + Default + 'static,
@@ -664,10 +670,6 @@ where
     type Input = C;
     type Time = C::Time;
     type Output = ChunkBatch<C>;
-
-    fn new() -> Self {
-        Self { input: VecDeque::new(), output: VecDeque::new() }
-    }
 
     fn push(&mut self, chunk: &mut C) {
         let chunk = std::mem::take(chunk);

--- a/differential-dataflow/src/trace/chunk/mod.rs
+++ b/differential-dataflow/src/trace/chunk/mod.rs
@@ -665,7 +665,7 @@ where
     type Time = C::Time;
     type Output = ChunkBatch<C>;
 
-    fn with_capacity(_keys: usize, _vals: usize, _upds: usize) -> Self {
+    fn new() -> Self {
         Self { input: VecDeque::new(), output: VecDeque::new() }
     }
 
@@ -683,6 +683,15 @@ where
         let chunks: Vec<C> = output.into();
         wrap(chunks)
     }
+
+}
+
+impl<C> crate::trace::Sealer<C> for ChunkBatchBuilder<C>
+where
+    C: Chunk + Default + 'static,
+    C::Time: timely::progress::Timestamp,
+{
+    type Output = ChunkBatch<C>;
 
     fn seal(chain: &mut Vec<C>) -> Option<Self::Output> {
         // We settle the chain because we are not guaranteed to received pre-settled data.

--- a/differential-dataflow/src/trace/implementations/merge_batcher.rs
+++ b/differential-dataflow/src/trace/implementations/merge_batcher.rs
@@ -13,11 +13,11 @@ use timely::progress::frontier::AntichainRef;
 use timely::progress::{frontier::Antichain, Timestamp};
 
 use crate::logging::{BatcherEvent, Logger};
-use crate::trace::{Batcher, Builder};
+use crate::trace::{Batcher, Sealer};
 
 /// Creates batches from chunks of sorted, consolidated tuples.
 ///
-/// Chunking input is `Chu`'s business, merging chunks is `M`'s, and building the extracted chain
+/// Chunking input is `Chu`'s business, merging chunks is `M`'s, and sealing the extracted chain
 /// into a batch is `Bu`'s; the batcher's own work is the geometric ladder of chains and the
 /// carve-by-frontier.
 pub struct MergeBatcher<Chu, M: Merger, Bu> {
@@ -42,14 +42,14 @@ pub struct MergeBatcher<Chu, M: Merger, Bu> {
     /// Timely operator ID.
     operator_id: usize,
     /// Seals each extracted chain into a batch.
-    builder: std::marker::PhantomData<Bu>,
+    sealer: std::marker::PhantomData<Bu>,
 }
 
 impl<C, Chu, M, Bu> Batcher<C> for MergeBatcher<Chu, M, Bu>
 where
     M: Merger<Time: Timestamp>,
     Chu: ContainerBuilder<Container = M::Chunk> + for<'a> PushInto<&'a mut C>,
-    Bu: Builder<Input = M::Chunk>,
+    Bu: Sealer<M::Chunk>,
 {
     type Time = M::Time;
     type Output = Bu::Output;
@@ -112,7 +112,7 @@ impl<Chu: Default, M: Merger, Bu> MergeBatcher<Chu, M, Bu> {
             chains: Vec::new(),
             stash: Vec::new(),
             frontier: Antichain::new(),
-            builder: std::marker::PhantomData,
+            sealer: std::marker::PhantomData,
         }
     }
 }

--- a/differential-dataflow/src/trace/implementations/merge_batcher.rs
+++ b/differential-dataflow/src/trace/implementations/merge_batcher.rs
@@ -18,9 +18,9 @@ use crate::trace::{Batcher, Sealer};
 /// Creates batches from chunks of sorted, consolidated tuples.
 ///
 /// Chunking input is `Chu`'s business, merging chunks is `M`'s, and sealing the extracted chain
-/// into a batch is `Bu`'s; the batcher's own work is the geometric ladder of chains and the
+/// into a batch is `S`'s; the batcher's own work is the geometric ladder of chains and the
 /// carve-by-frontier.
-pub struct MergeBatcher<Chu, M: Merger, Bu> {
+pub struct MergeBatcher<Chu, M: Merger, S> {
     /// Melds input containers into sorted, consolidated chunks.
     chunker: Chu,
     /// Sorted, consolidated chains, each paired with its cached summed update count.
@@ -42,17 +42,17 @@ pub struct MergeBatcher<Chu, M: Merger, Bu> {
     /// Timely operator ID.
     operator_id: usize,
     /// Seals each extracted chain into a batch.
-    sealer: std::marker::PhantomData<Bu>,
+    sealer: std::marker::PhantomData<S>,
 }
 
-impl<C, Chu, M, Bu> Batcher<C> for MergeBatcher<Chu, M, Bu>
+impl<C, Chu, M, S> Batcher<C> for MergeBatcher<Chu, M, S>
 where
     M: Merger<Time: Timestamp>,
     Chu: ContainerBuilder<Container = M::Chunk> + for<'a> PushInto<&'a mut C>,
-    Bu: Sealer<M::Chunk>,
+    S: Sealer<M::Chunk>,
 {
     type Time = M::Time;
-    type Output = Bu::Output;
+    type Output = S::Output;
 
     fn insert(&mut self, container: &mut C) {
         self.chunker.push_into(container);
@@ -65,7 +65,7 @@ where
     // `upper`. All updates must have time greater or equal to the previously used `upper`, by
     // assumption that after extracting from a batcher we receive no more updates with times not
     // greater or equal to `upper`.
-    fn extract<'a>(&'a mut self, upper: AntichainRef<'_, M::Time>) -> (Option<Bu::Output>, AntichainRef<'a, M::Time>) {
+    fn extract<'a>(&'a mut self, upper: AntichainRef<'_, M::Time>) -> (Option<S::Output>, AntichainRef<'a, M::Time>) {
         // Flush whatever the chunker is still accumulating: a partial final chunk would
         // otherwise never reach the merge ladder.
         while let Some(chunk) = self.chunker.finish().map(std::mem::take) {
@@ -94,11 +94,11 @@ where
 
         self.stash.clear();
 
-        (Bu::seal(&mut readied), self.frontier.borrow())
+        (S::seal(&mut readied), self.frontier.borrow())
     }
 }
 
-impl<Chu: Default, M: Merger, Bu> MergeBatcher<Chu, M, Bu> {
+impl<Chu: Default, M: Merger, S> MergeBatcher<Chu, M, S> {
     /// Allocates a new empty batcher.
     ///
     /// The logger and operator identifier are used to report the batcher's memory footprint,
@@ -117,7 +117,7 @@ impl<Chu: Default, M: Merger, Bu> MergeBatcher<Chu, M, Bu> {
     }
 }
 
-impl<Chu, M: Merger, Bu> MergeBatcher<Chu, M, Bu> {
+impl<Chu, M: Merger, S> MergeBatcher<Chu, M, S> {
     /// Insert a chain and maintain chain properties: Chains are geometrically sized
     /// (by summed updates) and ordered by decreasing update weight.
     fn insert_chain(&mut self, chain: Vec<M::Chunk>) {
@@ -192,7 +192,7 @@ impl<Chu, M: Merger, Bu> MergeBatcher<Chu, M, Bu> {
     }
 }
 
-impl<Chu, M: Merger, Bu> Drop for MergeBatcher<Chu, M, Bu> {
+impl<Chu, M: Merger, S> Drop for MergeBatcher<Chu, M, S> {
     fn drop(&mut self) {
         // Cleanup chain to retract accounting information.
         while self.chain_pop().is_some() {}

--- a/differential-dataflow/src/trace/implementations/ord_neu.rs
+++ b/differential-dataflow/src/trace/implementations/ord_neu.rs
@@ -248,7 +248,7 @@ pub mod val_batch {
     use timely::container::PushInto;
     use timely::progress::{Antichain, frontier::AntichainRef};
 
-    use crate::trace::{Builder, Cursor};
+    use crate::trace::{Builder, Sealer, Cursor};
     use crate::trace::implementations::spine_fueled::{SpineBatch, Merger};
     use crate::trace::implementations::{BatchContainer, BuilderInput};
     use crate::trace::implementations::layout;
@@ -614,6 +614,26 @@ pub mod val_batch {
         _marker: PhantomData<CI>,
     }
 
+    impl<L, CI> OrdValBuilder<L, CI>
+    where
+        L: Layout,
+    {
+        /// Allocates a builder with capacity for the specified keys, values, and updates.
+        ///
+        /// They represent respectively the number of distinct `key`, `(key, val)`, and total updates.
+        fn with_capacity(keys: usize, vals: usize, upds: usize) -> Self {
+            Self {
+                result: OrdValStorage {
+                    keys: L::KeyContainer::with_capacity(keys),
+                    vals: Vals::with_capacity(keys + 1, vals),
+                    upds: Upds::with_capacity(vals + 1, upds),
+                },
+                staging: UpdsBuilder::default(),
+                _marker: PhantomData,
+            }
+        }
+    }
+
     impl<L, CI> Builder for OrdValBuilder<L, CI>
     where
         L: for<'a> Layout<
@@ -627,17 +647,7 @@ pub mod val_batch {
         type Time = layout::Time<L>;
         type Output = OrdValBatch<L>;
 
-        fn with_capacity(keys: usize, vals: usize, upds: usize) -> Self {
-            Self {
-                result: OrdValStorage {
-                    keys: L::KeyContainer::with_capacity(keys),
-                    vals: Vals::with_capacity(keys + 1, vals),
-                    upds: Upds::with_capacity(vals + 1, upds),
-                },
-                staging: UpdsBuilder::default(),
-                _marker: PhantomData,
-            }
-        }
+        fn new() -> Self { Self::with_capacity(0, 0, 0) }
 
         #[inline]
         fn push(&mut self, chunk: &mut Self::Input) {
@@ -680,8 +690,20 @@ pub mod val_batch {
             (updates > 0).then(|| OrdValBatch { updates, storage: self.result })
         }
 
-        fn seal(chain: &mut Vec<Self::Input>) -> Option<Self::Output> {
-            let (keys, vals, upds) = Self::Input::key_val_upd_counts(&chain[..]);
+    }
+
+    impl<L, CI> Sealer<CI> for OrdValBuilder<L, CI>
+    where
+        L: for<'a> Layout<
+            KeyContainer: PushInto<CI::Key<'a>>,
+            ValContainer: PushInto<CI::Val<'a>>,
+        >,
+        CI: for<'a> BuilderInput<L::KeyContainer, L::ValContainer, Time=layout::Time<L>, Diff=layout::Diff<L>>,
+    {
+        type Output = OrdValBatch<L>;
+
+        fn seal(chain: &mut Vec<CI>) -> Option<Self::Output> {
+            let (keys, vals, upds) = CI::key_val_upd_counts(&chain[..]);
             let mut builder = Self::with_capacity(keys, vals, upds);
             for mut chunk in chain.drain(..) {
                 builder.push(&mut chunk);
@@ -700,7 +722,7 @@ pub mod key_batch {
     use timely::container::PushInto;
     use timely::progress::{Antichain, frontier::AntichainRef};
 
-    use crate::trace::{Builder, Cursor};
+    use crate::trace::{Builder, Sealer, Cursor};
     use crate::trace::implementations::spine_fueled::{SpineBatch, Merger};
     use crate::trace::implementations::{BatchContainer, BuilderInput};
     use crate::trace::implementations::layout;
@@ -995,6 +1017,22 @@ pub mod key_batch {
         _marker: PhantomData<CI>,
     }
 
+    impl<L: Layout, CI> OrdKeyBuilder<L, CI> {
+        /// Allocates a builder with capacity for the specified keys and updates.
+        ///
+        /// They represent respectively the number of distinct `key` and total updates.
+        fn with_capacity(keys: usize, _vals: usize, upds: usize) -> Self {
+            Self {
+                result: OrdKeyStorage {
+                    keys: L::KeyContainer::with_capacity(keys),
+                    upds: Upds::with_capacity(keys+1, upds),
+                },
+                staging: UpdsBuilder::default(),
+                _marker: PhantomData,
+            }
+        }
+    }
+
     impl<L: Layout, CI> Builder for OrdKeyBuilder<L, CI>
     where
         L: for<'a> Layout<KeyContainer: PushInto<CI::Key<'a>>>,
@@ -1006,16 +1044,7 @@ pub mod key_batch {
         type Time = layout::Time<L>;
         type Output = OrdKeyBatch<L>;
 
-        fn with_capacity(keys: usize, _vals: usize, upds: usize) -> Self {
-            Self {
-                result: OrdKeyStorage {
-                    keys: L::KeyContainer::with_capacity(keys),
-                    upds: Upds::with_capacity(keys+1, upds),
-                },
-                staging: UpdsBuilder::default(),
-                _marker: PhantomData,
-            }
-        }
+        fn new() -> Self { Self::with_capacity(0, 0, 0) }
 
         #[inline]
         fn push(&mut self, chunk: &mut Self::Input) {
@@ -1047,8 +1076,18 @@ pub mod key_batch {
             })
         }
 
-        fn seal(chain: &mut Vec<Self::Input>) -> Option<Self::Output> {
-            let (keys, vals, upds) = Self::Input::key_val_upd_counts(&chain[..]);
+    }
+
+    impl<L: Layout, CI> Sealer<CI> for OrdKeyBuilder<L, CI>
+    where
+        L: for<'a> Layout<KeyContainer: PushInto<CI::Key<'a>>>,
+        L: Layout<ValContainer: BatchContainer<Owned: Default>>,
+        CI: BuilderInput<L::KeyContainer, L::ValContainer, Time=layout::Time<L>, Diff=layout::Diff<L>>,
+    {
+        type Output = OrdKeyBatch<L>;
+
+        fn seal(chain: &mut Vec<CI>) -> Option<Self::Output> {
+            let (keys, vals, upds) = CI::key_val_upd_counts(&chain[..]);
             let mut builder = Self::with_capacity(keys, vals, upds);
             for mut chunk in chain.drain(..) {
                 builder.push(&mut chunk);

--- a/differential-dataflow/src/trace/implementations/ord_neu.rs
+++ b/differential-dataflow/src/trace/implementations/ord_neu.rs
@@ -634,6 +634,10 @@ pub mod val_batch {
         }
     }
 
+    impl<L: Layout, CI> Default for OrdValBuilder<L, CI> {
+        fn default() -> Self { Self::with_capacity(0, 0, 0) }
+    }
+
     impl<L, CI> Builder for OrdValBuilder<L, CI>
     where
         L: for<'a> Layout<
@@ -646,8 +650,6 @@ pub mod val_batch {
         type Input = CI;
         type Time = layout::Time<L>;
         type Output = OrdValBatch<L>;
-
-        fn new() -> Self { Self::with_capacity(0, 0, 0) }
 
         #[inline]
         fn push(&mut self, chunk: &mut Self::Input) {
@@ -1033,6 +1035,10 @@ pub mod key_batch {
         }
     }
 
+    impl<L: Layout, CI> Default for OrdKeyBuilder<L, CI> {
+        fn default() -> Self { Self::with_capacity(0, 0, 0) }
+    }
+
     impl<L: Layout, CI> Builder for OrdKeyBuilder<L, CI>
     where
         L: for<'a> Layout<KeyContainer: PushInto<CI::Key<'a>>>,
@@ -1043,8 +1049,6 @@ pub mod key_batch {
         type Input = CI;
         type Time = layout::Time<L>;
         type Output = OrdKeyBatch<L>;
-
-        fn new() -> Self { Self::with_capacity(0, 0, 0) }
 
         #[inline]
         fn push(&mut self, chunk: &mut Self::Input) {

--- a/differential-dataflow/src/trace/mod.rs
+++ b/differential-dataflow/src/trace/mod.rs
@@ -258,7 +258,10 @@ pub trait Batcher<C0> {
 }
 
 /// Functionality for building batches from ordered update sequences.
-pub trait Builder: Sized {
+///
+/// `Default` is the empty builder; a builder discovers its output as it is pushed, and so has
+/// no opportunity to size itself in advance.
+pub trait Builder: Default {
     /// Input item type.
     type Input;
     /// Timestamp type.
@@ -266,8 +269,6 @@ pub trait Builder: Sized {
     /// Output batch type.
     type Output;
 
-    /// Allocates an empty builder.
-    fn new() -> Self;
     /// Adds a chunk of elements to the batch.
     ///
     /// Adds all elements from `chunk` to the builder and leaves `chunk` in an undefined state.

--- a/differential-dataflow/src/trace/mod.rs
+++ b/differential-dataflow/src/trace/mod.rs
@@ -267,27 +267,32 @@ pub trait Builder: Sized {
     type Output;
 
     /// Allocates an empty builder.
-    ///
-    /// Ideally we deprecate this and insist all non-trivial building happens via `with_capacity()`.
-    // #[deprecated]
-    fn new() -> Self { Self::with_capacity(0, 0, 0) }
-    /// Allocates an empty builder with capacity for the specified keys, values, and updates.
-    ///
-    /// They represent respectively the number of distinct `key`, `(key, val)`, and total updates.
-    fn with_capacity(keys: usize, vals: usize, upds: usize) -> Self;
+    fn new() -> Self;
     /// Adds a chunk of elements to the batch.
     ///
     /// Adds all elements from `chunk` to the builder and leaves `chunk` in an undefined state.
     fn push(&mut self, chunk: &mut Self::Input);
     /// Completes building and returns the batch, absent if no updates were pushed.
     fn done(self) -> Option<Self::Output>;
+}
+
+/// Forms a batch from a whole chain of updates at once.
+///
+/// Named rather than a bare `fn(&mut Vec<C>) -> Option<B>` so that implementors can name the
+/// batch they produce. There is no receiver: the chain goes in and the batch comes out, leaving
+/// nowhere for an update to be retained.
+pub trait Sealer<C> {
+    /// Output batch type.
+    type Output;
 
     /// Builds a batch from a chain of updates.
     ///
     /// This method relies on the chain only containing updates greater or equal to the lower frontier,
     /// and not greater or equal to the upper frontier, of the interval the caller means to describe.
     /// Chains must also be sorted and consolidated.
-    fn seal(chain: &mut Vec<Self::Input>) -> Option<Self::Output>;
+    ///
+    /// Having the whole chain in hand, an implementor can size itself before it fills.
+    fn seal(chain: &mut Vec<C>) -> Option<Self::Output>;
 }
 
 /// Blanket implementations for reference counted batches.


### PR DESCRIPTION
`Builder` had two consumers using disjoint halves of it.
`MergeBatcher` called only `seal`, and through it `with_capacity`, because it holds a whole chain and can count keys, values, and updates before allocating.
Reduce and upsert called only `new`, `push`, and `done`, discovering their output key by key and never sizing anything.

`seal` moves to a trait of its own:

```rust
pub trait Sealer<C> {
    type Output;
    fn seal(chain: &mut Vec<C>) -> Option<Self::Output>;
}
```

which is a `fn(&mut Vec<C>) -> Option<B>` in a form that can name `B`.
It has no receiver, so there is nowhere for an update to be retained between the chain going in and the batch coming out.

`with_capacity` becomes inherent on the two `ord_neu` builders.
It had no callers outside `seal` and `new`, so it was never vocabulary; `new` now carries its own one-line body instead of a default.

`MergeBatcher` bounds `Bu: Sealer<M::Chunk>` and stops naming `Builder`, which also drops `Builder::Time` from its vocabulary — it never wanted it.
The three implementors implement both traits and share their machinery.

No call site changes: the aliases name the same types, and those types satisfy both bounds.
The diff is four files, all under `trace/`.

This splits one question into two.
Whether reduce and upsert should take a `Batcher` instead, and whether `Sealer` should be a function value rather than a trait, can now be answered independently.

Builds warning-free, workspace tests and doctests pass.