### PR TITLE
The corgi backend, on more than one worker

### DIFF
--- a/interactive/Cargo.toml
+++ b/interactive/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 columnar = { workspace = true }
 # The columnar kernels for the interpreted backend, pinned by git rev.
-corgi = { git = "https://github.com/frankmcsherry/wip", rev = "222157885ef424674163aeaf3f97775c9f160293" }
+corgi = { git = "https://github.com/frankmcsherry/wip", rev = "20f38d69ba0f964e6dd0d904338bf433fea0c642" }
 differential-dataflow = { workspace = true }
 mimalloc = "0.1.48"
 serde = { version = "1.0", features = ["derive"] }

--- a/interactive/examples/ddir.rs
+++ b/interactive/examples/ddir.rs
@@ -13,7 +13,7 @@
 //! - `--debug-demand`: tap every demand collection with an Inspect.
 //! - `--diag`: serve timely/DD diagnostics on port 51371.
 //! - `--backend=vec|corgi`: rendering substrate (default `vec`). The corgi
-//!   backend is single-worker (its arrange does not exchange).
+//!   backend exchanges by key hash, so both take `-w`.
 //! - `--sync=K`: await completion only every K rounds (default 1), letting K
 //!   timestamps retire with whatever inter-timestamp concurrency the system
 //!   finds — the open(er)-loop regime DD adapts into under load.

--- a/interactive/src/backend/corgi.rs
+++ b/interactive/src/backend/corgi.rs
@@ -26,6 +26,7 @@ use corgi::Value as CValue;
 use crate::backend::Backend;
 use crate::corgi::chunk::{recover_key, CorgiChunk, CorgiChunker};
 use crate::corgi::container::CorgiContainer;
+use crate::corgi::exchange::CorgiPact;
 use crate::corgi::join::CorgiJoinBackend;
 use crate::corgi::reduce::CorgiReduceBackend;
 use differential_dataflow::operators::int_proxy::{ProxyJoinTactic, ProxyReduceTactic};
@@ -288,16 +289,20 @@ impl Backend for CorgiBackend {
     }
 
     fn arrange<'s>(c: Collection<'s, Time, CC>) -> Self::Arr<'s> {
-        // Single-worker guard: this arrange is `Pipeline` (no key exchange), so multi-worker
-        // execution would MIS-PLACE keys — silently wrong, not slow. A columnar exchange
-        // (radix partition by key hash) lifts this; it pairs with the stored-hash-column work.
-        assert_eq!(c.inner.scope().peers(), 1, "the corgi backend is single-worker: arrange does not exchange keys");
+        // This is the backend's ONE inter-worker data movement. `CorgiPact` partitions each
+        // container by the structural hash of its key column and gathers each destination's rows
+        // into fresh contiguous columns, so every update for a key reaches one worker and both
+        // sides of a join agree which. Every other operator here is key-local given correctly
+        // placed arrangements, which is why substituting this for `Pipeline` is the whole of
+        // multi-worker support. At one worker timely's `Exchange` short-circuits to a direct
+        // push, so the single-worker path costs nothing.
+        //
         // Column-native ingest: `CorgiChunker` sort-consolidates each input `CorgiContainer`'s
         // columns straight into a `CorgiChunk` (no drain-to-rows), then the standard chunk batcher +
         // builder. No columns→rows→columns round-trip at the arrangement boundary.
         arrange_core::<_, CC, _, CTrace>(
             c.inner,
-            Pipeline,
+            CorgiPact,
             "CorgiArrange",
             ChunkBatcher::<CorgiChunker<Time, Diff>, _>::new,
         )
@@ -475,8 +480,42 @@ pub fn evaluate(
     program: &st::Program,
     inputs: &[Vec<(Row, Row)>],
 ) -> std::collections::BTreeMap<String, Vec<((Row, Row), Diff)>> {
+    evaluate_with_workers(program, inputs, 1)
+}
+
+/// [`evaluate`] on `workers` worker threads in one process.
+///
+/// The answer must not depend on `workers`: the exchange places each key on one worker, every
+/// operator is key-local from there, and each worker's captured output is a disjoint share of the
+/// same collection, so summing the shares reproduces the single-worker result exactly. That
+/// invariant is the correctness statement for [`CorgiPact`], and the backend gate checks it by
+/// running each program at several worker counts.
+///
+/// Input rows are dealt round-robin across workers (`row index % peers`) so each row is introduced
+/// exactly once globally — where they enter is irrelevant, since `arrange` re-places them.
+pub fn evaluate_with_workers(
+    program: &st::Program,
+    inputs: &[Vec<(Row, Row)>],
+    workers: usize,
+) -> std::collections::BTreeMap<String, Vec<((Row, Row), Diff)>> {
+    evaluate_with_config(program, inputs, timely::Config::process(workers))
+}
+
+/// [`evaluate_with_workers`] with the timely configuration named outright.
+///
+/// The configuration decides which half of the exchange gets exercised.
+/// `Config::process(n)` hands containers between worker threads as typed values — the
+/// [`CorgiDistributor`](crate::corgi::exchange::CorgiDistributor)'s partition runs, but no bytes
+/// are produced. `CommunicationConfig::ProcessBinary(n)` puts the same threads behind serializing
+/// channels, so every container makes the round trip through
+/// [the wire format](crate::corgi::bytes) — the multi-*process* path, without the processes.
+pub fn evaluate_with_config(
+    program: &st::Program,
+    inputs: &[Vec<(Row, Row)>],
+    config: timely::Config,
+) -> std::collections::BTreeMap<String, Vec<((Row, Row), Diff)>> {
     use std::collections::BTreeMap;
-    use std::sync::mpsc::channel;
+    use std::sync::{Arc, Mutex, mpsc::channel};
     use timely::dataflow::operators::core::capture::{Capture, Event};
     use differential_dataflow::input::Input;
     use differential_dataflow::dynamic::pointstamp::PointStamp;
@@ -489,10 +528,16 @@ pub fn evaluate(
         txs.push(tx);
         rxs.push(rx);
     }
+    // Every worker captures into the same per-export channel. `Sender` is `Send` but not `Sync`,
+    // and timely's worker closure must be both, so the senders travel behind a mutex and each
+    // worker clones its own out of it once, at construction.
+    let txs = Arc::new(Mutex::new(txs));
 
     let program = program.clone();
     let inputs: Vec<Vec<(Row, Row)>> = inputs.to_vec();
-    timely::execute_directly(move |worker| {
+    let guards = timely::execute(config, move |worker| {
+        let (index, peers) = (worker.index(), worker.peers());
+        let txs: Vec<_> = txs.lock().expect("capture senders").iter().cloned().collect();
         let mut handles = worker.dataflow::<u64, _, _>(|scope| {
             let mut handles = Vec::new();
             let mut collections = Vec::new();
@@ -525,11 +570,15 @@ pub fn evaluate(
             handles
         });
         for (i, rows) in inputs.iter().enumerate() {
-            for r in rows {
+            for r in rows.iter().skip(index).step_by(peers) {
                 handles[i].update(r.clone(), 1);
             }
         }
-    });
+    })
+    .expect("corgi evaluate: worker startup");
+    // Join the workers before draining, so every capture has been sent and every cloned sender
+    // dropped; otherwise the receive loop below would block on a channel that is still open.
+    guards.join();
 
     names
         .into_iter()

--- a/interactive/src/backend/corgi.rs
+++ b/interactive/src/backend/corgi.rs
@@ -93,7 +93,32 @@ fn apply_ops(mut c: CC, ops: &[LinearOp], level: usize) -> CC {
     use differential_dataflow::lattice::Lattice;
     use differential_dataflow::dynamic::pointstamp::PointStamp;
 
+    // A container with no rows has no SHAPE either, and the ops below are shape-directed.
+    //
+    // Every path that rebuilds a container from rows (`from_updates`) infers its columns by
+    // scanning them, so with nothing to scan it returns the shape-erased default — `Unit` keys and
+    // `Unit` vals. Feed that to the next op and `compile_projection` cheerfully lowers `$1[0]`
+    // against a `Unit`, because a `Field` is legal in the abstract; `eval_graph` then meets a
+    // column that is not a product and panics. A filter that empties a batch mid-chain is enough
+    // to arrange this: `... | filter(len($1) == 2) | map(; $1[0][0] * $1[1][0])`.
+    //
+    // Skipping is not a shortcut, it is the whole answer: every `LinearOp` here maps zero rows to
+    // zero rows, so the only thing the ops could contribute is the output shape, and the input's
+    // shape is already gone. Nothing downstream reads it either — `CorgiChunker::push_into` drops
+    // empty containers before they reach `concat_blocks`, which is the one place shapes must
+    // agree.
+    //
+    // Latent since the backend was written; a single worker rarely empties a batch it was given,
+    // and the key-hash exchange makes it routine.
+    //
+    // The check belongs at the top of the LOOP, not before it. A chain empties itself: a filter
+    // takes the row-wise path, drops every row, and hands the erased container to the very next
+    // op in the same `ops` slice. Guarding only the entry catches the batch that arrives empty
+    // and misses the one that becomes empty, which is the common case.
     for op in ops {
+        if c.times.is_empty() {
+            break;
+        }
         c = match op {
             LinearOp::Project(p) => {
                 let (kshape, vshape) = (corgi::shape_of_value(&c.keys), corgi::shape_of_value(&c.vals));

--- a/interactive/src/corgi/bytes.rs
+++ b/interactive/src/corgi/bytes.rs
@@ -1,0 +1,207 @@
+//! The wire format for a [`CorgiContainer`] — what a worker sends when a container crosses a
+//! process boundary.
+//!
+//! Four columns, four encoders, one framing header:
+//!
+//! ```text
+//! u64 keys_len | u64 vals_len | u64 times_len | u64 diffs_len | keys | vals | times | diffs
+//! ```
+//!
+//! * `keys` / `vals` go through [`corgi::bytes`], which writes each leaf column as one contiguous
+//!   run of its stored bytes. A batch of a million `(u64, u64)` keys is two headers and two 8 MB
+//!   writes — no per-row framing, no per-row dispatch.
+//! * `times` / `diffs` go through `columnar`'s [`Stash`], the same encoder DD's own columnar
+//!   updates use. `T` is already `Columnar` (the arrangement stores times SoA in
+//!   [`ColTimes`](crate::corgi::col_times::ColTimes)), so this is the encoder that type was chosen
+//!   for.
+//!
+//! Every section is a whole number of 64-bit words, so each begins 8-aligned in an 8-aligned
+//! buffer — which is what lets `Stash::try_from_bytes` install the received bytes directly rather
+//! than relocating them.
+//!
+//! The comparison worth keeping in view: the row backend's `Vec<((Row, Row), T, R)>` reaches the
+//! wire through `bincode`, which walks every `Value` of every row and emits varints. This walks
+//! four columns and emits memcpys. That difference is the whole reason a columnar exchange is
+//! worth building.
+//!
+//! **Known cost.** `length_in_bytes` and `into_bytes` are separate calls on `&self`, and the
+//! time/diff columns must be built to be measured, so they are built twice — two linear passes
+//! over `times`. The fix is the one [`container`](crate::corgi::container) already names: hold
+//! times columnar in the container instead of as `Vec<T>`, at which point both calls read a
+//! column that already exists. Keys and values do not have this problem: `corgi::bytes` sizes a
+//! `Value` by walking its shape, without touching a payload byte.
+
+use columnar::Columnar;
+use columnar::bytes::stash::Stash;
+
+use timely::bytes::arc::Bytes;
+use timely::dataflow::channels::ContainerBytes;
+
+use crate::corgi::container::CorgiContainer;
+
+/// A columnar column of `T` backed either by an owned container or by received bytes.
+type ColStash<T> = Stash<<T as Columnar>::Container, Bytes>;
+
+/// Read a `u64` length word out of the framing header.
+fn header_word(header: &[u8], i: usize) -> usize {
+    u64::from_le_bytes(header[i * 8..i * 8 + 8].try_into().unwrap()) as usize
+}
+
+/// Materialize a received column as owned values. This is the one place the decode pays per row:
+/// `Vec<T>` owns its elements, so a `T` has to be reconstructed for each.
+fn to_owned_vec<T: Columnar>(stash: &ColStash<T>) -> Vec<T> {
+    use columnar::{Index, Len};
+    let borrowed = stash.borrow();
+    (0..borrowed.len()).map(|i| <T as Columnar>::into_owned(borrowed.get(i))).collect()
+}
+
+impl<T: Columnar, R: Columnar> ContainerBytes for CorgiContainer<T, R> {
+    fn from_bytes(mut bytes: Bytes) -> Self {
+        let header = bytes.extract_to(32);
+        let (kl, vl, tl, dl) = (header_word(&header, 0), header_word(&header, 1), header_word(&header, 2), header_word(&header, 3));
+
+        let key_bytes = bytes.extract_to(kl);
+        let (keys, read) = corgi::bytes::read_from(&key_bytes).expect("corgi key column decode");
+        assert_eq!(read, kl, "corgi key column decode read {read} of {kl} bytes");
+        let val_bytes = bytes.extract_to(vl);
+        let (vals, vread) = corgi::bytes::read_from(&val_bytes).expect("corgi val column decode");
+        assert_eq!(vread, vl, "corgi val column decode read {vread} of {vl} bytes");
+
+        let times: ColStash<T> = Stash::try_from_bytes(bytes.extract_to(tl)).expect("time column decode");
+        let diffs: ColStash<R> = Stash::try_from_bytes(bytes.extract_to(dl)).expect("diff column decode");
+
+        CorgiContainer { keys, vals, times: to_owned_vec(&times), diffs: to_owned_vec(&diffs) }
+    }
+
+    fn length_in_bytes(&self) -> usize {
+        let times: ColStash<T> = Stash::Typed(T::as_columns(self.times.iter()));
+        let diffs: ColStash<R> = Stash::Typed(R::as_columns(self.diffs.iter()));
+        32 + corgi::bytes::length_in_bytes(&self.keys)
+           + corgi::bytes::length_in_bytes(&self.vals)
+           + times.length_in_bytes()
+           + diffs.length_in_bytes()
+    }
+
+    fn into_bytes<W: std::io::Write>(&self, writer: &mut W) {
+        let times: ColStash<T> = Stash::Typed(T::as_columns(self.times.iter()));
+        let diffs: ColStash<R> = Stash::Typed(R::as_columns(self.diffs.iter()));
+        let lens = [
+            corgi::bytes::length_in_bytes(&self.keys) as u64,
+            corgi::bytes::length_in_bytes(&self.vals) as u64,
+            times.length_in_bytes() as u64,
+            diffs.length_in_bytes() as u64,
+        ];
+        for l in lens {
+            writer.write_all(&l.to_le_bytes()).unwrap();
+        }
+        corgi::bytes::write_to(&self.keys, writer).unwrap();
+        corgi::bytes::write_to(&self.vals, writer).unwrap();
+        times.write_bytes(writer).unwrap();
+        diffs.write_bytes(writer).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use timely::dataflow::channels::ContainerBytes;
+
+    use crate::corgi::container::CorgiContainer;
+    use crate::ir::{Diff, Time, Value as DValue};
+
+    /// Serialize through the same two-step timely uses (size, then write) and decode the result,
+    /// checking that the promised size is the size delivered.
+    fn round_trip(c: &CorgiContainer<Time, Diff>) -> CorgiContainer<Time, Diff> {
+        let len = c.length_in_bytes();
+        let mut buf: Vec<u8> = Vec::with_capacity(len);
+        c.into_bytes(&mut buf);
+        assert_eq!(buf.len(), len, "length_in_bytes disagrees with into_bytes");
+        assert_eq!(buf.len() % 8, 0, "encoding is not word-aligned");
+        let bytes = timely::bytes::arc::BytesMut::from(buf).freeze();
+        <CorgiContainer<Time, Diff> as ContainerBytes>::from_bytes(bytes)
+    }
+
+    fn time(outer: u64, coords: &[u64]) -> Time {
+        use differential_dataflow::dynamic::pointstamp::PointStamp;
+        timely::order::Product::new(outer, PointStamp::new(coords.iter().copied().collect()))
+    }
+
+    /// One batch per key/value shape family. A corgi column is homogeneous — every row of a
+    /// column shares a shape — so the constructors are exercised one batch at a time rather than
+    /// mixed into a single container: scalars (a bare leaf), tuples (a `Prod`), lists (a `List`,
+    /// including an empty row), variants (a `Sum`, with per-arm payload shapes), and the nesting
+    /// that puts one inside another.
+    fn shape_families() -> Vec<(&'static str, Vec<((DValue, DValue), Time, Diff)>)> {
+        use DValue::*;
+        vec![
+            ("scalars", vec![
+                ((Int(7), Int(1)), time(0, &[]), 1),
+                ((Int(-3), Int(9)), time(1, &[2]), -4),
+                ((Int(i64::MIN), Int(i64::MAX)), time(0, &[1, 1]), 7),
+            ]),
+            ("tuples", vec![
+                ((Tuple(vec![Int(1), Int(2)]), Tuple(vec![Int(3)])), time(2, &[]), 2),
+                ((Tuple(vec![Int(1), Int(3)]), Tuple(vec![Int(-3)])), time(0, &[0]), -1),
+            ]),
+            ("lists", vec![
+                ((Int(1), List(vec![Int(3), Int(4), Int(5)])), time(0, &[]), 1),
+                ((Int(2), List(vec![])), time(0, &[7]), -2),
+                ((Int(3), List(vec![Int(6)])), time(1, &[]), 3),
+            ]),
+            ("variants", vec![
+                ((Variant(0, Box::new(Int(11))), Int(0)), time(3, &[7, 7]), 5),
+                ((Variant(1, Box::new(Tuple(vec![Int(2), Int(3)]))), Int(1)), time(0, &[]), 1),
+                ((Variant(0, Box::new(Int(12))), Int(2)), time(0, &[]), -1),
+            ]),
+            ("nested", vec![
+                ((Tuple(vec![Int(1), Variant(0, Box::new(Int(5)))]), List(vec![Int(1), Int(2)])), time(0, &[]), 1),
+                ((Tuple(vec![Int(2), Variant(1, Box::new(Tuple(vec![Int(6), Int(7)])))]), List(vec![Int(3)])), time(1, &[1]), -1),
+            ]),
+        ]
+    }
+
+    /// Every update survives the round trip, with its time and diff, for every shape family.
+    #[test]
+    fn round_trip_preserves_updates() {
+        for (name, updates) in shape_families() {
+            let c = CorgiContainer::<Time, Diff>::from_updates(updates.clone());
+            let back = round_trip(&c);
+            assert_eq!(back.into_updates(), updates, "{name} did not survive the round trip");
+        }
+    }
+
+    /// An empty container is a legal message: timely can hand one to the encoder, and what comes
+    /// back must be empty rather than malformed.
+    #[test]
+    fn round_trip_empty() {
+        let c = CorgiContainer::<Time, Diff>::default();
+        let back = round_trip(&c);
+        assert_eq!(back.into_updates(), Vec::new());
+    }
+
+    /// The columns themselves survive, not just the rows read back out: the decoded key column
+    /// hashes row-for-row like the sender's, which is what the exchange relies on to place a key
+    /// on the same worker after a round trip as before it.
+    #[test]
+    fn round_trip_preserves_column_hashes() {
+        for (name, updates) in shape_families() {
+            let c = CorgiContainer::<Time, Diff>::from_updates(updates);
+            let (keys, vals) = (c.keys.clone(), c.vals.clone());
+            let back = round_trip(&c);
+            assert_eq!(corgi::arrange::hash_rows(&back.keys), corgi::arrange::hash_rows(&keys), "{name} keys");
+            assert_eq!(corgi::arrange::hash_rows(&back.vals), corgi::arrange::hash_rows(&vals), "{name} vals");
+        }
+    }
+
+    /// The payload scales with the data, not with a per-row framing tax: a thousand scalar keys
+    /// cost their thousand words plus one header, which is the property the whole format exists
+    /// for. (Times and diffs are genuinely per-row data and are counted separately.)
+    #[test]
+    fn key_columns_cost_their_payload() {
+        let updates: Vec<_> = (0..1000i64)
+            .map(|i| ((DValue::Int(i), DValue::Int(i * 2)), time(0, &[]), 1))
+            .collect();
+        let c = CorgiContainer::<Time, Diff>::from_updates(updates);
+        assert_eq!(corgi::bytes::length_in_bytes(&c.keys), 24 + 8 * 1000);
+        assert_eq!(corgi::bytes::length_in_bytes(&c.vals), 24 + 8 * 1000);
+    }
+}

--- a/interactive/src/corgi/bytes.rs
+++ b/interactive/src/corgi/bytes.rs
@@ -69,8 +69,26 @@ impl<T: Columnar, R: Columnar> ContainerBytes for CorgiContainer<T, R> {
 
         let times: ColStash<T> = Stash::try_from_bytes(bytes.extract_to(tl)).expect("time column decode");
         let diffs: ColStash<R> = Stash::try_from_bytes(bytes.extract_to(dl)).expect("diff column decode");
+        let container = CorgiContainer { keys, vals, times: to_owned_vec(&times), diffs: to_owned_vec(&diffs) };
 
-        CorgiContainer { keys, vals, times: to_owned_vec(&times), diffs: to_owned_vec(&diffs) }
+        // The four columns are one table, so they must agree on how many rows it has. Checking
+        // that here is not ceremony — it is the only layer that knows the answer.
+        //
+        // `corgi::bytes` guarantees a structurally sound `Value`, but not a *small* one: the
+        // payload-free constructors declare rows without spending bytes, so a `Unit` can name a
+        // trillion rows in sixteen bytes and nothing inside corgi can call that wrong. The time
+        // column can. It is stored per row, so its length is the row count this message actually
+        // paid for, and every other column has to match it.
+        //
+        // What this does not reach is a claim nested *under a `List`*, where flattening
+        // legitimately multiplies and the row count no longer bounds the element count. That is
+        // the sender's honesty, which is the boundary a cluster-internal exchange accepts anyway;
+        // a caller that wants a hard ceiling has `corgi::bytes::declared_rows`.
+        let rows = container.times.len();
+        assert_eq!(container.diffs.len(), rows, "corgi container: {} diffs for {rows} times", container.diffs.len());
+        assert_eq!(container.keys.len(), rows, "corgi container: {} keys for {rows} times", container.keys.len());
+        assert_eq!(container.vals.len(), rows, "corgi container: {} vals for {rows} times", container.vals.len());
+        container
     }
 
     fn length_in_bytes(&self) -> usize {

--- a/interactive/src/corgi/container.rs
+++ b/interactive/src/corgi/container.rs
@@ -3,8 +3,10 @@
 //! the corgi backend; operators transform block→block via `eval_graph` with NO per-op transcode.
 //! Conversion to/from DDIR rows happens only at I/O boundaries (`from_updates`/`into_updates`).
 //!
-//! Minimal trait surface for a pipelined (single-worker) dataflow: `Accountable + Default + Clone`
-//! (= `timely::Container`). `Negate`/`Enter`/`Leave`/`ResultsIn` (iterative scopes) come with M3.
+//! Trait surface: `Accountable + Default + Clone` (= `timely::Container`) for dataflow edges,
+//! `Negate`/`Enter`/`Leave`/`ResultsIn` for iterative scopes, and `ContainerBytes` (in
+//! [`bytes`](crate::corgi::bytes)) for crossing a process boundary. Splitting one of these across
+//! workers is [`exchange`](crate::corgi::exchange)'s job.
 
 use timely::Accountable;
 use timely::progress::{PathSummary, Timestamp};

--- a/interactive/src/corgi/exchange.rs
+++ b/interactive/src/corgi/exchange.rs
@@ -47,20 +47,23 @@ use crate::corgi::container::CorgiContainer;
 
 /// Partitions a [`CorgiContainer`] across workers by the structural hash of each row's key.
 ///
-/// The scratch buffers are fields rather than locals because `partition` is called once per
-/// container for the life of the dataflow; a per-call allocation of three `Vec`s per batch is the
-/// kind of cost that shows up as a flat tax on every exchange.
+/// The index buffers are fields rather than locals because `partition` runs once per container for
+/// the life of the dataflow; allocating three `Vec`s per batch is the kind of cost that shows up as
+/// a flat tax on every exchange. (The one per-batch allocation left is the hash column itself,
+/// which `corgi::hash` returns owned.)
 pub struct CorgiDistributor<T, R> {
     marker: std::marker::PhantomData<(T, R)>,
     /// Row indices, grouped by destination: destination `p` owns `order[starts[p]..starts[p+1]]`.
     order: Vec<usize>,
     /// Running offsets into `order`, one per destination plus the total.
     starts: Vec<usize>,
+    /// Write position within each destination's run, while `order` is being filled.
+    cursor: Vec<usize>,
 }
 
 impl<T, R> Default for CorgiDistributor<T, R> {
     fn default() -> Self {
-        CorgiDistributor { marker: std::marker::PhantomData, order: Vec::new(), starts: Vec::new() }
+        CorgiDistributor { marker: std::marker::PhantomData, order: Vec::new(), starts: Vec::new(), cursor: Vec::new() }
     }
 }
 
@@ -85,11 +88,12 @@ impl<T: Clone + 'static, R: Clone + 'static> CorgiDistributor<T, R> {
         // `cursor` walks each destination's run as rows are placed; `starts` is left intact.
         self.order.clear();
         self.order.resize(ids.len(), 0);
-        let mut cursor = self.starts[..peers].to_vec();
+        self.cursor.clear();
+        self.cursor.extend_from_slice(&self.starts[..peers]);
         for (row, &h) in ids.iter().enumerate() {
             let p = dest(h);
-            self.order[cursor[p]] = row;
-            cursor[p] += 1;
+            self.order[self.cursor[p]] = row;
+            self.cursor[p] += 1;
         }
     }
 }
@@ -145,6 +149,7 @@ impl<T: Clone + 'static, R: Clone + 'static> Distributor<CorgiContainer<T, R>> f
     fn relax(&mut self) {
         self.order = Vec::new();
         self.starts = Vec::new();
+        self.cursor = Vec::new();
     }
 }
 

--- a/interactive/src/corgi/exchange.rs
+++ b/interactive/src/corgi/exchange.rs
@@ -1,0 +1,315 @@
+//! The corgi exchange: how a [`CorgiContainer`] is split across workers.
+//!
+//! An arrangement is only correct if every update for a key reaches the same worker, and a join is
+//! only correct if both of its arrangements agree on which worker that is. [`CorgiPact`] is the
+//! contract that establishes both — the corgi backend's `arrange` uses it in place of `Pipeline`,
+//! and that single substitution is what lifts the backend off one worker.
+//!
+//! # Partitioning a column, not a stream of rows
+//!
+//! Timely's stock distributor ([`DrainContainerDistributor`]) drains a container item by item and
+//! pushes each into a per-destination builder. A corgi container has no items to drain: it is four
+//! columns, and taking it apart row-wise would undo the representation before the data even left
+//! the worker.
+//!
+//! So [`CorgiDistributor`] partitions the way a columnar engine does — a counting sort:
+//!
+//! 1. Hash the key column once, one pass, columnar ([`corgi::hash`]).
+//! 2. Count how many rows each destination takes, then place row indices into one `order` buffer
+//!    so each destination's rows are a contiguous run of it.
+//! 3. Per destination, `gather` the key and value columns through its run.
+//!
+//! The output of step 3 is a freshly allocated, contiguous column per destination — which is
+//! exactly what the [wire format](crate::corgi::bytes) wants to write, one `memcpy` per leaf. The
+//! sort is stable, so rows keep their relative order within a destination.
+//!
+//! # The hash
+//!
+//! Routing uses [`corgi::hash`] — the same structural content hash that
+//! [`present_key`](crate::corgi::chunk::present_key) prepends as a key's identifier lane. Any
+//! deterministic function of the key would be correct here; choosing *this* one means the
+//! distributor and the arrangement agree on what a key's identifier is, so the hash a receiver
+//! recomputes is the one the sender routed by. (It is also seed-free and structural, so it agrees
+//! across processes and across runs, and its low bits are mixed — a raw key column would route a
+//! strided identifier space onto a fraction of the workers.)
+
+use timely::communication::Push;
+use timely::dataflow::channels::Message;
+use timely::dataflow::channels::pact::{LogPuller, LogPusher, ParallelizationContract};
+use timely::dataflow::channels::pushers::{Exchange, exchange::Distributor};
+use timely::logging::TimelyLogger;
+use timely::progress::{Stamp, Timestamp};
+use timely::worker::Worker;
+
+use corgi::arrange::gather;
+
+use crate::corgi::container::CorgiContainer;
+
+/// Partitions a [`CorgiContainer`] across workers by the structural hash of each row's key.
+///
+/// The scratch buffers are fields rather than locals because `partition` is called once per
+/// container for the life of the dataflow; a per-call allocation of three `Vec`s per batch is the
+/// kind of cost that shows up as a flat tax on every exchange.
+pub struct CorgiDistributor<T, R> {
+    marker: std::marker::PhantomData<(T, R)>,
+    /// Row indices, grouped by destination: destination `p` owns `order[starts[p]..starts[p+1]]`.
+    order: Vec<usize>,
+    /// Running offsets into `order`, one per destination plus the total.
+    starts: Vec<usize>,
+}
+
+impl<T, R> Default for CorgiDistributor<T, R> {
+    fn default() -> Self {
+        CorgiDistributor { marker: std::marker::PhantomData, order: Vec::new(), starts: Vec::new() }
+    }
+}
+
+impl<T: Clone + 'static, R: Clone + 'static> CorgiDistributor<T, R> {
+    /// Group row indices by destination, leaving each destination's rows as a contiguous,
+    /// input-ordered run of `self.order` delimited by `self.starts`.
+    ///
+    /// A counting sort: one pass to count, one to place. `peers` is a power of two in the common
+    /// case, where the modulus is a mask.
+    fn counting_sort(&mut self, ids: &[u64], peers: usize) {
+        self.starts.clear();
+        self.starts.resize(peers + 1, 0);
+        let dest = |h: u64| -> usize {
+            if peers.is_power_of_two() { (h & (peers as u64 - 1)) as usize } else { (h % peers as u64) as usize }
+        };
+        for &h in ids {
+            self.starts[dest(h) + 1] += 1;
+        }
+        for p in 0..peers {
+            self.starts[p + 1] += self.starts[p];
+        }
+        // `cursor` walks each destination's run as rows are placed; `starts` is left intact.
+        self.order.clear();
+        self.order.resize(ids.len(), 0);
+        let mut cursor = self.starts[..peers].to_vec();
+        for (row, &h) in ids.iter().enumerate() {
+            let p = dest(h);
+            self.order[cursor[p]] = row;
+            cursor[p] += 1;
+        }
+    }
+}
+
+impl<T: Clone + 'static, R: Clone + 'static> Distributor<CorgiContainer<T, R>> for CorgiDistributor<T, R> {
+    fn partition<Ts: Clone, P: Push<Message<Ts, CorgiContainer<T, R>>>>(
+        &mut self,
+        container: &mut CorgiContainer<T, R>,
+        stamp: &Stamp<Ts>,
+        pushers: &mut [P],
+    ) {
+        let rows = container.times.len();
+        if rows == 0 {
+            return;
+        }
+        let peers = pushers.len();
+
+        let ids = corgi::hash(&container.keys).into_u64("corgi exchange: key hash");
+        self.counting_sort(&ids, peers);
+
+        // Whole-container fast path. When every row shares a destination — a batch narrower than
+        // the worker count, or data already partitioned upstream — the container moves as it
+        // stands: no hash-ordered gather, no column copy, no per-row time clone.
+        if let Some(p) = (0..peers).find(|&p| self.starts[p + 1] - self.starts[p] == rows) {
+            Message::push_at(container, stamp.clone(), &mut pushers[p]);
+            return;
+        }
+
+        for (p, pusher) in pushers.iter_mut().enumerate() {
+            let idx = &self.order[self.starts[p]..self.starts[p + 1]];
+            if idx.is_empty() {
+                continue;
+            }
+            let mut part = CorgiContainer {
+                keys: gather(&container.keys, idx),
+                vals: gather(&container.vals, idx),
+                times: idx.iter().map(|&i| container.times[i].clone()).collect(),
+                diffs: idx.iter().map(|&i| container.diffs[i].clone()).collect(),
+            };
+            Message::push_at(&mut part, stamp.clone(), pusher);
+        }
+        // Every row of the input landed in exactly one output, so the record count timely tracks
+        // is preserved. Clear the input rather than leaving it to be re-sent.
+        *container = CorgiContainer::default();
+    }
+
+    /// Nothing is held back: `partition` ships each destination's rows immediately, so there is
+    /// never a partial container waiting on a flush. Batching across containers would mean
+    /// holding key columns per destination and concatenating them, which is the batcher's job one
+    /// operator downstream — doing it here as well would just move the copy.
+    fn flush<Ts: Clone, P: Push<Message<Ts, CorgiContainer<T, R>>>>(&mut self, _stamp: &Stamp<Ts>, _pushers: &mut [P]) {}
+
+    fn relax(&mut self) {
+        self.order = Vec::new();
+        self.starts = Vec::new();
+    }
+}
+
+/// The parallelization contract that shuffles [`CorgiContainer`]s by key hash.
+///
+/// Substituting this for `Pipeline` in the corgi backend's `arrange` is what makes the backend
+/// multi-worker: it is the only place the backend's data has to move between workers, because
+/// every other operator (`linear`, `join`, `reduce`, `as_collection`) is key-local given
+/// correctly placed arrangements.
+pub struct CorgiPact;
+
+impl<Time, T, R> ParallelizationContract<Time, CorgiContainer<T, R>> for CorgiPact
+where
+    Time: Timestamp,
+    T: Clone + Send + 'static,
+    R: Clone + Send + 'static,
+    CorgiContainer<T, R>: timely::dataflow::channels::ContainerBytes,
+{
+    type Pusher = Exchange<
+        Time,
+        LogPusher<Box<dyn Push<Message<Time, CorgiContainer<T, R>>>>>,
+        CorgiDistributor<T, R>,
+    >;
+    type Puller = LogPuller<Box<dyn timely::communication::Pull<Message<Time, CorgiContainer<T, R>>>>>;
+
+    fn connect(self, worker: &Worker, identifier: usize, address: std::rc::Rc<[usize]>, logging: Option<TimelyLogger>) -> (Self::Pusher, Self::Puller) {
+        let (senders, receiver) = worker.allocate::<Message<Time, CorgiContainer<T, R>>>(identifier, address);
+        let senders = senders
+            .into_iter()
+            .enumerate()
+            .map(|(i, x)| LogPusher::new(x, worker.index(), i, identifier, logging.clone()))
+            .collect::<Vec<_>>();
+        (Exchange::new(senders, CorgiDistributor::default()), LogPuller::new(receiver, worker.index(), identifier, logging))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use timely::dataflow::channels::pushers::exchange::Distributor;
+
+    use super::CorgiDistributor;
+    use crate::corgi::container::CorgiContainer;
+    use crate::ir::{Diff, Time, Value as DValue};
+
+    /// A pusher that keeps what it is given, so a test can inspect the partition directly.
+    #[derive(Default)]
+    struct Collect<T, R>(Vec<CorgiContainer<T, R>>);
+
+    impl<Ts, T: 'static, R: 'static> timely::communication::Push<timely::dataflow::channels::Message<Ts, CorgiContainer<T, R>>> for Collect<T, R> {
+        fn push(&mut self, message: &mut Option<timely::dataflow::channels::Message<Ts, CorgiContainer<T, R>>>) {
+            if let Some(message) = message.take() {
+                self.0.push(message.data);
+            }
+        }
+    }
+
+    fn time() -> Time {
+        use differential_dataflow::dynamic::pointstamp::PointStamp;
+        timely::order::Product::new(0, PointStamp::new(Default::default()))
+    }
+
+    /// Partition `updates` across `peers` destinations and read each destination back as rows.
+    fn partition(updates: Vec<((DValue, DValue), Time, Diff)>, peers: usize) -> Vec<Vec<((DValue, DValue), Time, Diff)>> {
+        let mut container = CorgiContainer::<Time, Diff>::from_updates(updates);
+        let mut pushers: Vec<Collect<Time, Diff>> = (0..peers).map(|_| Collect::default()).collect();
+        let mut distributor = CorgiDistributor::<Time, Diff>::default();
+        distributor.partition(&mut container, &timely::progress::Stamp::from_elem(0u64), &mut pushers);
+        pushers
+            .into_iter()
+            .map(|p| p.0.into_iter().flat_map(|c| c.into_updates()).collect())
+            .collect()
+    }
+
+    fn scalar_updates(n: i64) -> Vec<((DValue, DValue), Time, Diff)> {
+        (0..n).map(|i| ((DValue::Int(i), DValue::Int(i * 10)), time(), i)).collect()
+    }
+
+    /// Nothing is lost and nothing is duplicated: the partition is a partition.
+    #[test]
+    fn partition_preserves_every_update() {
+        let updates = scalar_updates(200);
+        for peers in [2, 3, 4, 8] {
+            let parts = partition(updates.clone(), peers);
+            let mut got: Vec<_> = parts.into_iter().flatten().collect();
+            got.sort();
+            let mut want = updates.clone();
+            want.sort();
+            assert_eq!(got, want, "peers = {peers}");
+        }
+    }
+
+    /// The property arrangements depend on: a key's updates all land on one worker, whatever
+    /// value, time, or diff they carry, and whichever batch they arrived in.
+    #[test]
+    fn a_key_goes_to_one_destination() {
+        // Three updates per key, differing in value and diff, so a key that routed by anything
+        // other than its key would scatter.
+        let updates: Vec<_> = (0..100i64)
+            .flat_map(|k| (0..3i64).map(move |v| ((DValue::Tuple(vec![DValue::Int(k), DValue::Int(k / 7)]), DValue::Int(v)), time(), v + 1)))
+            .collect();
+        for peers in [2, 3, 5, 8] {
+            let parts = partition(updates.clone(), peers);
+            let mut seen: std::collections::HashMap<DValue, usize> = Default::default();
+            for (p, part) in parts.iter().enumerate() {
+                for ((k, _), _, _) in part {
+                    if let Some(&q) = seen.get(k) {
+                        assert_eq!(q, p, "key {k:?} landed on both {q} and {p} at peers = {peers}");
+                    } else {
+                        seen.insert(k.clone(), p);
+                    }
+                }
+            }
+            assert_eq!(seen.len(), 100, "peers = {peers}");
+        }
+    }
+
+    /// Two containers holding the same key route it to the same place — the property that makes
+    /// a join correct, since its two inputs are separate streams.
+    #[test]
+    fn routing_is_independent_of_the_batch() {
+        let keys: Vec<DValue> = (0..64i64).map(|k| DValue::Tuple(vec![DValue::Int(k), DValue::Int(-k)])).collect();
+        let left: Vec<_> = keys.iter().map(|k| ((k.clone(), DValue::Int(1)), time(), 1)).collect();
+        // The same keys, in a different order, with different values: only the key may matter.
+        let right: Vec<_> = keys.iter().rev().map(|k| ((k.clone(), DValue::Int(2)), time(), 5)).collect();
+        for peers in [2, 4, 7] {
+            let (lp, rp) = (partition(left.clone(), peers), partition(right.clone(), peers));
+            let dest = |parts: &Vec<Vec<((DValue, DValue), Time, Diff)>>| -> std::collections::HashMap<DValue, usize> {
+                parts.iter().enumerate().flat_map(|(p, part)| part.iter().map(move |((k, _), _, _)| (k.clone(), p))).collect()
+            };
+            assert_eq!(dest(&lp), dest(&rp), "peers = {peers}");
+        }
+    }
+
+    /// Hashing, not the key's own bits: a strided identifier space (every key a multiple of the
+    /// worker count) must not collapse onto one worker, which is what routing by the raw key
+    /// would do.
+    #[test]
+    fn strided_keys_still_spread() {
+        let updates: Vec<_> = (0..400i64).map(|i| ((DValue::Int(i * 8), DValue::Int(i)), time(), 1)).collect();
+        let parts = partition(updates, 8);
+        for (p, part) in parts.iter().enumerate() {
+            assert!(!part.is_empty(), "destination {p} got nothing from 400 strided keys");
+        }
+    }
+
+    /// A container whose rows all share a destination moves whole, and the input is left empty
+    /// either way so no row is sent twice.
+    #[test]
+    fn the_input_is_consumed() {
+        let mut container = CorgiContainer::<Time, Diff>::from_updates(scalar_updates(50));
+        let mut pushers: Vec<Collect<Time, Diff>> = (0..4).map(|_| Collect::default()).collect();
+        let mut distributor = CorgiDistributor::<Time, Diff>::default();
+        distributor.partition(&mut container, &timely::progress::Stamp::from_elem(0u64), &mut pushers);
+        assert_eq!(container.times.len(), 0, "partition left rows in the input container");
+        let shipped: usize = pushers.iter().map(|p| p.0.iter().map(|c| c.times.len()).sum::<usize>()).sum();
+        assert_eq!(shipped, 50, "record count was not preserved");
+    }
+
+    /// An empty container is a no-op, not a panic or a stream of empty messages.
+    #[test]
+    fn empty_containers_ship_nothing() {
+        let mut container = CorgiContainer::<Time, Diff>::default();
+        let mut pushers: Vec<Collect<Time, Diff>> = (0..4).map(|_| Collect::default()).collect();
+        let mut distributor = CorgiDistributor::<Time, Diff>::default();
+        distributor.partition(&mut container, &timely::progress::Stamp::from_elem(0u64), &mut pushers);
+        assert!(pushers.iter().all(|p| p.0.is_empty()));
+    }
+}

--- a/interactive/src/corgi/mod.rs
+++ b/interactive/src/corgi/mod.rs
@@ -1,12 +1,15 @@
 //! The corgi rendering substrate's internals: the columnar container on dataflow
-//! edges ([`container`]), the columnar chunk and its arrangement plumbing ([`chunk`]),
+//! edges ([`container`]) and its wire format ([`bytes`]), the columnar chunk and
+//! its arrangement plumbing ([`chunk`]), the key-hash shuffle ([`exchange`]),
 //! the DDIR-term compiler ([`logic`]), and the join/reduce tactic bindings ([`join`],
 //! [`reduce`]). The `Backend` impl wiring these into rendering is
 //! [`crate::backend::corgi`].
 
+pub mod bytes;
 pub mod chunk;
 pub mod col_times;
 pub mod container;
+pub mod exchange;
 pub mod join;
 pub mod logic;
 pub mod reduce;

--- a/interactive/tests/corgi_backend.rs
+++ b/interactive/tests/corgi_backend.rs
@@ -33,6 +33,12 @@ fn inputs_for(prog: &str) -> Vec<Vec<(Value, Value)>> {
         // scalar_ops: (key, a, b) triples; a values straddle the `> 2` and `= -5` tests.
         "scalar_ops" => vec![rows(&[&[1, 1, 9], &[1, 4, 8], &[2, 3, 7], &[3, -5, 6], &[3, 2, 5]])],
         "sum_ops" => vec![rows(&[&[1, 10], &[2, 20], &[2, 21]])],
+        // empty_batch: only key 1 has the two values the filter keeps, so at several workers at
+        // least one gets a batch that arrives non-empty and leaves empty.
+        "empty_batch" => vec![rows(&[
+            &[1, 10], &[1, 20],
+            &[2, 1], &[3, 1], &[4, 1], &[5, 1], &[6, 1], &[7, 1], &[8, 1], &[9, 1],
+        ])],
         // sum_skew: any keyed pairs — the skew is in the program, not the data.
         "sum_skew" => vec![rows(&[&[1, 10], &[2, 20], &[2, 21], &[3, 30]])],
         "case_ops" => vec![rows(&[&[1, 10], &[2, 20], &[3, 14], &[3, 30]])],
@@ -104,6 +110,7 @@ fn serializing(n: usize) -> timely::Config {
 #[test] fn join_fallback() { assert_backends_agree("join_fallback"); }
 #[test] fn scalar_ops() { assert_backends_agree("scalar_ops"); }
 #[test] fn sum_ops() { assert_backends_agree("sum_ops"); }
+#[test] fn empty_batch() { assert_backends_agree("empty_batch"); }
 #[test] fn sum_skew() { assert_backends_agree("sum_skew"); }
 #[test] fn case_ops() { assert_backends_agree("case_ops"); }
 #[test] fn tour() { assert_backends_agree("tour"); }

--- a/interactive/tests/corgi_backend.rs
+++ b/interactive/tests/corgi_backend.rs
@@ -64,11 +64,34 @@ fn assert_backends_agree(prog: &str) {
     let mut tree = lower::lower_tree(parse::pipe::parse(&src));
     tree.optimize();
     let inputs = inputs_for(prog);
+    let want = vec::evaluate(&tree, &inputs);
+    // At every worker count: the exchange places each key on one worker and every operator is
+    // key-local from there, so the answer must not depend on how many workers ran it. 3 is in the
+    // list on purpose — it is not a power of two, so it takes the modulus path rather than the
+    // mask, and it cannot divide these inputs evenly.
+    for workers in [1, 2, 3, 4] {
+        assert_eq!(
+            corgi::evaluate_with_workers(&tree, &inputs, workers),
+            want,
+            "corgi backend at {workers} worker(s) disagrees with the vec backend on {prog}",
+        );
+    }
+    // The same programs again with serializing channels, so every exchanged container makes the
+    // round trip through the wire format. This is the multi-process path: `Config::process` above
+    // hands containers between threads as typed values and never encodes a byte.
     assert_eq!(
-        corgi::evaluate(&tree, &inputs),
-        vec::evaluate(&tree, &inputs),
-        "corgi backend disagrees with the vec backend on {prog}",
+        corgi::evaluate_with_config(&tree, &inputs, serializing(3)),
+        want,
+        "corgi backend over serializing channels disagrees with the vec backend on {prog}",
     );
+}
+
+/// `n` worker threads whose exchange channels serialize — the wire format in the loop.
+fn serializing(n: usize) -> timely::Config {
+    timely::Config {
+        communication: timely::CommunicationConfig::ProcessBinary(n),
+        worker: timely::WorkerConfig::default(),
+    }
 }
 
 #[test] fn reach() { assert_backends_agree("reach"); }

--- a/interactive/tests/programs/empty_batch.ddp
+++ b/interactive/tests/programs/empty_batch.ddp
@@ -1,0 +1,26 @@
+-- A batch emptied by a columnar filter, then a projection that falls back to rows.
+--
+-- The corgi backend's linear ops are shape-directed, and a container with no rows has no shape.
+-- Two steps are needed to reach the hole, which is why it survived until the exchange landed:
+--
+--   1. an op that empties a batch while KEEPING its shape — the columnar filter path does this,
+--      since `gather` of an empty index list is still a typed zero-row column;
+--   2. an op whose term the lowering DECLINES, so it takes the row-wise path and rebuilds the
+--      container with `from_updates` — which, with no rows to scan, returns `Unit` keys and vals.
+--
+-- After that any op needing the shape lowers a `Field` against a `Unit`: legal to compile,
+-- impossible to evaluate. `$1[0][0] * $1[1][0]` over a collected list is a declining term, and
+-- the export's `$1[0]` is the op that then meets the erased shape.
+--
+-- Reaching it also takes a batch that arrives non-empty and leaves empty, which is why the gate
+-- runs every program at several worker counts: only key 1 has the two values the filter keeps, so
+-- at three or four workers at least one holds nothing but keys the filter rejects.
+--
+-- This is the shape of AoC 2023 day 3 part 2's export, which is where it was found.
+
+let vals    = input 0 | key($0[0] ; $0[1]);
+let grouped = vals | collect;
+let two     = grouped | filter(len($1) == 2);
+let prod    = two | map(; $1[0][0] * $1[1][0]);
+
+export "result" = prod | map($0 ; $1[0] * 2) | arrange | inspect(total);


### PR DESCRIPTION
The corgi backend's `arrange` used `Pipeline` and asserted `peers() == 1`, because a multi-worker run would have MIS-PLACED keys — silently wrong, not slow. This replaces that assert with the exchange it was waiting for, and the backend now renders on any number of workers, in any number of processes.

## The distributor

`arrange` is the only exchange point in the `Backend` trait, so substituting a pact for `Pipeline` is the whole of multi-worker support: every other operator (`linear`, `join`, `reduce`, `as_collection`) is key-local once arrangements are placed correctly, and both sides of a join agree on placement because they route by the same function of the key.

Timely's stock `DrainContainerDistributor` is unusable here. A `CorgiContainer` has no items to drain — it is four columns — and taking it apart row-wise would undo the representation before the data left the worker. `CorgiDistributor` partitions the way a columnar engine does:

1. hash the key column once, columnar, with `corgi::hash` — the same structural hash `present_key` prepends as a key's identifier lane, so the distributor and the arrangement agree on what a key's identifier *is*;
2. counting-sort row indices by destination (mask when peers is a power of two, modulus otherwise);
3. `gather` each destination's rows into fresh contiguous columns — which is exactly what the wire format wants to write, one memcpy per leaf.

Stable, so rows keep their order within a destination. A container whose rows all share a destination moves whole, with no gather at all. The index buffers are fields, not locals, so a batch costs no allocation beyond the hash column itself.

## The wire format

`corgi/bytes.rs` is `ContainerBytes` for `CorgiContainer`: four length words, then the key and value columns through `corgi::bytes` (landed as frankmcsherry/WIP#13) and the time and diff columns through `columnar`'s `Stash` — the encoder `T: Columnar` was already chosen for. Every section is a whole number of words, so a receiver can install the bytes rather than relocate them.

The contrast is the point: the row backend's `Vec<((Row, Row), T, R)>` reaches the wire through bincode, walking every `Value` of every row and emitting varints. This walks four columns and emits memcpys.

The container decoder checks the four columns agree with the time column's length. `corgi::bytes` guarantees a structurally sound `Value` but not a small one — the payload-free constructors declare rows without spending bytes, so a `Unit` names a trillion rows in sixteen bytes and nothing inside corgi can call that wrong. Here it is wrong, and this is the layer that knows.

## A latent bug the exchange made reachable

A container with no rows has no *shape* either: every path that rebuilds one from rows infers its columns by scanning them, so `from_updates` on an empty vector returns the shape-erased default. Hand that to the next op and `compile_projection` lowers `$1[0]` against a `Unit`, because a `Field` is legal in the abstract; `eval_graph` then panics with "Field: expected a product".

Reaching it takes two steps, which is why it survived: an op that empties a batch while KEEPING its shape (the columnar filter path — `gather` of an empty index list is still a typed zero-row column), and then an op whose term the lowering DECLINES, taking the row-wise path through `from_updates`. One worker rarely empties a batch it was given; the key-hash exchange makes it routine.

Fixed by skipping ops once a container is empty, at the top of the loop rather than before it — a chain empties *itself*, a filter dropping every row and handing the erased container to the very next op in the same slice. That is the whole answer rather than a shortcut: every `LinearOp` maps zero rows to zero rows, so the only thing the ops could contribute is the output shape, and no consumer reads an empty container's shape anyway.

## Testing

**The gate.** `tests/corgi_backend.rs` runs each of its programs at 1, 2, 3 and 4 workers — 3 deliberately, so the modulus path runs rather than the mask and no input divides evenly — and again over `ProcessBinary` channels, which serializes every exchanged container. That last one is the multi-process path without the processes, so the wire format is exercised in-tree rather than only in a cluster. `evaluate_with_workers` / `evaluate_with_config` are the entry points that makes possible.

**The AoC suite.** The 33 parts added in #847 have known answers, so they were run through the corgi backend at 1, 3 and 4 workers. This is what found the bug above: day03 part2 answered correctly at one worker and panicked at four. With the fix, all 33 give identical results at every worker count. Four still disagree with the oracle — day01 p1/p2 and day05 p1/p2 — but those are the pre-existing ones that suite's README already records, and they do not vary with worker count. `tests/programs/empty_batch.ddp` reproduces the failure in the gate, built from the failing day03 export rather than guessed at: two earlier attempts passed with the fix reverted, because the filters I reached for compiled columnar and kept their shape.

**Real processes.** `scc` at n=20k with 200 rounds of incremental insertions and retractions gives the identical net count (25298) for vec at 1/2/4 workers, corgi at 1/2/4 workers, and corgi across two OS processes over TCP.

**Unit tests** cover the partition (it is a partition; a key goes to one destination; routing does not depend on the batch, which is what makes a join correct; strided keys still spread, which routing by the raw key would not) and the container codec (round trips per shape family, truncation, and that a key column costs its payload).

## Performance

M4, 10 cores. Load time, median of 3, `rounds = 0`.

| program | backend | -w1 | -w2 | -w4 |
|---|---|---|---|---|
| scc n=100k e=200k | corgi | 2.01 s | 1.12 s | **716 ms** |
| scc n=100k e=200k | vec | 2.70 s | 1.49 s | 876 ms |
| reach n=200k e=400k | corgi | 279 ms | 153 ms | **99 ms** |
| reach n=200k e=400k | vec | 357 ms | 195 ms | 109 ms |

2.8× at four workers on both programs, and corgi stays ahead of vec at every worker count. Both backends regress past four workers, which is this machine's P-core/E-core boundary rather than anything about the exchange.

**Serialization costs +6.3%.** Same program, four workers either way: 715 ms as one process with typed channels, 760 ms as two OS processes with the wire format plus TCP. vec pays +9.0% for bincode over the same step. corgi paying full serialization beats vec paying none.

**The exchange itself is 1.2%** — everything under `Exchange::push` in a `samply` profile of `scc` at `-w4` is 35 of 2983 samples.

**Why 2.8× and not 4×,** since that is the obvious next question. Total CPU rises 1.54× from one worker to four (1931 → 2983 samples), and 4 / 1.54 = 2.6. Of the 1052 added samples: `step_or_park` self time is **0 at one worker and 362 at four** — timely's scheduler, a third of the loss — then `ProxyReduceTactic::retire` +178, `MergeBatcher::seal` +122, `SmallVec::try_grow` +91, which are per-batch fixed costs multiplying by worker count as each worker seals and retires and merges its own quarter. The exchange is +35. **The lever for better scaling is batch granularity, not the shuffle.**

## Two ideas measured and set aside

**Ship each destination pre-sorted by key hash.** The receiver's chunker sorts anyway, and has to — it is merging W senders' blocks, not one. Sorting at the sender adds a sort there and leaves the receiver's merge in place. The profile puts the receiver's whole ingest sort at 3.3%; there is no 20% sitting there.

**Carry the hash lane across the exchange** so the receiver's `present_key` need not recompute it. Only bites compound keys — `present_key` uses a primitive-integer key as it stands and hashes nothing, and scc, reach and stable are all scalar-keyed after lowering. It would need a flag on the container whose invariant is held by the dataflow's topology rather than by the type, which is fragile for a slice of an already-1.2% budget.

## Known cost

`length_in_bytes` and `into_bytes` are separate calls on `&self`, and the time and diff columns must be built to be measured, so they are built twice — two linear passes over `times`, on the multi-process path only. The fix is the one `container.rs` already names: hold times columnar in the container instead of as `Vec<T>`. Keys and values do not have this problem, since sizing a `Value` walks its shape without touching a payload byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
