### PR TITLE
DDIR: the optimizer as a DDIR program (an e-graph over each scope)

### DIFF
--- a/differential-dataflow/src/collection.rs
+++ b/differential-dataflow/src/collection.rs
@@ -1252,6 +1252,42 @@ pub mod vec {
     }
 }
 
+/// Routes the records of one message to singleton capabilities when the message's stamp has
+/// several elements.
+///
+/// A batch is shipped under the set of capabilities it retires, so a message of batches can
+/// carry several timestamps. Records each have one time, and an operator over records reads a
+/// message's time as one (`InputCapability::time`); an operator that turns batches into records
+/// keeps that true by sending each record under the first element of the stamp at or before its
+/// time. The elements cover every record: a batch's times are at or beyond one of the
+/// capabilities it retired under.
+pub struct StampRouter<T: Timestamp> {
+    caps: Vec<timely::dataflow::operators::Capability<T>>,
+}
+
+impl<T: Timestamp> StampRouter<T> {
+    /// One capability per element of the message's stamp, for output `port`.
+    pub fn new(cap: &timely::dataflow::operators::InputCapability<T>, port: usize) -> Self {
+        Self { caps: cap.stamp().iter().map(|t| cap.delayed(t, port)).collect() }
+    }
+    /// One capability per element of a set.
+    pub fn from_set(set: &timely::dataflow::operators::CapabilitySet<T>) -> Self {
+        Self { caps: set.iter().cloned().collect() }
+    }
+    /// The capabilities, in the order `index` names them.
+    pub fn capabilities(&self) -> &[timely::dataflow::operators::Capability<T>] {
+        &self.caps
+    }
+    /// Which capability a record at `time` goes under.
+    pub fn index(&self, time: &T) -> usize {
+        self.caps.iter().position(|c| c.time().less_equal(time)).expect("a record's time is at or beyond an element of its message's stamp")
+    }
+    /// Empty buffers, one per capability, to route records into and then give under each.
+    pub fn buffers<D>(&self) -> Vec<Vec<D>> {
+        (0..self.caps.len()).map(|_| Vec::new()).collect()
+    }
+}
+
 /// Conversion to a differential dataflow Collection.
 pub trait AsCollection<'scope, T: Timestamp, C> {
     /// Converts the type to a differential dataflow collection.

--- a/differential-dataflow/src/columnar/collection/operators.rs
+++ b/differential-dataflow/src/columnar/collection/operators.rs
@@ -116,12 +116,19 @@ where
         move |_frontier| {
             let mut output = output.activate();
             op_input.for_each(|cap, data| {
-                // Truncate the capability's timestamp.
-                let mut new_time = cap.time().clone();
-                let mut vec = std::mem::take(&mut new_time.inner).into_inner();
-                vec.truncate(level - 1);
-                new_time.inner = PointStamp::new(vec);
-                let new_cap = cap.delayed(&new_time, 0);
+                // A message may carry several timestamps (a multi-element stamp): hold a
+                // capability for each, truncated exactly as the updates are.
+                let new_cap: timely::dataflow::operators::CapabilitySet<_> = cap
+                    .stamp()
+                    .iter()
+                    .map(|t| {
+                        let mut new_time = t.clone();
+                        let mut vec = std::mem::take(&mut new_time.inner).into_inner();
+                        vec.truncate(level - 1);
+                        new_time.inner = PointStamp::new(vec);
+                        cap.delayed(&new_time, 0)
+                    })
+                    .collect();
                 // Push updates with truncated times into the builder.
                 // The builder's form call on flush sorts and consolidates,
                 // handling the duplicate times that truncation can produce.

--- a/differential-dataflow/src/columnar/collection/operators.rs
+++ b/differential-dataflow/src/columnar/collection/operators.rs
@@ -174,20 +174,30 @@ where
         .unary::<Builder<U>, _, _, _>(Pipeline, "AsRecordedUpdates", |_, _| {
             move |input, output| {
                 input.for_each(|time, batches| {
-                    let mut session = output.session_with_builder(&time);
-                    for batch in batches.drain(..) {
-                        let Some(batch) = batch.inner else { continue };
-                        let mut cursor = batch.cursor();
-                        while cursor.key_valid(&batch) {
-                            while cursor.val_valid(&batch) {
-                                let key = cursor.key(&batch);
-                                let val = cursor.val(&batch);
-                                cursor.map_times(&batch, |time, diff| {
-                                    session.give((key, val, time, diff));
-                                });
-                                cursor.step_val(&batch);
+                    // A message of batches may carry several timestamps; each record goes out
+                    // under the one at or before its time (a pass per element, the rare case),
+                    // so the collection's messages carry one each.
+                    let router = crate::collection::StampRouter::new(&time, 0);
+                    let batches: Vec<_> = batches.drain(..).filter_map(|b| b.inner).collect();
+                    let mut owned_time = U::Time::default();
+                    for (index, cap) in router.capabilities().iter().enumerate() {
+                        let mut session = output.session_with_builder(cap);
+                        for batch in batches.iter() {
+                            let mut cursor = batch.cursor();
+                            while cursor.key_valid(batch) {
+                                while cursor.val_valid(batch) {
+                                    let key = cursor.key(batch);
+                                    let val = cursor.val(batch);
+                                    cursor.map_times(batch, |time, diff| {
+                                        columnar::Columnar::copy_from(&mut owned_time, time);
+                                        if router.index(&owned_time) == index {
+                                            session.give((key, val, time, diff));
+                                        }
+                                    });
+                                    cursor.step_val(batch);
+                                }
+                                cursor.step_key(batch);
                             }
-                            cursor.step_key(&batch);
                         }
                     }
                 });

--- a/differential-dataflow/src/dynamic/mod.rs
+++ b/differential-dataflow/src/dynamic/mod.rs
@@ -16,6 +16,7 @@ pub mod pointstamp;
 use timely::order::Product;
 use timely::progress::Timestamp;
 use timely::dataflow::operators::generic::{OutputBuilder, builder_rc::OperatorBuilder};
+use timely::dataflow::operators::CapabilitySet;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::progress::Antichain;
 
@@ -47,17 +48,21 @@ where
         builder.build(move |_capability| move |_frontier| {
             let mut output = output.activate();
             input.for_each(|cap, data| {
-                let mut new_time = cap.time().clone();
-                let mut vec = std::mem::take(&mut new_time.inner).into_inner();
-                vec.truncate(level - 1);
-                new_time.inner = PointStamp::new(vec);
-                let new_cap = cap.delayed(&new_time, 0);
-                for (_data, time, _diff) in data.iter_mut() {
-                    let mut vec = std::mem::take(&mut time.inner).into_inner();
+                // A message may carry several timestamps (a multi-element stamp, e.g. late
+                // iterations of one epoch alongside early ones of the next): hold a capability
+                // for each, truncated exactly as the records are.
+                let truncate = |time: &Product<TOuter, PointStamp<T>>| {
+                    let mut new_time = time.clone();
+                    let mut vec = std::mem::take(&mut new_time.inner).into_inner();
                     vec.truncate(level - 1);
-                    time.inner = PointStamp::new(vec);
+                    new_time.inner = PointStamp::new(vec);
+                    new_time
+                };
+                let caps: CapabilitySet<_> = cap.stamp().iter().map(|t| cap.delayed(&truncate(t), 0)).collect();
+                for (_data, time, _diff) in data.iter_mut() {
+                    *time = truncate(time);
                 }
-                output.session(&new_cap).give_container(data);
+                output.session(&caps).give_container(data);
             });
         });
 

--- a/differential-dataflow/src/operators/arrange/arrangement.rs
+++ b/differential-dataflow/src/operators/arrange/arrangement.rs
@@ -179,20 +179,30 @@ impl<'scope, Tr: TraceReader> Arranged<'scope, Tr> {
     {
         stream.unary(Pipeline, "AsCollection", move |_,_| move |input, output| {
             input.for_each(|time, data| {
-                let mut session = output.session(&time);
+                // A message of batches may carry several timestamps; each record goes out under
+                // the one at or before its time, so the collection's messages carry one each.
+                let router = crate::collection::StampRouter::new(&time, 0);
+                let mut buffers = router.buffers();
                 for wrapper in data.iter() {
                     let Some(batch) = wrapper.inner.as_ref() else { continue };
                     let mut cursor = batch.cursor();
                     while let Some(key) = cursor.get_key(batch) {
                         while let Some(val) = cursor.get_val(batch) {
                             for datum in logic(key, val) {
-                                cursor.map_times(batch, |time, diff| {
-                                    session.give((datum.clone(), <BatchCursor<Tr> as Cursor>::owned_time(time), <BatchCursor<Tr> as Cursor>::owned_diff(diff)));
+                                cursor.map_times(batch, |t, diff| {
+                                    let t = <BatchCursor<Tr> as Cursor>::owned_time(t);
+                                    let index = router.index(&t);
+                                    buffers[index].push((datum.clone(), t, <BatchCursor<Tr> as Cursor>::owned_diff(diff)));
                                 });
                             }
                             cursor.step_val(batch);
                         }
                         cursor.step_key(batch);
+                    }
+                }
+                for (cap, mut buffer) in router.capabilities().iter().zip(buffers) {
+                    if !buffer.is_empty() {
+                        output.session(cap).give_container(&mut buffer);
                     }
                 }
             });

--- a/differential-dataflow/src/operators/count.rs
+++ b/differential-dataflow/src/operators/count.rs
@@ -94,7 +94,14 @@ where
 
                 if !caps.is_empty() {
 
-                    let mut session = output.session(&caps);
+                    // The batches' capabilities may span several timestamps; each record goes out
+                    // under the one at or before its time, so the collection's messages carry one.
+                    let router = crate::collection::StampRouter::from_set(&caps);
+                    let mut buffers = router.buffers();
+                    let mut give = |record: (_, Tr::Time, _)| {
+                        let index = router.index(&record.1);
+                        buffers[index].push(record);
+                    };
 
                     let (mut batch_cursor, batch_storage) = crate::trace::cursor::cursor_list(batch_storage.into_iter().filter_map(|b| b.inner).collect());
                     let (mut trace_cursor, trace_storage) = crate::trace::cursor::cursor_list(trace.batches_through(lower_limit.borrow()).unwrap());
@@ -114,19 +121,24 @@ where
 
                             if let Some(count) = count.as_ref() {
                                 if !count.is_zero() {
-                                    session.give(((key.clone(), count.clone()), <BatchCursor<Tr> as Cursor>::owned_time(time), R2::from(-1i8)));
+                                    give(((key.clone(), count.clone()), <BatchCursor<Tr> as Cursor>::owned_time(time), R2::from(-1i8)));
                                 }
                             }
                             count.as_mut().map(|c| c.plus_equals(&diff));
                             if count.is_none() { count = Some(<BatchCursor<Tr> as Cursor>::owned_diff(diff)); }
                             if let Some(count) = count.as_ref() {
                                 if !count.is_zero() {
-                                    session.give(((key.clone(), count.clone()), <BatchCursor<Tr> as Cursor>::owned_time(time), R2::from(1i8)));
+                                    give(((key.clone(), count.clone()), <BatchCursor<Tr> as Cursor>::owned_time(time), R2::from(1i8)));
                                 }
                             }
                         });
 
                         batch_cursor.step_key(&batch_storage);
+                    }
+                    for (cap, mut buffer) in router.capabilities().iter().zip(buffers) {
+                        if !buffer.is_empty() {
+                            output.session(cap).give_container(&mut buffer);
+                        }
                     }
                 }
 

--- a/differential-dataflow/src/operators/threshold.rs
+++ b/differential-dataflow/src/operators/threshold.rs
@@ -144,7 +144,14 @@ where
 
                 if !caps.is_empty() {
 
-                    let mut session = output.session(&caps);
+                    // The batches' capabilities may span several timestamps; each record goes out
+                    // under the one at or before its time, so the collection's messages carry one.
+                    let router = crate::collection::StampRouter::from_set(&caps);
+                    let mut buffers = router.buffers();
+                    let mut give = |record: (_, Tr::Time, _)| {
+                        let index = router.index(&record.1);
+                        buffers[index].push(record);
+                    };
 
                     let (mut batch_cursor, batch_storage) = crate::trace::cursor::cursor_list(batch_storage.into_iter().filter_map(|b| b.inner).collect());
                     let (mut trace_cursor, trace_storage) = crate::trace::cursor::cursor_list(trace.batches_through(lower_limit.borrow()).unwrap());
@@ -185,12 +192,17 @@ where
 
                             if let Some(difference) = difference {
                                 if !difference.is_zero() {
-                                    session.give((key.clone(), <BatchCursor<Tr> as Cursor>::owned_time(time), difference));
+                                    give((key.clone(), <BatchCursor<Tr> as Cursor>::owned_time(time), difference));
                                 }
                             }
                         });
 
                         batch_cursor.step_key(&batch_storage);
+                    }
+                    for (cap, mut buffer) in router.capabilities().iter().zip(buffers) {
+                        if !buffer.is_empty() {
+                            output.session(cap).give_container(&mut buffer);
+                        }
                     }
                 }
 

--- a/differential-dataflow/tests/dynamic.rs
+++ b/differential-dataflow/tests/dynamic.rs
@@ -1,0 +1,82 @@
+//! Leaving a dynamic scope on a message that carries two timestamps.
+//!
+//! Since timely's stamps became multisets, a message can carry several timestamps, and DD's
+//! batch-shipping operators make such messages: `arrange` ships a batch under the set of
+//! capabilities it retires, `reduce` likewise, and `join` forwards its input batch's set. In an
+//! iterative scope with two epochs in flight, an arrange holding `(1, [18])` (epoch 1, round 18)
+//! and `(2, [])` (epoch 2, just entered) retires both in one batch when its input frontier passes
+//! both at once. `as_collection` then forwards the batch's records under that same set, and the
+//! feedback delays it element-wise, so the set reaches whatever reads the *message's* time
+//! rather than the records' — which `leave_dynamic` did, to truncate it, and so panicked on
+//! "expected a singleton stamp". (Observed on a DDIR program at 20k nodes with four workers;
+//! the first multi-element stamp came from an arrange, then a join, then a reduce, then the
+//! arrange whose batch reached the scope's exit.)
+//!
+//! Which retirements coincide depends on scheduling, so this test makes the message directly: an
+//! operator that ships its input under a capability for epoch `e` round 3 and one for epoch
+//! `e + 1` round 0, into `leave_dynamic`.
+
+use differential_dataflow::collection::AsCollection;
+use differential_dataflow::dynamic::pointstamp::PointStamp;
+use differential_dataflow::input::Input;
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::generic::{builder_rc::OperatorBuilder, OutputBuilder};
+use timely::dataflow::operators::CapabilitySet;
+use timely::dataflow::Scope;
+use timely::order::Product;
+
+type Time = Product<u64, PointStamp<u64>>;
+
+#[test]
+fn leave_dynamic_on_a_message_over_two_epochs() {
+    let received = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let seen = received.clone();
+    timely::execute_directly(move |worker| {
+        let mut probe = timely::dataflow::ProbeHandle::new();
+        let mut input = worker.dataflow::<u64, _, _>(|scope| {
+            let (input, data) = scope.new_collection::<u64, isize>();
+            let left = scope.iterative::<PointStamp<u64>, _, _>(|inner| {
+                let entered = data.enter(inner);
+                let mut builder = OperatorBuilder::new("TwoEpochs".to_string(), inner.clone());
+                let (output, stream) = builder.new_output();
+                let mut output = OutputBuilder::from(output);
+                let mut input = builder.new_input(entered.inner, Pipeline);
+                builder.build(move |mut caps| {
+                    // the initial capability, at (0, []), can be delayed to any later time; it is
+                    // dropped once the input is done, so the computation can finish
+                    let mut root = caps.pop();
+                    move |frontier| {
+                        let mut output = output.activate();
+                        input.for_each(|cap, data| {
+                            let Some(root) = root.as_ref() else { return };
+                            let epoch = cap.time().outer;
+                            let t1 = Product::new(epoch, PointStamp::new([3].into_iter().collect()));
+                            let t2 = Product::new(epoch + 1, PointStamp::new([0].into_iter().collect()));
+                            let caps: CapabilitySet<Time> = [root.delayed(&t1), root.delayed(&t2)].into_iter().collect();
+                            for (i, (_datum, time, _diff)) in data.iter_mut().enumerate() {
+                                *time = if i % 2 == 0 { t1.clone() } else { t2.clone() };
+                            }
+                            output.session(&caps).give_container(data);
+                        });
+                        if frontier[0].frontier().is_empty() {
+                            root = None;
+                        }
+                    }
+                });
+                stream.as_collection().leave_dynamic(1).leave(scope)
+            });
+            left.inspect(move |(datum, time, diff)| seen.lock().unwrap().push((*datum, *time, *diff))).probe_with(&mut probe);
+            input
+        });
+        for x in 0..8u64 {
+            input.insert(x);
+        }
+        input.close();
+        worker.step_while(|| !probe.done());
+    });
+    let mut got = received.lock().unwrap().clone();
+    got.sort();
+    // even records at epoch 0 (round 3, truncated away), odd ones at epoch 1 (round 0, likewise)
+    let want: Vec<(u64, u64, isize)> = (0..8u64).map(|x| (x, x % 2, 1)).collect();
+    assert_eq!(got, want);
+}

--- a/differential-dataflow/tests/dynamic.rs
+++ b/differential-dataflow/tests/dynamic.rs
@@ -22,7 +22,6 @@ use differential_dataflow::input::Input;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::{builder_rc::OperatorBuilder, OutputBuilder};
 use timely::dataflow::operators::CapabilitySet;
-use timely::dataflow::Scope;
 use timely::order::Product;
 
 type Time = Product<u64, PointStamp<u64>>;
@@ -30,14 +29,14 @@ type Time = Product<u64, PointStamp<u64>>;
 #[test]
 fn leave_dynamic_on_a_message_over_two_epochs() {
     let received = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
-    let seen = received.clone();
+    let seen = std::sync::Arc::clone(&received);
     timely::execute_directly(move |worker| {
         let mut probe = timely::dataflow::ProbeHandle::new();
         let mut input = worker.dataflow::<u64, _, _>(|scope| {
             let (input, data) = scope.new_collection::<u64, isize>();
             let left = scope.iterative::<PointStamp<u64>, _, _>(|inner| {
                 let entered = data.enter(inner);
-                let mut builder = OperatorBuilder::new("TwoEpochs".to_string(), inner.clone());
+                let mut builder = OperatorBuilder::new("TwoEpochs".to_string(), inner);
                 let (output, stream) = builder.new_output();
                 let mut output = OutputBuilder::from(output);
                 let mut input = builder.new_input(entered.inner, Pipeline);
@@ -79,4 +78,81 @@ fn leave_dynamic_on_a_message_over_two_epochs() {
     // even records at epoch 0 (round 3, truncated away), odd ones at epoch 1 (round 0, likewise)
     let want: Vec<(u64, u64, isize)> = (0..8u64).map(|x| (x, x % 2, 1)).collect();
     assert_eq!(got, want);
+}
+
+/// The seam itself: `as_collection` on a message of batches carrying two timestamps hands each
+/// record on under the one at or before its time, so the collection's messages carry one each
+/// and an operator over records may read `cap.time()`.
+#[test]
+fn as_collection_routes_records_under_singleton_stamps() {
+    use differential_dataflow::batcher::Batcher;
+    use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
+    use differential_dataflow::trace::implementations::{ValBatcher, ValSpine};
+    use differential_dataflow::trace::{Description, Span, SpanOf};
+    use timely::dataflow::operators::generic::Operator;
+    use timely::progress::Antichain;
+
+    type Tr = ValSpine<u64, u64, Time, isize>;
+
+    let received = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let seen = std::sync::Arc::clone(&received);
+    timely::execute_directly(move |worker| {
+        let mut probe = timely::dataflow::ProbeHandle::new();
+        let mut input = worker.dataflow::<u64, _, _>(|scope| {
+            let (input, data) = scope.new_collection::<u64, isize>();
+            let left = scope.iterative::<PointStamp<u64>, _, _>(|inner| {
+                let entered = data.enter(inner);
+                // on its first input, ship one batch holding an update at epoch 0 round 3 and one
+                // at epoch 1 round 0, under a capability for each: what an arrange does when it
+                // retires both at once.
+                let mut builder = OperatorBuilder::new("TwoEpochBatch".to_string(), inner);
+                let (output, stream) = builder.new_output();
+                let mut output = OutputBuilder::from(output);
+                let mut input = builder.new_input(entered.inner, Pipeline);
+                builder.build(move |mut caps| {
+                    let mut root = caps.pop();
+                    move |frontier| {
+                        let mut output = output.activate();
+                        input.for_each(|_cap, _data| {
+                            let Some(root) = root.take() else { return };
+                            let t1 = Product::new(0, PointStamp::new([3].into_iter().collect()));
+                            let t2 = Product::new(1, PointStamp::new([0].into_iter().collect()));
+                            let mut batcher = ValBatcher::<u64, u64, Time, isize>::new(None, 0);
+                            let mut updates = vec![((1u64, 10u64), t1.clone(), 1isize), ((2, 20), t2.clone(), 1)];
+                            batcher.insert(&mut updates);
+                            let upper = Antichain::from_elem(Product::new(2, PointStamp::new(Default::default())));
+                            let (batch, _retained) = Batcher::<Vec<((u64, u64), Time, isize)>>::extract(&mut batcher, upper.borrow());
+                            let lower = Antichain::from_elem(Product::new(0, PointStamp::new(Default::default())));
+                            let description = Description::new(lower.clone(), upper, lower);
+                            let mut spans: Vec<SpanOf<Tr>> = vec![Span::new(description, batch.map(Into::into))];
+                            let caps: CapabilitySet<Time> = [root.delayed(&t1), root.delayed(&t2)].into_iter().collect();
+                            output.session(&caps).give_container(&mut spans);
+                        });
+                        if frontier[0].frontier().is_empty() {
+                            root = None;
+                        }
+                    }
+                });
+                let records = Arranged::<TraceAgent<Tr>>::flat_map_batches(stream, |key, val| Some((*key, *val)));
+                // every message of records now names one time
+                let checked = records.inner.unary(Pipeline, "OneTime", |_, _| {
+                    move |input, output| {
+                        input.for_each(|time, data| {
+                            let _one = time.time();
+                            output.session(&time).give_container(data);
+                        });
+                    }
+                });
+                checked.as_collection().leave(scope)
+            });
+            left.inspect(move |(datum, time, diff)| seen.lock().unwrap().push((*datum, *time, *diff))).probe_with(&mut probe);
+            input
+        });
+        input.insert(0);
+        input.close();
+        worker.step_while(|| !probe.done());
+    });
+    let mut got = received.lock().unwrap().clone();
+    got.sort();
+    assert_eq!(got, vec![((1, 10), 0, 1), ((2, 20), 1, 1)]);
 }

--- a/interactive/Cargo.toml
+++ b/interactive/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 columnar = { workspace = true }
 # The columnar kernels for the interpreted backend, pinned by git rev.
-corgi = { git = "https://github.com/frankmcsherry/WIP", rev = "578ef3fe79fdaa813ba0c721c08f60323f22d420", features = ["serde"] }
+corgi = { git = "https://github.com/frankmcsherry/WIP", rev = "3c4b0d6f90393dc25105ebcc4c869ca7d429411c", features = ["serde"] }
 differential-dataflow = { workspace = true }
 mimalloc = "0.1.48"
 serde = { version = "1.0", features = ["derive"] }

--- a/interactive/examples/ddir.rs
+++ b/interactive/examples/ddir.rs
@@ -71,7 +71,12 @@ fn run(
         tree = interactive::explain::explain_with(&tree, &source_shapes, options);
     }
     let ops_before = tree.op_count();
-    tree.optimize();
+    // the positional inputs' rows are `arity` keys with no value; the query input is unknown
+    let widths: Vec<Option<(usize, usize)>> = tree.root.imports.iter().map(|imp| match &imp.from {
+        st::Source::Input(k) if *k < n_inputs => Some((arity, 0)),
+        _ => None,
+    }).collect();
+    tree.optimize_with_widths(&widths);
     let tree_export_idx = tree.root.exports.iter().position(|e| e.name == "result").unwrap_or(0);
     println!("{}: {} ops before optimize, {} after; driving export {:?}",
         name, ops_before, tree.op_count(), tree.root.exports[tree_export_idx].name);

--- a/interactive/examples/ddir.rs
+++ b/interactive/examples/ddir.rs
@@ -128,15 +128,23 @@ fn run(
         // With `EDGES_FILE` set, rows come from the file (one row per line,
         // whitespace-separated i64 fields), assigned round-robin to inputs.
         // Otherwise `gen_row` synthesizes `edges` rows.
+        // With a file, the rounds EDIT its rows (retract one, re-insert it with its last field
+        // rewired to a value below its first) rather than churning synthetic rows, so an update is
+        // a change to data the dataflow has, not a phantom retraction of a row it never saw.
+        let mut file_rows: Option<Vec<(usize, Vec<i64>)>> = None;
         if let Some(path) = &edges_file {
             let text = std::fs::read_to_string(path).unwrap_or_else(|e| panic!("Cannot read {}: {}", path, e));
+            let mut mine = Vec::new();
             for (e, line) in text.lines().filter(|l| !l.trim().is_empty()).enumerate() {
                 if e % peers == index {
                     let input_idx = e % n_inputs;
-                    let fields: Vec<Value> = line.split_whitespace().map(|t| Value::Int(t.parse::<i64>().unwrap())).collect();
+                    let ints: Vec<i64> = line.split_whitespace().map(|t| t.parse::<i64>().unwrap()).collect();
+                    let fields: Vec<Value> = ints.iter().map(|&n| Value::Int(n)).collect();
                     inputs[input_idx].update((Value::Tuple(fields), Value::unit()), 1);
+                    mine.push((input_idx, ints));
                 }
             }
+            file_rows = Some(mine);
         } else {
             for e in 0..edges {
                 if (e as usize) % peers == index {
@@ -175,6 +183,23 @@ fn run(
             let timer_round = std::time::Instant::now();
             let time = (round + 2) as u64;
             for _ in 0..batch {
+                if let Some(rows) = file_rows.as_mut() {
+                    if !rows.is_empty() {
+                        let idx = (cursor as usize) % rows.len();
+                        let (input_idx, old) = rows[idx].clone();
+                        let mut new = old.clone();
+                        let last = new.len() - 1;
+                        let mut h = cursor.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ 0xD1B5_4A32_D192_ED03;
+                        h ^= h >> 29; h = h.wrapping_mul(0xBF58_476D_1CE4_E5B9); h ^= h >> 32;
+                        new[last] = if old[0] > 0 { (h % old[0] as u64) as i64 } else { 0 };
+                        let row = |f: &Vec<i64>| (Value::Tuple(f.iter().map(|&n| Value::Int(n)).collect()), Value::unit());
+                        inputs[input_idx].update(row(&old), -1);
+                        inputs[input_idx].update(row(&new), 1);
+                        rows[idx] = (input_idx, new);
+                    }
+                    cursor += 1;
+                    continue;
+                }
                 let remove_idx = cursor;
                 let add_idx = edges + cursor;
                 if (remove_idx as usize) % peers == index {

--- a/interactive/src/backend/corgi.rs
+++ b/interactive/src/backend/corgi.rs
@@ -284,19 +284,36 @@ impl Backend for CorgiBackend {
             .unary(Pipeline, "CorgiAsCollection", |_, _| {
                 |input, output| {
                     input.for_each(|cap, data| {
-                        let mut session = output.session(&cap);
+                        // A message of batches may carry several timestamps; each row goes out
+                        // under the one at or before its time, so the collection's messages
+                        // carry one each. One capability is the usual case and takes the chunk
+                        // whole; several split it by row.
+                        let router = differential_dataflow::collection::StampRouter::new(&cap, 0);
                         for batch in data.iter() {
                             let Some(payload) = batch.inner.as_ref() else { continue };
                             for ch in payload.chunks.iter().filter(|c| c.len() > 0) {
-                                let mut c = CorgiContainer {
-                                    // Drop the arrangement's leading identifier lane: edges carry
-                                    // the key the program wrote, so `$0` indexes what it always did.
-                                    keys: recover_key(ch.keys()),
-                                    vals: ch.vals().clone(),
-                                    times: ch.times().to_vec(),
-                                    diffs: ch.diffs().to_vec(),
-                                };
-                                session.give_container(&mut c);
+                                // Drop the arrangement's leading identifier lane: edges carry
+                                // the key the program wrote, so `$0` indexes what it always did.
+                                let keys = recover_key(ch.keys());
+                                let times = ch.times().to_vec();
+                                if router.capabilities().len() == 1 {
+                                    let mut c = CorgiContainer { keys, vals: ch.vals().clone(), times, diffs: ch.diffs().to_vec() };
+                                    output.session(&router.capabilities()[0]).give_container(&mut c);
+                                    continue;
+                                }
+                                for (index, cap) in router.capabilities().iter().enumerate() {
+                                    let keep: Vec<usize> = (0..times.len()).filter(|&i| router.index(&times[i]) == index).collect();
+                                    if keep.is_empty() {
+                                        continue;
+                                    }
+                                    let mut c = CorgiContainer {
+                                        keys: gather(&keys, &keep),
+                                        vals: gather(ch.vals(), &keep),
+                                        times: keep.iter().map(|&i| times[i].clone()).collect(),
+                                        diffs: keep.iter().map(|&i| ch.diffs()[i]).collect(),
+                                    };
+                                    output.session(cap).give_container(&mut c);
+                                }
                             }
                         }
                     });

--- a/interactive/src/backend/corgi.rs
+++ b/interactive/src/backend/corgi.rs
@@ -367,17 +367,21 @@ impl Backend for CorgiBackend {
         builder.build(move |_capability| move |_frontier| {
             let mut output = output.activate();
             input.for_each(|cap, data| {
-                let mut new_time = cap.time().clone();
-                let mut v = std::mem::take(&mut new_time.inner).into_inner();
-                v.truncate(level - 1);
-                new_time.inner = PointStamp::new(v);
-                let new_cap = cap.delayed(&new_time, 0);
-                for t in data.times.iter_mut() {
-                    let mut v = std::mem::take(&mut t.inner).into_inner();
+                // A message may carry several timestamps (a multi-element stamp): hold a
+                // capability for each, truncated exactly as the records are.
+                let truncate = |t: &Time| {
+                    let mut new_time = t.clone();
+                    let mut v = std::mem::take(&mut new_time.inner).into_inner();
                     v.truncate(level - 1);
-                    t.inner = PointStamp::new(v);
+                    new_time.inner = PointStamp::new(v);
+                    new_time
+                };
+                let caps: timely::dataflow::operators::CapabilitySet<Time> =
+                    cap.stamp().iter().map(|t| cap.delayed(&truncate(t), 0)).collect();
+                for t in data.times.iter_mut() {
+                    *t = truncate(t);
                 }
-                output.session(&new_cap).give_container(data);
+                output.session(&caps).give_container(data);
             });
         });
 

--- a/interactive/src/backend/mod.rs
+++ b/interactive/src/backend/mod.rs
@@ -48,6 +48,14 @@ pub trait Backend {
     fn reduce<'s>(a: Self::Arr<'s>, reducer: &Reducer) -> Self::Arr<'s>;
     fn inspect<'s>(c: Collection<'s, Time, Self::Container>, label: String) -> Collection<'s, Time, Self::Container>;
     fn leave_dynamic<'s>(c: Collection<'s, Time, Self::Container>, depth: usize) -> Collection<'s, Time, Self::Container>;
+    /// The same collection with its changes consolidated: rows that cancel are gone. A feedback
+    /// variable is set to this — an iteration quiesces when its feedback carries no *records*,
+    /// so a step whose additions and retractions cancel only logically (a `negate` under a
+    /// `concat`, say) would never quiesce. Through the arrangement by default; a backend with a
+    /// cheaper consolidation can override.
+    fn consolidate<'s>(c: Collection<'s, Time, Self::Container>) -> Collection<'s, Time, Self::Container> {
+        Self::as_collection(Self::arrange(c))
+    }
 }
 
 /// A rendered item's value: a collection, or an arrangement.
@@ -170,7 +178,7 @@ pub fn render_tree<'s, B: Backend>(
 
     for bind in &s.binds {
         let c = resolve(&items, &imports, &var_cols, &bind.value).collection();
-        var_handles[bind.var].take().expect("bind: variable already bound").set(c);
+        var_handles[bind.var].take().expect("bind: variable already bound").set(B::consolidate(c));
     }
 
     s.exports.iter().map(|e| resolve(&items, &imports, &var_cols, &e.value).collection()).collect()

--- a/interactive/src/egraph/mod.rs
+++ b/interactive/src/egraph/mod.rs
@@ -107,7 +107,23 @@ fn root_rows(program: &Program, source_widths: &[Option<Width>]) -> Vec<Row> {
 /// gives each root import's row width, so rows can be priced; `None` for an input whose width is
 /// not known.
 pub fn optimize(program: &Program, source_widths: &[Option<Width>]) -> Program {
-    Program { root: optimize_scope(&program.root, &root_rows(program, source_widths)).0 }
+    optimize_with(program, source_widths, Extraction::Cheapest)
+}
+
+/// How to choose a node per class once the classes are known. The cost model lives entirely
+/// here: saturation is the same whatever the choice, and any acyclic choice is a correct
+/// program — `Random` exists to check exactly that, over alternatives the cost never picks.
+#[derive(Clone, Copy, Debug)]
+pub enum Extraction {
+    /// The cheapest DAG the hill-climb finds from the tree optimum.
+    Cheapest,
+    /// From the tree optimum, a few hundred random moves, each kept if the choices stay acyclic.
+    Random(u64),
+}
+
+/// `optimize`, with the extraction chosen.
+pub fn optimize_with(program: &Program, source_widths: &[Option<Width>], extraction: Extraction) -> Program {
+    Program { root: optimize_scope(&program.root, &root_rows(program, source_widths), extraction).0 }
 }
 
 /// The DAG cost of a program under the optimizer's model: every operator priced by kind, row
@@ -365,7 +381,7 @@ impl Refs {
 /// Reify a scope: one node per import, var, linear step, and operator; children scopes optimized
 /// first and entered as opaque `Sub` nodes. Returns the table with the nodes of the binds and of
 /// the exports (the roots).
-fn reify(scope: &Scope, f: &Facts) -> (Reified, Vec<usize>, Vec<usize>) {
+fn reify(scope: &Scope, f: &Facts, extraction: Extraction) -> (Reified, Vec<usize>, Vec<usize>) {
     let mut r = Reified::default();
     let mut refs = Refs {
         import_nodes: (0..scope.imports.len()).map(|k| r.push(KIND_IMPORT, k as i64, vec![], f.imports[k])).collect(),
@@ -411,7 +427,7 @@ fn reify(scope: &Scope, f: &Facts) -> (Reified, Vec<usize>, Vec<usize>) {
                 r.push(KIND_INSPECT, payload, vec![kid], f.items[i])
             }
             Item::Sub(child) => {
-                let (optimized, export_rows) = optimize_scope(child, &f.child_imports(child));
+                let (optimized, export_rows) = optimize_scope(child, &f.child_imports(child), extraction);
                 refs.sub_export_rows.insert(i, export_rows);
                 let kids: Vec<usize> = optimized
                     .imports
@@ -588,9 +604,9 @@ fn filter_pushdown(r: &mut Reified, n: usize, found: &mut Vec<(usize, usize)>) {
 }
 
 /// Optimize one scope; returns it with its exports' rows (what its parent needs of it).
-fn optimize_scope(scope: &Scope, import_rows: &[Row]) -> (Scope, Vec<Row>) {
+fn optimize_scope(scope: &Scope, import_rows: &[Row], extraction: Extraction) -> (Scope, Vec<Row>) {
     let f = scope_facts(scope, import_rows);
-    let (mut r, bind_roots, export_roots) = reify(scope, &f);
+    let (mut r, bind_roots, export_roots) = reify(scope, &f, extraction);
     instantiate_rules(&mut r);
 
     // the child scope behind each Sub node, by node id.
@@ -624,7 +640,10 @@ fn optimize_scope(scope: &Scope, import_rows: &[Row]) -> (Scope, Vec<Row>) {
     let best: BTreeMap<usize, usize> =
         out["best"].iter().filter(|(_, d)| *d > 0).map(|((k, v), _)| (ints(k)[0] as usize, ints(v)[0] as usize)).collect();
     let roots: Vec<usize> = bind_roots.iter().chain(&export_roots).copied().collect();
-    let best = refine_dag(&r, &classes, &roots, best);
+    let best = match extraction {
+        Extraction::Cheapest => refine_dag(&r, &classes, &roots, best),
+        Extraction::Random(seed) => random_dag(&r, &classes, &roots, best, seed),
+    };
     let chosen = |node: usize| -> usize {
         let class = classes[&node];
         *best.get(&class).unwrap_or_else(|| panic!("class {class} has no extracted node"))
@@ -673,53 +692,12 @@ fn optimize_scope(scope: &Scope, import_rows: &[Row]) -> (Scope, Vec<Row>) {
 /// pays for a second copy of something a sibling already materializes, is never taken).
 /// Optimal DAG extraction is NP-hard; this is the standard greedy, seeded by the tree optimum.
 fn refine_dag(r: &Reified, classes: &BTreeMap<usize, usize>, roots: &[usize], mut pick: BTreeMap<usize, usize>) -> BTreeMap<usize, usize> {
-    let w: Vec<i64> = (0..r.nodes.len()).map(|n| r.price_of(n)).collect();
+    let walk = Walk::new(r, classes, roots);
     let mut members: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
     for (&node, &class) in classes {
         members.entry(class).or_default().push(node);
     }
-    let root_classes: Vec<usize> = roots.iter().map(|&n| classes[&n]).collect();
-
-    /// The chosen DAG's walker: from a class, sum weights and list the classes reached;
-    /// `false` on a cycle or a class without a choice.
-    struct Walk<'a> {
-        r: &'a Reified,
-        classes: &'a BTreeMap<usize, usize>,
-        w: &'a [i64],
-    }
-    impl Walk<'_> {
-        fn visit(&self, class: usize, choice: &BTreeMap<usize, usize>, state: &mut HashMap<usize, u8>, sum: &mut i64, reached: &mut Vec<usize>) -> bool {
-            match state.get(&class) {
-                Some(1) => return false,
-                Some(_) => return true,
-                None => {}
-            }
-            let Some(&p) = choice.get(&class) else { return false };
-            state.insert(class, 1);
-            *sum += self.w[p];
-            reached.push(class);
-            for &k in &self.r.nodes[p].children {
-                if !self.visit(self.classes[&k], choice, state, sum, reached) {
-                    return false;
-                }
-            }
-            state.insert(class, 2);
-            true
-        }
-    }
-    let walk = Walk { r, classes, w: &w };
-    let total = |choice: &BTreeMap<usize, usize>| -> Option<(i64, Vec<usize>)> {
-        let mut state = HashMap::new();
-        let (mut sum, mut reached) = (0, Vec::new());
-        for &rc in &root_classes {
-            if !walk.visit(rc, choice, &mut state, &mut sum, &mut reached) {
-                return None;
-            }
-        }
-        Some((sum, reached))
-    };
-
-    let (mut best, mut reached) = total(&pick).expect("the tree-cost extraction is acyclic and complete");
+    let (mut best, mut reached) = walk.total(&pick).expect("the tree-cost extraction is acyclic and complete");
     loop {
         let mut improved = false;
         'moves: for &class in &reached {
@@ -729,7 +707,7 @@ fn refine_dag(r: &Reified, classes: &BTreeMap<usize, usize>, roots: &[usize], mu
                     continue;
                 }
                 pick.insert(class, node);
-                if let Some((t, rr)) = total(&pick) {
+                if let Some((t, rr)) = walk.total(&pick) {
                     if t < best {
                         best = t;
                         reached = rr;
@@ -743,6 +721,84 @@ fn refine_dag(r: &Reified, classes: &BTreeMap<usize, usize>, roots: &[usize], mu
         if !improved {
             return pick;
         }
+    }
+}
+
+/// Extraction by coin: from the tree optimum, a few hundred moves to a random member of a
+/// random reached class, each kept if the choices stay acyclic, whatever it costs.
+fn random_dag(r: &Reified, classes: &BTreeMap<usize, usize>, roots: &[usize], mut pick: BTreeMap<usize, usize>, seed: u64) -> BTreeMap<usize, usize> {
+    let walk = Walk::new(r, classes, roots);
+    let mut members: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for (&node, &class) in classes {
+        members.entry(class).or_default().push(node);
+    }
+    let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    let mut next = move || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    let (_, mut reached) = walk.total(&pick).expect("the tree-cost extraction is acyclic and complete");
+    for _ in 0..256 {
+        let class = reached[(next() % reached.len() as u64) as usize];
+        let nodes = &members[&class];
+        let node = nodes[(next() % nodes.len() as u64) as usize];
+        let cur = pick[&class];
+        if node == cur {
+            continue;
+        }
+        pick.insert(class, node);
+        match walk.total(&pick) {
+            Some((_, rr)) => reached = rr,
+            None => {
+                pick.insert(class, cur);
+            }
+        }
+    }
+    pick
+}
+
+/// The chosen DAG's walker: from the roots, sum prices and list the classes reached; nothing on
+/// a cycle or a class without a choice.
+struct Walk<'a> {
+    r: &'a Reified,
+    classes: &'a BTreeMap<usize, usize>,
+    root_classes: Vec<usize>,
+    w: Vec<i64>,
+}
+
+impl<'a> Walk<'a> {
+    fn new(r: &'a Reified, classes: &'a BTreeMap<usize, usize>, roots: &[usize]) -> Self {
+        Walk { r, classes, root_classes: roots.iter().map(|&n| classes[&n]).collect(), w: (0..r.nodes.len()).map(|n| r.price_of(n)).collect() }
+    }
+    fn total(&self, choice: &BTreeMap<usize, usize>) -> Option<(i64, Vec<usize>)> {
+        let mut state = HashMap::new();
+        let (mut sum, mut reached) = (0, Vec::new());
+        for &rc in &self.root_classes {
+            if !self.visit(rc, choice, &mut state, &mut sum, &mut reached) {
+                return None;
+            }
+        }
+        Some((sum, reached))
+    }
+    fn visit(&self, class: usize, choice: &BTreeMap<usize, usize>, state: &mut HashMap<usize, u8>, sum: &mut i64, reached: &mut Vec<usize>) -> bool {
+        match state.get(&class) {
+            Some(1) => return false,
+            Some(_) => return true,
+            None => {}
+        }
+        let Some(&p) = choice.get(&class) else { return false };
+        state.insert(class, 1);
+        *sum += self.w[p];
+        reached.push(class);
+        for &k in &self.r.nodes[p].children {
+            if !self.visit(self.classes[&k], choice, state, sum, reached) {
+                return false;
+            }
+        }
+        state.insert(class, 2);
+        true
     }
 }
 

--- a/interactive/src/egraph/mod.rs
+++ b/interactive/src/egraph/mod.rs
@@ -4,27 +4,33 @@
 //!
 //! What the e-graph sees is the scope's operator DAG at the grain of one node per linear step,
 //! with everything an operator closes over — a projection, a predicate, a reducer, a child
-//! scope's body — interned to an opaque id, and each node priced by the width of the row it
-//! produces. Two nodes are equal when their kinds, payloads, and children's classes agree
-//! (congruence), or when a rule says so. Rules come in two kinds: those the program states over
-//! the term table alone (arrange idempotence), and those the host instantiates because they need
-//! a fact about a scalar operator ([`scalar`]) — demand pushdown mints, for a reducer or a join
-//! that reads only some of an input's fields, the same operator over a projection of that input
-//! keeping just those fields, and asserts the two equal; join commutativity mints each join with
-//! its inputs swapped.
+//! scope's body — interned to an opaque id, and each node priced by the host: an op weight, times
+//! the width of the rows it holds or produces, times a relative row volume (a filter halves it).
+//! Two nodes are equal when their kinds, payloads, and children's classes agree (congruence,
+//! with a concatenation's children taken as the unordered multiset of its leaves through nested
+//! concatenations), or when a rule says so. Rules come in two kinds: those the program states
+//! over the term table alone (arrange idempotence), and those the host instantiates because
+//! they need a fact about a scalar operator ([`scalar`]), handed to the program as asserted
+//! equalities — demand pushdown (a reducer or a join that reads only some of an input's fields
+//! equals itself over that input narrowed to them), join commutativity, and filter pushdown (a
+//! filter equals itself composed through the projection, negation, concatenation, or join below
+//! it, when its predicate can be expressed over the rows there). The host applies its rules to
+//! the nodes they mint too, so a filter sinks as far as its predicate allows.
+//!
 //! Extraction picks one node per class: the program computes the least *tree* cost per class
 //! (a dynamic program, which counts a shared subterm once per use), and the host refines that
 //! choice against the *DAG* cost — the weight of what the choices materialize from the roots,
 //! shared subterms once — by hill-climbing to a local optimum (optimal DAG extraction is
 //! NP-hard; this is the standard greedy, seeded by the tree optimum). The host then regroups
-//! single-consumer chains of steps back into `Linear` operators.
+//! single-consumer chains of steps back into `Linear` operators, and single-consumer nested
+//! concatenations into one.
 //!
 //! Child scopes are opaque leaves of their parent's e-graph, optimized on their own first: a scope
 //! boundary is a semantic barrier, so nothing merges across one.
 
 pub mod scalar;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::backend::vec;
 use crate::ir::{LinearOp, Value};
@@ -43,7 +49,10 @@ const KIND_REDUCE: i64 = 7;
 const KIND_INSPECT: i64 = 8;
 const KIND_SUB: i64 = 9;
 
-/// The op weight by kind — the same table `optimize.ddp` prices with.
+/// The relative volume of an input's rows; a filter halves whatever it sees.
+const BASE_VOLUME: i64 = 64;
+
+/// The op weight by kind.
 fn weight(kind: i64) -> i64 {
     match kind {
         KIND_ARRANGE => 3,
@@ -54,18 +63,29 @@ fn weight(kind: i64) -> i64 {
     }
 }
 
-/// The width a node is priced by: the rows it holds for an Arrange or a Reduce (its input's),
-/// the rows it produces for everything else.
-fn priced_width(kind: i64, input: Option<Width>, output: Option<Width>) -> Option<Width> {
-    match kind {
-        KIND_ARRANGE | KIND_REDUCE => input,
-        _ => output,
+/// What the optimizer knows of a row: its width, when the language can tell, and a relative
+/// volume, an estimate with no claim beyond ordering the alternatives a rule proposes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Row {
+    width: Option<Width>,
+    volume: i64,
+}
+
+impl Row {
+    const UNKNOWN: Row = Row { width: None, volume: BASE_VOLUME };
+    fn fields(&self) -> i64 {
+        self.width.map_or(0, |(k, v)| (k + v) as i64)
     }
 }
 
-/// A node's price: its weight times one plus its priced width.
-fn price(kind: i64, priced: Option<Width>) -> i64 {
-    weight(kind) * (1 + priced.map_or(0, |(k, v)| (k + v) as i64))
+/// A node's price: its weight, times one plus the width of the rows it holds (its input's, for
+/// an Arrange or a Reduce) or produces (everything else), times their volume.
+fn price(kind: i64, input: Option<Row>, output: Row) -> i64 {
+    let priced = match kind {
+        KIND_ARRANGE | KIND_REDUCE => input.unwrap_or(output),
+        _ => output,
+    };
+    weight(kind) * (1 + priced.fields()) * priced.volume
 }
 
 /// The optimizer program, parsed and lowered once.
@@ -79,31 +99,31 @@ fn optimizer() -> &'static Program {
     })
 }
 
-fn root_widths(program: &Program, source_widths: &[Option<Width>]) -> Vec<Option<Width>> {
-    (0..program.root.imports.len()).map(|k| source_widths.get(k).copied().flatten()).collect()
+fn root_rows(program: &Program, source_widths: &[Option<Width>]) -> Vec<Row> {
+    (0..program.root.imports.len()).map(|k| Row { width: source_widths.get(k).copied().flatten(), volume: BASE_VOLUME }).collect()
 }
 
 /// Optimize every scope of `program`, innermost first, through the e-graph. `source_widths`
 /// gives each root import's row width, so rows can be priced; `None` for an input whose width is
 /// not known.
 pub fn optimize(program: &Program, source_widths: &[Option<Width>]) -> Program {
-    Program { root: optimize_scope(&program.root, &root_widths(program, source_widths)).0 }
+    Program { root: optimize_scope(&program.root, &root_rows(program, source_widths)).0 }
 }
 
-/// The DAG cost of a program under the optimizer's model: every operator priced by kind and by
-/// the width of the row it produces. What `optimize` minimizes per class, summed over the program
-/// as it will run (shared subterms once).
+/// The DAG cost of a program under the optimizer's model: every operator priced by kind, row
+/// width, and row volume. What `optimize` minimizes, summed over the program as it will run
+/// (shared subterms once).
 pub fn cost(program: &Program, source_widths: &[Option<Width>]) -> i64 {
-    fn scope_cost(s: &Scope, import_widths: &[Option<Width>]) -> i64 {
-        let w = scope_widths(s, import_widths);
+    fn scope_cost(s: &Scope, import_rows: &[Row]) -> i64 {
+        let f = scope_facts(s, import_rows);
         let mut total = 0;
         for (i, item) in s.items.iter().enumerate() {
             match item {
                 Item::Op(Node::Linear { ops, .. }) => {
-                    let mut cur = w.inputs[i];
+                    let mut cur = f.inputs[i];
                     for op in ops {
-                        cur = cur.and_then(|c| scalar::width_after(op, c));
-                        total += price(KIND_OP, cur);
+                        cur = scalar_step(op, cur);
+                        total += price(KIND_OP, None, cur);
                     }
                 }
                 Item::Op(node) => {
@@ -115,92 +135,104 @@ pub fn cost(program: &Program, source_widths: &[Option<Width>]) -> i64 {
                         Node::Inspect { .. } => (KIND_INSPECT, None),
                         Node::Linear { .. } => unreachable!(),
                     };
-                    total += price(kind, priced_width(kind, input.and_then(|rf| w.of_ref(rf)), w.items[i]));
+                    total += price(kind, input.map(|rf| f.of_ref(rf)), f.items[i]);
                 }
                 Item::Sub(child) => {
-                    total += price(KIND_SUB, None) + scope_cost(child, &w.child_imports(child));
+                    total += weight(KIND_SUB) + scope_cost(child, &f.child_imports(child));
                 }
             }
         }
         total
     }
-    scope_cost(&program.root, &root_widths(program, source_widths))
+    scope_cost(&program.root, &root_rows(program, source_widths))
 }
 
-/// Row widths through one scope: per item (its output), per linear item's input, per var, per
+/// The row after a linear step.
+fn scalar_step(op: &LinearOp, row: Row) -> Row {
+    Row { width: row.width.and_then(|w| scalar::width_after(op, w)), volume: scalar::volume_after(op, row.volume) }
+}
+
+/// Row facts through one scope: per item (its output), per linear item's input, per var, per
 /// import, and per child scope's exports.
-struct Widths {
-    items: Vec<Option<Width>>,
-    inputs: Vec<Option<Width>>,
-    vars: Vec<Option<Width>>,
-    imports: Vec<Option<Width>>,
-    child_exports: HashMap<usize, Vec<Option<Width>>>,
+struct Facts {
+    items: Vec<Row>,
+    inputs: Vec<Row>,
+    vars: Vec<Row>,
+    imports: Vec<Row>,
+    child_exports: HashMap<usize, Vec<Row>>,
 }
 
-impl Widths {
-    fn of_ref(&self, rf: &Ref) -> Option<Width> {
+impl Facts {
+    fn of_ref(&self, rf: &Ref) -> Row {
         match rf {
             Ref::Local(i) => self.items[*i],
             Ref::Import(k) => self.imports[*k],
             Ref::Var(v) => self.vars[*v],
-            Ref::ChildExport(i, k) => self.child_exports.get(i).and_then(|ws| ws.get(*k).copied().flatten()),
+            Ref::ChildExport(i, k) => self.child_exports.get(i).and_then(|ws| ws.get(*k).copied()).unwrap_or(Row::UNKNOWN),
         }
     }
-    /// A child scope's import widths, as its parent sees them.
-    fn child_imports(&self, child: &Scope) -> Vec<Option<Width>> {
+    /// A child scope's import rows, as its parent sees them.
+    fn child_imports(&self, child: &Scope) -> Vec<Row> {
         child
             .imports
             .iter()
             .map(|imp| match &imp.from {
                 Source::Parent(rf) => self.of_ref(rf),
-                _ => None,
+                _ => Row::UNKNOWN,
             })
             .collect()
     }
 }
 
-/// The forward width pass over a scope; feedback vars take their bound value's width, to a
-/// fixpoint (a var read before it is known stays unknown for that pass).
-fn scope_widths(s: &Scope, import_widths: &[Option<Width>]) -> Widths {
-    let mut w = Widths {
-        items: vec![None; s.items.len()],
-        inputs: vec![None; s.items.len()],
-        vars: vec![None; s.vars.len()],
-        imports: import_widths.to_vec(),
+/// The forward pass over a scope. Feedback vars take their bound value's width, to a fixpoint (a
+/// var read before it is known stays unknown for that pass), and the base volume: a feedback
+/// volume has no fixpoint worth estimating.
+fn scope_facts(s: &Scope, import_rows: &[Row]) -> Facts {
+    let mut f = Facts {
+        items: vec![Row::UNKNOWN; s.items.len()],
+        inputs: vec![Row::UNKNOWN; s.items.len()],
+        vars: vec![Row::UNKNOWN; s.vars.len()],
+        imports: import_rows.to_vec(),
         child_exports: HashMap::new(),
     };
     for _pass in 0..4 {
         for (i, item) in s.items.iter().enumerate() {
             let out = match item {
                 Item::Op(Node::Linear { input, ops }) => {
-                    let mut cur = w.of_ref(input);
-                    w.inputs[i] = cur;
+                    let mut cur = f.of_ref(input);
+                    f.inputs[i] = cur;
                     for op in ops {
-                        cur = cur.and_then(|c| scalar::width_after(op, c));
+                        cur = scalar_step(op, cur);
                     }
                     cur
                 }
-                Item::Op(Node::Concat(refs)) => refs.first().and_then(|r| w.of_ref(r)),
-                Item::Op(Node::Arrange(input)) | Item::Op(Node::Inspect { input, .. }) => w.of_ref(input),
-                Item::Op(Node::Join { left, right, projection }) => match (w.of_ref(left), w.of_ref(right)) {
-                    (Some(l), Some(r)) => scalar::join_width(projection, l.0, l.1, r.1),
-                    _ => None,
-                },
-                Item::Op(Node::Reduce { input, reducer }) => w.of_ref(input).map(|c| scalar::reducer_width(reducer, c)),
+                Item::Op(Node::Concat(refs)) => {
+                    let rows: Vec<Row> = refs.iter().map(|r| f.of_ref(r)).collect();
+                    Row { width: rows.first().and_then(|r| r.width), volume: rows.iter().map(|r| r.volume).sum() }
+                }
+                Item::Op(Node::Arrange(input)) | Item::Op(Node::Inspect { input, .. }) => f.of_ref(input),
+                Item::Op(Node::Join { left, right, projection }) => {
+                    let (l, r) = (f.of_ref(left), f.of_ref(right));
+                    join_row(projection, l, r)
+                }
+                Item::Op(Node::Reduce { input, reducer }) => {
+                    let row = f.of_ref(input);
+                    Row { width: row.width.map(|w| scalar::reducer_width(reducer, w)), volume: row.volume }
+                }
                 Item::Sub(child) => {
-                    let cw = scope_widths(child, &w.child_imports(child));
-                    let exports: Vec<Option<Width>> = child.exports.iter().map(|e| cw.of_ref(&e.value)).collect();
-                    w.child_exports.insert(i, exports);
-                    None
+                    let cf = scope_facts(child, &f.child_imports(child));
+                    let exports: Vec<Row> = child.exports.iter().map(|e| cf.of_ref(&e.value)).collect();
+                    f.child_exports.insert(i, exports);
+                    Row::UNKNOWN
                 }
             };
-            w.items[i] = out;
+            f.items[i] = out;
         }
         let mut changed = false;
         for b in &s.binds {
-            let nw = w.of_ref(&b.value);
-            if nw.is_some() && w.vars[b.var] != nw {
-                w.vars[b.var] = nw;
+            let width = f.of_ref(&b.value).width;
+            if width.is_some() && f.vars[b.var].width != width {
+                f.vars[b.var].width = width;
                 changed = true;
             }
         }
@@ -208,7 +240,16 @@ fn scope_widths(s: &Scope, import_widths: &[Option<Width>]) -> Widths {
             break;
         }
     }
-    w
+    f
+}
+
+/// The row a join produces from its inputs' rows.
+fn join_row(projection: &Projection, l: Row, r: Row) -> Row {
+    let width = match (l.width, r.width) {
+        (Some(l), Some(r)) => scalar::join_width(projection, l.0, l.1, r.1),
+        _ => None,
+    };
+    Row { width, volume: l.volume.max(r.volume) }
 }
 
 /// One node of a reified scope.
@@ -217,15 +258,8 @@ struct RNode {
     kind: i64,
     payload: i64,
     children: Vec<usize>,
-    /// the width of the row the node produces
-    width: Option<Width>,
-}
-
-impl RNode {
-    /// The width the node is priced by (see `priced_width`), given its children.
-    fn priced(&self, nodes: &[RNode]) -> Option<Width> {
-        priced_width(self.kind, self.children.first().and_then(|&c| nodes[c].width), self.width)
-    }
+    /// the row the node produces
+    row: Row,
 }
 
 /// A scope reified for the e-graph: its nodes, the tables its payloads intern into, and the
@@ -241,12 +275,21 @@ struct Reified {
     subs: Vec<Scope>,
     /// interned payloads by kind: (kind, debug rendering) -> payload id
     interned: HashMap<(i64, String), i64>,
+    /// nodes by signature, so a rule minting a node that exists gets that node
+    index: HashMap<(i64, i64, Vec<usize>), usize>,
 }
 
 impl Reified {
-    fn push(&mut self, kind: i64, payload: i64, children: Vec<usize>, width: Option<Width>) -> usize {
-        self.nodes.push(RNode { kind, payload, children, width });
-        self.nodes.len() - 1
+    fn push(&mut self, kind: i64, payload: i64, children: Vec<usize>, row: Row) -> usize {
+        if kind != KIND_SUB {
+            if let Some(&id) = self.index.get(&(kind, payload, children.clone())) {
+                return id;
+            }
+        }
+        self.nodes.push(RNode { kind, payload, children: children.clone(), row });
+        let id = self.nodes.len() - 1;
+        self.index.insert((kind, payload, children), id);
+        id
     }
     fn intern<T: std::fmt::Debug + Clone>(&mut self, kind: i64, value: &T, table: fn(&mut Self) -> &mut Vec<T>) -> i64 {
         let key = (kind, format!("{value:?}"));
@@ -258,6 +301,33 @@ impl Reified {
         let id = (t.len() - 1) as i64;
         self.interned.insert(key, id);
         id
+    }
+    fn price_of(&self, n: usize) -> i64 {
+        let node = &self.nodes[n];
+        price(node.kind, node.children.first().map(|&c| self.nodes[c].row), node.row)
+    }
+    /// The step a node stands for, if it is one.
+    fn op_of(&self, n: usize) -> Option<&LinearOp> {
+        (self.nodes[n].kind == KIND_OP).then(|| &self.ops[self.nodes[n].payload as usize])
+    }
+    /// A node's input for narrowing or filtering: below its Arrange, if it is one, since that is
+    /// where the rows are held. Returns the input and whether to re-arrange.
+    fn below_arrange(&self, n: usize) -> (usize, bool) {
+        match self.nodes[n].kind {
+            KIND_ARRANGE => (self.nodes[n].children[0], true),
+            _ => (n, false),
+        }
+    }
+    /// A step over `input`, then the same arrangement of it as `like` had.
+    fn step_below(&mut self, input: usize, rearrange: bool, op: &LinearOp) -> usize {
+        let row = scalar_step(op, self.nodes[input].row);
+        let payload = self.intern(KIND_OP, op, |r| &mut r.ops);
+        let stepped = self.push(KIND_OP, payload, vec![input], row);
+        if rearrange {
+            self.push(KIND_ARRANGE, 0, vec![stepped], row)
+        } else {
+            stepped
+        }
     }
 }
 
@@ -275,7 +345,7 @@ struct Refs {
     var_nodes: Vec<usize>,
     item_nodes: Vec<usize>,
     child_exports: HashMap<(usize, usize), usize>,
-    sub_export_widths: HashMap<usize, Vec<Option<Width>>>,
+    sub_export_rows: HashMap<usize, Vec<Row>>,
 }
 
 impl Refs {
@@ -285,33 +355,32 @@ impl Refs {
             Ref::Import(k) => self.import_nodes[*k],
             Ref::Var(v) => self.var_nodes[*v],
             Ref::ChildExport(i, k) => *self.child_exports.entry((*i, *k)).or_insert_with(|| {
-                let width = self.sub_export_widths.get(i).and_then(|ws| ws.get(*k).copied().flatten());
-                r.push(KIND_CHILD_EXPORT, *k as i64, vec![self.item_nodes[*i]], width)
+                let row = self.sub_export_rows.get(i).and_then(|ws| ws.get(*k).copied()).unwrap_or(Row::UNKNOWN);
+                r.push(KIND_CHILD_EXPORT, *k as i64, vec![self.item_nodes[*i]], row)
             }),
         }
     }
 }
 
-/// Optimize one scope; returns it with its exports' widths (what its parent needs of it).
-fn optimize_scope(scope: &Scope, import_widths: &[Option<Width>]) -> (Scope, Vec<Option<Width>>) {
-    let w = scope_widths(scope, import_widths);
-
-    // Reify. Children scopes are optimized first and enter as opaque `Sub` nodes.
+/// Reify a scope: one node per import, var, linear step, and operator; children scopes optimized
+/// first and entered as opaque `Sub` nodes. Returns the table with the nodes of the binds and of
+/// the exports (the roots).
+fn reify(scope: &Scope, f: &Facts) -> (Reified, Vec<usize>, Vec<usize>) {
     let mut r = Reified::default();
     let mut refs = Refs {
-        import_nodes: (0..scope.imports.len()).map(|k| r.push(KIND_IMPORT, k as i64, vec![], w.imports[k])).collect(),
-        var_nodes: (0..scope.vars.len()).map(|v| r.push(KIND_VAR, v as i64, vec![], w.vars[v])).collect(),
+        import_nodes: (0..scope.imports.len()).map(|k| r.push(KIND_IMPORT, k as i64, vec![], f.imports[k])).collect(),
+        var_nodes: (0..scope.vars.len()).map(|v| r.push(KIND_VAR, v as i64, vec![], f.vars[v])).collect(),
         item_nodes: Vec::with_capacity(scope.items.len()),
         child_exports: HashMap::new(),
-        sub_export_widths: HashMap::new(),
+        sub_export_rows: HashMap::new(),
     };
     for (i, item) in scope.items.iter().enumerate() {
         let node = match item {
             Item::Op(Node::Linear { input, ops }) => {
                 let mut prev = refs.resolve(input, &mut r);
-                let mut cur = w.inputs[i];
+                let mut cur = f.inputs[i];
                 for op in ops {
-                    cur = cur.and_then(|c| scalar::width_after(op, c));
+                    cur = scalar_step(op, cur);
                     let payload = r.intern(KIND_OP, op, |r| &mut r.ops);
                     prev = r.push(KIND_OP, payload, vec![prev], cur);
                 }
@@ -319,31 +388,31 @@ fn optimize_scope(scope: &Scope, import_widths: &[Option<Width>]) -> (Scope, Vec
             }
             Item::Op(Node::Concat(xs)) => {
                 let kids: Vec<usize> = xs.iter().map(|x| refs.resolve(x, &mut r)).collect();
-                r.push(KIND_CONCAT, 0, kids, w.items[i])
+                r.push(KIND_CONCAT, 0, kids, f.items[i])
             }
             Item::Op(Node::Arrange(input)) => {
                 let kid = refs.resolve(input, &mut r);
-                r.push(KIND_ARRANGE, 0, vec![kid], w.items[i])
+                r.push(KIND_ARRANGE, 0, vec![kid], f.items[i])
             }
             Item::Op(Node::Join { left, right, projection }) => {
                 let l = refs.resolve(left, &mut r);
                 let rr = refs.resolve(right, &mut r);
                 let payload = r.intern(KIND_JOIN, projection, |r| &mut r.projections);
-                r.push(KIND_JOIN, payload, vec![l, rr], w.items[i])
+                r.push(KIND_JOIN, payload, vec![l, rr], f.items[i])
             }
             Item::Op(Node::Reduce { input, reducer }) => {
                 let kid = refs.resolve(input, &mut r);
                 let payload = r.intern(KIND_REDUCE, reducer, |r| &mut r.reducers);
-                r.push(KIND_REDUCE, payload, vec![kid], w.items[i])
+                r.push(KIND_REDUCE, payload, vec![kid], f.items[i])
             }
             Item::Op(Node::Inspect { input, label }) => {
                 let kid = refs.resolve(input, &mut r);
                 let payload = r.intern(KIND_INSPECT, label, |r| &mut r.labels);
-                r.push(KIND_INSPECT, payload, vec![kid], w.items[i])
+                r.push(KIND_INSPECT, payload, vec![kid], f.items[i])
             }
             Item::Sub(child) => {
-                let (optimized, export_widths) = optimize_scope(child, &w.child_imports(child));
-                refs.sub_export_widths.insert(i, export_widths);
+                let (optimized, export_rows) = optimize_scope(child, &f.child_imports(child));
+                refs.sub_export_rows.insert(i, export_rows);
                 let kids: Vec<usize> = optimized
                     .imports
                     .iter()
@@ -355,91 +424,178 @@ fn optimize_scope(scope: &Scope, import_widths: &[Option<Width>]) -> (Scope, Vec
                 let body = sub_body(&optimized);
                 let payload = r.intern(KIND_SUB, &body, |r| &mut r.labels);
                 r.subs.push(optimized);
-                r.push(KIND_SUB, payload, kids, None)
+                r.push(KIND_SUB, payload, kids, Row::UNKNOWN)
             }
         };
         refs.item_nodes.push(node);
     }
+    let bind_roots: Vec<usize> = scope.binds.iter().map(|b| refs.resolve(&b.value, &mut r)).collect();
+    let export_roots: Vec<usize> = scope.exports.iter().map(|e| refs.resolve(&e.value, &mut r)).collect();
+    (r, bind_roots, export_roots)
+}
+
+/// The host's rules, instantiated from scalar facts over every node — the ones the rules mint
+/// included, to a fixpoint (each rule mints something structurally below what it matched, so
+/// there is one; the round cap is a guard).
+fn instantiate_rules(r: &mut Reified) {
+    let mut seen: HashSet<(usize, usize)> = HashSet::new();
+    let mut done = 0;
+    for _round in 0..32 {
+        let end = r.nodes.len();
+        for n in done..end {
+            let mut found: Vec<(usize, usize)> = Vec::new();
+            match r.nodes[n].kind {
+                KIND_REDUCE => reduce_narrowing(r, n, &mut found),
+                KIND_JOIN => {
+                    join_narrowing(r, n, &mut found);
+                    join_commutativity(r, n, &mut found);
+                }
+                KIND_OP => filter_pushdown(r, n, &mut found),
+                _ => {}
+            }
+            for (a, b) in found {
+                if a != b && seen.insert((a.min(b), a.max(b))) {
+                    r.equal.push((a, b));
+                }
+            }
+        }
+        done = end;
+        if r.nodes.len() == end {
+            break;
+        }
+    }
+}
+
+/// Demand pushdown: a reducer that reads no values equals the same reducer over its input with
+/// the values projected away. The narrowed twin holds narrower rows, so it prices lower.
+fn reduce_narrowing(r: &mut Reified, n: usize, found: &mut Vec<(usize, usize)>) {
+    let reducer = r.reducers[r.nodes[n].payload as usize].clone();
+    let input = r.nodes[n].children[0];
+    let Some((_, v)) = r.nodes[input].row.width else { return };
+    if scalar::reducer_reads_values(&reducer) || v == 0 {
+        return;
+    }
+    let narrowed = r.step_below(input, false, &scalar::keep_key_only());
+    let (payload, row) = (r.nodes[n].payload, r.nodes[n].row);
+    let twin = r.push(KIND_REDUCE, payload, vec![narrowed], row);
+    found.push((n, twin));
+}
+
+/// Demand pushdown through a join: a join that reads only some fields of an input's values
+/// equals the join over that input with the other fields projected away (below the input's
+/// arrange), reading the kept fields by their new positions. Each side alone, and both together.
+fn join_narrowing(r: &mut Reified, n: usize, found: &mut Vec<(usize, usize)>) {
+    let projection = r.projections[r.nodes[n].payload as usize].clone();
+    let children = r.nodes[n].children.clone();
+    let mut narrowings: Vec<(usize, usize, BTreeMap<usize, usize>)> = Vec::new(); // (side, narrowed node, map)
+    for side in [1usize, 2] {
+        let (input, arranged) = r.below_arrange(children[side - 1]);
+        let Some((_, v)) = r.nodes[input].row.width else { continue };
+        let scalar::Demand::Fields(fields) = scalar::projection_demand(&projection, side) else { continue };
+        if fields.len() >= v {
+            continue;
+        }
+        let (op, map) = scalar::keep_fields(&fields);
+        let narrowed = r.step_below(input, arranged, &op);
+        narrowings.push((side, narrowed, map));
+    }
+    let mut variants: Vec<Vec<&(usize, usize, BTreeMap<usize, usize>)>> = narrowings.iter().map(|x| vec![x]).collect();
+    if narrowings.len() == 2 {
+        variants.push(narrowings.iter().collect());
+    }
+    for chosen in variants {
+        let mut kids = children.clone();
+        let mut p = projection.clone();
+        for (side, narrowed, map) in chosen {
+            kids[*side - 1] = *narrowed;
+            p = scalar::narrow_join(&p, *side, map);
+        }
+        let payload = r.intern(KIND_JOIN, &p, |r| &mut r.projections);
+        let row = r.nodes[n].row;
+        let twin = r.push(KIND_JOIN, payload, kids, row);
+        found.push((n, twin));
+    }
+}
+
+/// Join commutativity: a join equals the join of its inputs swapped, reading them swapped.
+fn join_commutativity(r: &mut Reified, n: usize, found: &mut Vec<(usize, usize)>) {
+    let projection = r.projections[r.nodes[n].payload as usize].clone();
+    let swapped = scalar::swap_join(&projection);
+    let payload = r.intern(KIND_JOIN, &swapped, |r| &mut r.projections);
+    let kids = vec![r.nodes[n].children[1], r.nodes[n].children[0]];
+    let row = r.nodes[n].row;
+    let twin = r.push(KIND_JOIN, payload, kids, row);
+    found.push((n, twin));
+}
+
+/// Filter pushdown: a filter over a projection equals the projection over the filter composed
+/// through it; over a negation or an entry, the same filter below; over a concatenation, the
+/// concatenation of the filter over each part; over a join, the join with the filter composed
+/// through its projection on whichever input alone the composed predicate reads (below that
+/// input's arrange). Each is minted only when the predicate can be expressed over the rows below.
+fn filter_pushdown(r: &mut Reified, n: usize, found: &mut Vec<(usize, usize)>) {
+    let Some(LinearOp::Filter(p)) = r.op_of(n).cloned() else { return };
+    let child = r.nodes[n].children[0];
+    match r.nodes[child].kind {
+        KIND_OP => {
+            let below = r.nodes[child].children[0];
+            let op = r.op_of(child).cloned().unwrap();
+            let pushed = match &op {
+                LinearOp::Project(q) => {
+                    let Some((k, v)) = r.nodes[below].row.width else { return };
+                    let Some(composed) = scalar::compose(&p, q, &[k, v]) else { return };
+                    LinearOp::Filter(composed)
+                }
+                LinearOp::Negate | LinearOp::EnterAt(_) => LinearOp::Filter(p),
+                _ => return,
+            };
+            let filtered = r.step_below(below, false, &pushed);
+            let payload = r.nodes[child].payload;
+            let row = scalar_step(&op, r.nodes[filtered].row);
+            let twin = r.push(KIND_OP, payload, vec![filtered], row);
+            found.push((n, twin));
+        }
+        KIND_CONCAT => {
+            let parts = r.nodes[child].children.clone();
+            let op = LinearOp::Filter(p);
+            let filtered: Vec<usize> = parts.iter().map(|&x| r.step_below(x, false, &op)).collect();
+            let row = Row { width: r.nodes[child].row.width, volume: filtered.iter().map(|&x| r.nodes[x].row.volume).sum() };
+            let twin = r.push(KIND_CONCAT, 0, filtered, row);
+            found.push((n, twin));
+        }
+        KIND_JOIN => {
+            let q = r.projections[r.nodes[child].payload as usize].clone();
+            let [l, rr] = r.nodes[child].children[..] else { return };
+            let (Some((k, wl)), Some((_, wr))) = (r.nodes[l].row.width, r.nodes[rr].row.width) else { return };
+            let Some(composed) = scalar::compose(&p, &q, &[k, wl, wr]) else { return };
+            let reads = |row: usize| !matches!(scalar::demand(&composed, row), scalar::Demand::Fields(ref f) if f.is_empty());
+            let (side, predicate) = match (reads(1), reads(2)) {
+                (_, false) => (0, composed),
+                (false, true) => (1, scalar::rename_rows(&composed, &[(2, 1)].into_iter().collect())),
+                _ => return,
+            };
+            let (input, arranged) = r.below_arrange(r.nodes[child].children[side]);
+            let filtered = r.step_below(input, arranged, &LinearOp::Filter(predicate));
+            let mut kids = r.nodes[child].children.clone();
+            kids[side] = filtered;
+            let row = join_row(&q, r.nodes[kids[0]].row, r.nodes[kids[1]].row);
+            let payload = r.nodes[child].payload;
+            let twin = r.push(KIND_JOIN, payload, kids, row);
+            found.push((n, twin));
+        }
+        _ => {}
+    }
+}
+
+/// Optimize one scope; returns it with its exports' rows (what its parent needs of it).
+fn optimize_scope(scope: &Scope, import_rows: &[Row]) -> (Scope, Vec<Row>) {
+    let f = scope_facts(scope, import_rows);
+    let (mut r, bind_roots, export_roots) = reify(scope, &f);
+    instantiate_rules(&mut r);
+
     // the child scope behind each Sub node, by node id.
     let sub_of: HashMap<usize, usize> =
         r.nodes.iter().enumerate().filter(|(_, n)| n.kind == KIND_SUB).map(|(id, _)| id).enumerate().map(|(k, id)| (id, k)).collect();
-    let bind_roots: Vec<usize> = scope.binds.iter().map(|b| refs.resolve(&b.value, &mut r)).collect();
-    let export_roots: Vec<usize> = scope.exports.iter().map(|e| refs.resolve(&e.value, &mut r)).collect();
-
-    // Host-instantiated rules, from scalar facts.
-    //
-    // Demand pushdown: a reducer that reads no values equals the same reducer over its input
-    // with the values projected away. The narrowed twin is cheaper by the values' width, so
-    // extraction takes it wherever there were values to drop.
-    let reduce_nodes: Vec<usize> = (0..r.nodes.len()).filter(|&n| r.nodes[n].kind == KIND_REDUCE).collect();
-    for n in reduce_nodes {
-        let reducer = r.reducers[r.nodes[n].payload as usize].clone();
-        let input = r.nodes[n].children[0];
-        let Some((k, v)) = r.nodes[input].width else { continue };
-        if scalar::reducer_reads_values(&reducer) || v == 0 {
-            continue;
-        }
-        let narrow_op = scalar::keep_key_only();
-        let payload = r.intern(KIND_OP, &narrow_op, |r| &mut r.ops);
-        let narrowed = r.push(KIND_OP, payload, vec![input], Some((k, 0)));
-        let (reduce_payload, width) = (r.nodes[n].payload, r.nodes[n].width);
-        let twin = r.push(KIND_REDUCE, reduce_payload, vec![narrowed], width);
-        r.equal.push((n, twin));
-    }
-    // Demand pushdown through a join: a join that reads only some fields of an input's values
-    // equals the join over that input with the other fields projected away, reading the kept
-    // fields by their new positions. Each side alone, and both together, are minted.
-    let join_nodes: Vec<usize> = (0..r.nodes.len()).filter(|&n| r.nodes[n].kind == KIND_JOIN).collect();
-    for &n in &join_nodes {
-        let projection = r.projections[r.nodes[n].payload as usize].clone();
-        let children = r.nodes[n].children.clone();
-        let mut narrowings: Vec<(usize, usize, BTreeMap<usize, usize>)> = Vec::new(); // (side, narrowed node, map)
-        for side in [1usize, 2] {
-            // narrow below an Arrange, which is where the rows are held
-            let (input, arranged) = match r.nodes[children[side - 1]].kind {
-                KIND_ARRANGE => (r.nodes[children[side - 1]].children[0], true),
-                _ => (children[side - 1], false),
-            };
-            let Some((k, v)) = r.nodes[input].width else { continue };
-            let scalar::Demand::Fields(fields) = scalar::projection_demand(&projection, side) else { continue };
-            if fields.len() >= v {
-                continue;
-            }
-            let (op, map) = scalar::keep_fields(&fields);
-            let payload = r.intern(KIND_OP, &op, |r| &mut r.ops);
-            let mut narrowed = r.push(KIND_OP, payload, vec![input], Some((k, fields.len())));
-            if arranged {
-                narrowed = r.push(KIND_ARRANGE, 0, vec![narrowed], Some((k, fields.len())));
-            }
-            narrowings.push((side, narrowed, map));
-        }
-        let mut variants: Vec<Vec<&(usize, usize, BTreeMap<usize, usize>)>> = narrowings.iter().map(|x| vec![x]).collect();
-        if narrowings.len() == 2 {
-            variants.push(narrowings.iter().collect());
-        }
-        for chosen in variants {
-            let mut kids = children.clone();
-            let mut p = projection.clone();
-            for (side, narrowed, map) in chosen {
-                kids[*side - 1] = *narrowed;
-                p = scalar::narrow_join(&p, *side, map);
-            }
-            let payload = r.intern(KIND_JOIN, &p, |r| &mut r.projections);
-            let width = r.nodes[n].width;
-            let twin = r.push(KIND_JOIN, payload, kids, width);
-            r.equal.push((n, twin));
-        }
-    }
-    // Join commutativity: a join equals the join of its inputs swapped, reading them swapped.
-    for &n in &join_nodes {
-        let projection = r.projections[r.nodes[n].payload as usize].clone();
-        let swapped = scalar::swap_join(&projection);
-        let payload = r.intern(KIND_JOIN, &swapped, |r| &mut r.projections);
-        let kids = vec![r.nodes[n].children[1], r.nodes[n].children[0]];
-        let width = r.nodes[n].width;
-        let twin = r.push(KIND_JOIN, payload, kids, width);
-        r.equal.push((n, twin));
-    }
 
     // Saturate and extract, as a DDIR program on the vec backend.
     let int = |n: usize| Value::Int(n as i64);
@@ -447,10 +603,7 @@ fn optimize_scope(scope: &Scope, import_widths: &[Option<Width>]) -> (Scope, Vec
         .nodes
         .iter()
         .enumerate()
-        .map(|(id, n)| {
-            let priced = n.priced(&r.nodes).map_or(0, |(k, v)| (k + v) as i64);
-            (Value::Tuple(vec![int(id), Value::Int(n.kind), Value::Int(n.payload), Value::Int(priced)]), Value::unit())
-        })
+        .map(|(id, n)| (Value::Tuple(vec![int(id), Value::Int(n.kind), Value::Int(n.payload), Value::Int(r.price_of(id))]), Value::unit()))
         .collect();
     let edge_rows: Vec<(Value, Value)> = r
         .nodes
@@ -478,12 +631,12 @@ fn optimize_scope(scope: &Scope, import_widths: &[Option<Width>]) -> (Scope, Vec
     };
 
     // Consumers per class in the extracted DAG (reachable from the roots), so a chain of steps
-    // with one consumer folds into one `Linear`. The roots (binds, exports) consume their classes
-    // too, so a chain ending at a root is not folded into the step that follows it.
+    // with one consumer folds into one `Linear`, and a nested concatenation with one consumer
+    // into its parent. The roots (binds, exports) consume their classes too.
     let mut consumers: HashMap<usize, usize> = HashMap::new();
-    let mut seen: std::collections::HashSet<usize> = Default::default();
-    let mut stack: Vec<usize> = bind_roots.iter().chain(&export_roots).map(|&n| chosen(n)).collect();
-    for &n in bind_roots.iter().chain(&export_roots) {
+    let mut seen: HashSet<usize> = Default::default();
+    let mut stack: Vec<usize> = roots.iter().map(|&n| chosen(n)).collect();
+    for &n in &roots {
         *consumers.entry(classes[&n]).or_insert(0) += 1;
     }
     while let Some(n) = stack.pop() {
@@ -509,8 +662,8 @@ fn optimize_scope(scope: &Scope, import_widths: &[Option<Width>]) -> (Scope, Vec
         let value = ctx.emit(root, &mut emitted, &mut out_scope);
         out_scope.exports.push(Export { name: e.name.clone(), value });
     }
-    let export_widths: Vec<Option<Width>> = export_roots.iter().map(|&n| r.nodes[n].width).collect();
-    (out_scope, export_widths)
+    let export_rows: Vec<Row> = export_roots.iter().map(|&n| r.nodes[n].row).collect();
+    (out_scope, export_rows)
 }
 
 /// DAG-aware extraction: starting from a choice per class (the tree-cost optimum), hill-climb on
@@ -520,7 +673,7 @@ fn optimize_scope(scope: &Scope, import_widths: &[Option<Width>]) -> (Scope, Vec
 /// pays for a second copy of something a sibling already materializes, is never taken).
 /// Optimal DAG extraction is NP-hard; this is the standard greedy, seeded by the tree optimum.
 fn refine_dag(r: &Reified, classes: &BTreeMap<usize, usize>, roots: &[usize], mut pick: BTreeMap<usize, usize>) -> BTreeMap<usize, usize> {
-    let w: Vec<i64> = r.nodes.iter().map(|x| price(x.kind, x.priced(&r.nodes))).collect();
+    let w: Vec<i64> = (0..r.nodes.len()).map(|n| r.price_of(n)).collect();
     let mut members: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
     for (&node, &class) in classes {
         members.entry(class).or_default().push(node);
@@ -609,6 +762,22 @@ impl Rebuild<'_> {
         Ref::Local(out.items.len() - 1)
     }
 
+    fn chosen(&self, node: usize) -> usize {
+        self.best[&self.classes[&node]]
+    }
+
+    /// A concatenation's parts, with single-consumer nested concatenations spliced in.
+    fn concat_parts(&self, children: &[usize], out: &mut Vec<usize>) {
+        for &c in children {
+            let cc = self.chosen(c);
+            if self.r.nodes[cc].kind == KIND_CONCAT && self.consumers.get(&self.classes[&cc]).copied().unwrap_or(0) == 1 {
+                self.concat_parts(&self.r.nodes[cc].children, out);
+            } else {
+                out.push(c);
+            }
+        }
+    }
+
     /// Emit the chosen node of `node`'s class into `out` (its children first), memoized by class.
     fn emit(&self, node: usize, emitted: &mut HashMap<usize, Ref>, out: &mut Scope) -> Ref {
         let class = self.classes[&node];
@@ -645,7 +814,9 @@ impl Rebuild<'_> {
                 Self::local(out, Node::Linear { input, ops: vec![op] })
             }
             KIND_CONCAT => {
-                let kids: Vec<Ref> = rn.children.iter().map(|&c| self.emit(c, emitted, out)).collect();
+                let mut parts = Vec::new();
+                self.concat_parts(&rn.children, &mut parts);
+                let kids: Vec<Ref> = parts.iter().map(|&c| self.emit(c, emitted, out)).collect();
                 Self::local(out, Node::Concat(kids))
             }
             KIND_ARRANGE => {

--- a/interactive/src/egraph/mod.rs
+++ b/interactive/src/egraph/mod.rs
@@ -4,13 +4,21 @@
 //!
 //! What the e-graph sees is the scope's operator DAG at the grain of one node per linear step,
 //! with everything an operator closes over — a projection, a predicate, a reducer, a child
-//! scope's body — interned to an opaque id. Two nodes are equal when their kinds, payloads, and
-//! children's classes agree (congruence), or when a rule says so; today the one rule is arrange
-//! idempotence. Extraction picks, per class, the node with the least tree cost, and the host
-//! regroups single-consumer chains of steps back into `Linear` operators.
+//! scope's body — interned to an opaque id, and each node priced by the width of the row it
+//! produces. Two nodes are equal when their kinds, payloads, and children's classes agree
+//! (congruence), or when a rule says so. Rules come in two kinds: those the program states over
+//! the term table alone (arrange idempotence), and those the host instantiates because they need
+//! a fact about a scalar operator ([`scalar`]) — demand pushdown mints, for a reducer or a join
+//! that reads only some of an input's fields, the same operator over a projection of that input
+//! keeping just those fields, and asserts the two equal; join commutativity mints each join with
+//! its inputs swapped.
+//! Extraction picks, per class, the node with the least tree cost, and the host regroups
+//! single-consumer chains of steps back into `Linear` operators.
 //!
 //! Child scopes are opaque leaves of their parent's e-graph, optimized on their own first: a scope
 //! boundary is a semantic barrier, so nothing merges across one.
+
+pub mod scalar;
 
 use std::collections::{BTreeMap, HashMap};
 
@@ -18,6 +26,7 @@ use crate::backend::vec;
 use crate::ir::{LinearOp, Value};
 use crate::parse::{Projection, Reducer};
 use crate::scope_ir::{Bind, Export, Item, Node, Program, Ref, Scope, Source};
+use scalar::Width;
 
 const KIND_IMPORT: i64 = 0;
 const KIND_VAR: i64 = 1;
@@ -30,6 +39,31 @@ const KIND_REDUCE: i64 = 7;
 const KIND_INSPECT: i64 = 8;
 const KIND_SUB: i64 = 9;
 
+/// The op weight by kind — the same table `optimize.ddp` prices with.
+fn weight(kind: i64) -> i64 {
+    match kind {
+        KIND_ARRANGE => 3,
+        KIND_JOIN => 5,
+        KIND_REDUCE => 4,
+        KIND_SUB => 8,
+        _ => 1,
+    }
+}
+
+/// The width a node is priced by: the rows it holds for an Arrange or a Reduce (its input's),
+/// the rows it produces for everything else.
+fn priced_width(kind: i64, input: Option<Width>, output: Option<Width>) -> Option<Width> {
+    match kind {
+        KIND_ARRANGE | KIND_REDUCE => input,
+        _ => output,
+    }
+}
+
+/// A node's price: its weight times one plus its priced width.
+fn price(kind: i64, priced: Option<Width>) -> i64 {
+    weight(kind) * (1 + priced.map_or(0, |(k, v)| (k + v) as i64))
+}
+
 /// The optimizer program, parsed and lowered once.
 fn optimizer() -> &'static Program {
     static PROGRAM: std::sync::OnceLock<Program> = std::sync::OnceLock::new();
@@ -41,9 +75,136 @@ fn optimizer() -> &'static Program {
     })
 }
 
-/// Optimize every scope of `program`, innermost first, through the e-graph.
-pub fn optimize(program: &Program) -> Program {
-    Program { root: optimize_scope(&program.root) }
+fn root_widths(program: &Program, source_widths: &[Option<Width>]) -> Vec<Option<Width>> {
+    (0..program.root.imports.len()).map(|k| source_widths.get(k).copied().flatten()).collect()
+}
+
+/// Optimize every scope of `program`, innermost first, through the e-graph. `source_widths`
+/// gives each root import's row width, so rows can be priced; `None` for an input whose width is
+/// not known.
+pub fn optimize(program: &Program, source_widths: &[Option<Width>]) -> Program {
+    Program { root: optimize_scope(&program.root, &root_widths(program, source_widths)).0 }
+}
+
+/// The DAG cost of a program under the optimizer's model: every operator priced by kind and by
+/// the width of the row it produces. What `optimize` minimizes per class, summed over the program
+/// as it will run (shared subterms once).
+pub fn cost(program: &Program, source_widths: &[Option<Width>]) -> i64 {
+    fn scope_cost(s: &Scope, import_widths: &[Option<Width>]) -> i64 {
+        let w = scope_widths(s, import_widths);
+        let mut total = 0;
+        for (i, item) in s.items.iter().enumerate() {
+            match item {
+                Item::Op(Node::Linear { ops, .. }) => {
+                    let mut cur = w.inputs[i];
+                    for op in ops {
+                        cur = cur.and_then(|c| scalar::width_after(op, c));
+                        total += price(KIND_OP, cur);
+                    }
+                }
+                Item::Op(node) => {
+                    let (kind, input) = match node {
+                        Node::Concat(_) => (KIND_CONCAT, None),
+                        Node::Arrange(input) => (KIND_ARRANGE, Some(input)),
+                        Node::Join { .. } => (KIND_JOIN, None),
+                        Node::Reduce { input, .. } => (KIND_REDUCE, Some(input)),
+                        Node::Inspect { .. } => (KIND_INSPECT, None),
+                        Node::Linear { .. } => unreachable!(),
+                    };
+                    total += price(kind, priced_width(kind, input.and_then(|rf| w.of_ref(rf)), w.items[i]));
+                }
+                Item::Sub(child) => {
+                    total += price(KIND_SUB, None) + scope_cost(child, &w.child_imports(child));
+                }
+            }
+        }
+        total
+    }
+    scope_cost(&program.root, &root_widths(program, source_widths))
+}
+
+/// Row widths through one scope: per item (its output), per linear item's input, per var, per
+/// import, and per child scope's exports.
+struct Widths {
+    items: Vec<Option<Width>>,
+    inputs: Vec<Option<Width>>,
+    vars: Vec<Option<Width>>,
+    imports: Vec<Option<Width>>,
+    child_exports: HashMap<usize, Vec<Option<Width>>>,
+}
+
+impl Widths {
+    fn of_ref(&self, rf: &Ref) -> Option<Width> {
+        match rf {
+            Ref::Local(i) => self.items[*i],
+            Ref::Import(k) => self.imports[*k],
+            Ref::Var(v) => self.vars[*v],
+            Ref::ChildExport(i, k) => self.child_exports.get(i).and_then(|ws| ws.get(*k).copied().flatten()),
+        }
+    }
+    /// A child scope's import widths, as its parent sees them.
+    fn child_imports(&self, child: &Scope) -> Vec<Option<Width>> {
+        child
+            .imports
+            .iter()
+            .map(|imp| match &imp.from {
+                Source::Parent(rf) => self.of_ref(rf),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+/// The forward width pass over a scope; feedback vars take their bound value's width, to a
+/// fixpoint (a var read before it is known stays unknown for that pass).
+fn scope_widths(s: &Scope, import_widths: &[Option<Width>]) -> Widths {
+    let mut w = Widths {
+        items: vec![None; s.items.len()],
+        inputs: vec![None; s.items.len()],
+        vars: vec![None; s.vars.len()],
+        imports: import_widths.to_vec(),
+        child_exports: HashMap::new(),
+    };
+    for _pass in 0..4 {
+        for (i, item) in s.items.iter().enumerate() {
+            let out = match item {
+                Item::Op(Node::Linear { input, ops }) => {
+                    let mut cur = w.of_ref(input);
+                    w.inputs[i] = cur;
+                    for op in ops {
+                        cur = cur.and_then(|c| scalar::width_after(op, c));
+                    }
+                    cur
+                }
+                Item::Op(Node::Concat(refs)) => refs.first().and_then(|r| w.of_ref(r)),
+                Item::Op(Node::Arrange(input)) | Item::Op(Node::Inspect { input, .. }) => w.of_ref(input),
+                Item::Op(Node::Join { left, right, projection }) => match (w.of_ref(left), w.of_ref(right)) {
+                    (Some(l), Some(r)) => scalar::join_width(projection, l.0, l.1, r.1),
+                    _ => None,
+                },
+                Item::Op(Node::Reduce { input, reducer }) => w.of_ref(input).map(|c| scalar::reducer_width(reducer, c)),
+                Item::Sub(child) => {
+                    let cw = scope_widths(child, &w.child_imports(child));
+                    let exports: Vec<Option<Width>> = child.exports.iter().map(|e| cw.of_ref(&e.value)).collect();
+                    w.child_exports.insert(i, exports);
+                    None
+                }
+            };
+            w.items[i] = out;
+        }
+        let mut changed = false;
+        for b in &s.binds {
+            let nw = w.of_ref(&b.value);
+            if nw.is_some() && w.vars[b.var] != nw {
+                w.vars[b.var] = nw;
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    w
 }
 
 /// One node of a reified scope.
@@ -52,12 +213,23 @@ struct RNode {
     kind: i64,
     payload: i64,
     children: Vec<usize>,
+    /// the width of the row the node produces
+    width: Option<Width>,
 }
 
-/// A scope reified for the e-graph: its nodes, and the tables its payloads intern into.
+impl RNode {
+    /// The width the node is priced by (see `priced_width`), given its children.
+    fn priced(&self, nodes: &[RNode]) -> Option<Width> {
+        priced_width(self.kind, self.children.first().and_then(|&c| nodes[c].width), self.width)
+    }
+}
+
+/// A scope reified for the e-graph: its nodes, the tables its payloads intern into, and the
+/// equalities the host asserted from scalar facts.
 #[derive(Default)]
 struct Reified {
     nodes: Vec<RNode>,
+    equal: Vec<(usize, usize)>,
     ops: Vec<LinearOp>,
     projections: Vec<Projection>,
     reducers: Vec<Reducer>,
@@ -68,8 +240,8 @@ struct Reified {
 }
 
 impl Reified {
-    fn push(&mut self, kind: i64, payload: i64, children: Vec<usize>) -> usize {
-        self.nodes.push(RNode { kind, payload, children });
+    fn push(&mut self, kind: i64, payload: i64, children: Vec<usize>, width: Option<Width>) -> usize {
+        self.nodes.push(RNode { kind, payload, children, width });
         self.nodes.len() - 1
     }
     fn intern<T: std::fmt::Debug + Clone>(&mut self, kind: i64, value: &T, table: fn(&mut Self) -> &mut Vec<T>) -> i64 {
@@ -92,135 +264,219 @@ fn sub_body(s: &Scope) -> String {
     format!("{:?} {:?} {:?} {:?} {:?}", imports, s.vars, s.items, s.binds, s.exports)
 }
 
-fn optimize_scope(scope: &Scope) -> Scope {
+/// The reifier's view of where a scope's refs land: node ids for imports, vars, items, and
+/// (minted on demand) child exports.
+struct Refs {
+    import_nodes: Vec<usize>,
+    var_nodes: Vec<usize>,
+    item_nodes: Vec<usize>,
+    child_exports: HashMap<(usize, usize), usize>,
+    sub_export_widths: HashMap<usize, Vec<Option<Width>>>,
+}
+
+impl Refs {
+    fn resolve(&mut self, rf: &Ref, r: &mut Reified) -> usize {
+        match rf {
+            Ref::Local(i) => self.item_nodes[*i],
+            Ref::Import(k) => self.import_nodes[*k],
+            Ref::Var(v) => self.var_nodes[*v],
+            Ref::ChildExport(i, k) => *self.child_exports.entry((*i, *k)).or_insert_with(|| {
+                let width = self.sub_export_widths.get(i).and_then(|ws| ws.get(*k).copied().flatten());
+                r.push(KIND_CHILD_EXPORT, *k as i64, vec![self.item_nodes[*i]], width)
+            }),
+        }
+    }
+}
+
+/// Optimize one scope; returns it with its exports' widths (what its parent needs of it).
+fn optimize_scope(scope: &Scope, import_widths: &[Option<Width>]) -> (Scope, Vec<Option<Width>>) {
+    let w = scope_widths(scope, import_widths);
+
     // Reify. Children scopes are optimized first and enter as opaque `Sub` nodes.
     let mut r = Reified::default();
-    let import_nodes: Vec<usize> = (0..scope.imports.len()).map(|k| r.push(KIND_IMPORT, k as i64, vec![])).collect();
-    let var_nodes: Vec<usize> = (0..scope.vars.len()).map(|v| r.push(KIND_VAR, v as i64, vec![])).collect();
-    let mut item_nodes: Vec<usize> = Vec::with_capacity(scope.items.len());
-    let mut child_exports: HashMap<(usize, usize), usize> = HashMap::new();
-    let resolve = |rf: &Ref, rr: &mut Reified, items: &[usize], exports: &mut HashMap<(usize, usize), usize>| -> usize {
-        match rf {
-            Ref::Local(i) => items[*i],
-            Ref::Import(k) => import_nodes[*k],
-            Ref::Var(v) => var_nodes[*v],
-            Ref::ChildExport(i, k) => *exports
-                .entry((*i, *k))
-                .or_insert_with(|| rr.push(KIND_CHILD_EXPORT, *k as i64, vec![items[*i]])),
-        }
+    let mut refs = Refs {
+        import_nodes: (0..scope.imports.len()).map(|k| r.push(KIND_IMPORT, k as i64, vec![], w.imports[k])).collect(),
+        var_nodes: (0..scope.vars.len()).map(|v| r.push(KIND_VAR, v as i64, vec![], w.vars[v])).collect(),
+        item_nodes: Vec::with_capacity(scope.items.len()),
+        child_exports: HashMap::new(),
+        sub_export_widths: HashMap::new(),
     };
-    for item in &scope.items {
+    for (i, item) in scope.items.iter().enumerate() {
         let node = match item {
             Item::Op(Node::Linear { input, ops }) => {
-                let mut prev = resolve(input, &mut r, &item_nodes, &mut child_exports);
+                let mut prev = refs.resolve(input, &mut r);
+                let mut cur = w.inputs[i];
                 for op in ops {
+                    cur = cur.and_then(|c| scalar::width_after(op, c));
                     let payload = r.intern(KIND_OP, op, |r| &mut r.ops);
-                    prev = r.push(KIND_OP, payload, vec![prev]);
+                    prev = r.push(KIND_OP, payload, vec![prev], cur);
                 }
                 prev
             }
-            Item::Op(Node::Concat(refs)) => {
-                let kids: Vec<usize> = refs.iter().map(|x| resolve(x, &mut r, &item_nodes, &mut child_exports)).collect();
-                r.push(KIND_CONCAT, 0, kids)
+            Item::Op(Node::Concat(xs)) => {
+                let kids: Vec<usize> = xs.iter().map(|x| refs.resolve(x, &mut r)).collect();
+                r.push(KIND_CONCAT, 0, kids, w.items[i])
             }
             Item::Op(Node::Arrange(input)) => {
-                let kid = resolve(input, &mut r, &item_nodes, &mut child_exports);
-                r.push(KIND_ARRANGE, 0, vec![kid])
+                let kid = refs.resolve(input, &mut r);
+                r.push(KIND_ARRANGE, 0, vec![kid], w.items[i])
             }
             Item::Op(Node::Join { left, right, projection }) => {
-                let l = resolve(left, &mut r, &item_nodes, &mut child_exports);
-                let rr = resolve(right, &mut r, &item_nodes, &mut child_exports);
+                let l = refs.resolve(left, &mut r);
+                let rr = refs.resolve(right, &mut r);
                 let payload = r.intern(KIND_JOIN, projection, |r| &mut r.projections);
-                r.push(KIND_JOIN, payload, vec![l, rr])
+                r.push(KIND_JOIN, payload, vec![l, rr], w.items[i])
             }
             Item::Op(Node::Reduce { input, reducer }) => {
-                let kid = resolve(input, &mut r, &item_nodes, &mut child_exports);
+                let kid = refs.resolve(input, &mut r);
                 let payload = r.intern(KIND_REDUCE, reducer, |r| &mut r.reducers);
-                r.push(KIND_REDUCE, payload, vec![kid])
+                r.push(KIND_REDUCE, payload, vec![kid], w.items[i])
             }
             Item::Op(Node::Inspect { input, label }) => {
-                let kid = resolve(input, &mut r, &item_nodes, &mut child_exports);
+                let kid = refs.resolve(input, &mut r);
                 let payload = r.intern(KIND_INSPECT, label, |r| &mut r.labels);
-                r.push(KIND_INSPECT, payload, vec![kid])
+                r.push(KIND_INSPECT, payload, vec![kid], w.items[i])
             }
             Item::Sub(child) => {
-                let optimized = optimize_scope(child);
+                let (optimized, export_widths) = optimize_scope(child, &w.child_imports(child));
+                refs.sub_export_widths.insert(i, export_widths);
                 let kids: Vec<usize> = optimized
                     .imports
                     .iter()
                     .map(|imp| match &imp.from {
-                        Source::Parent(rf) => resolve(rf, &mut r, &item_nodes, &mut child_exports),
+                        Source::Parent(rf) => refs.resolve(rf, &mut r),
                         other => panic!("a child scope imports from {other:?}, not its parent"),
                     })
                     .collect();
                 let body = sub_body(&optimized);
                 let payload = r.intern(KIND_SUB, &body, |r| &mut r.labels);
                 r.subs.push(optimized);
-                // the payload interns the body; `subs` keeps every child (one per Sub item) so the
-                // rebuilt scope can take the body from the node that survives extraction.
-                r.push(KIND_SUB, payload, kids)
+                r.push(KIND_SUB, payload, kids, None)
             }
         };
-        item_nodes.push(node);
+        refs.item_nodes.push(node);
     }
     // the child scope behind each Sub node, by node id.
-    let mut sub_of: HashMap<usize, usize> = HashMap::new();
-    let mut next_sub = 0;
-    for (id, n) in r.nodes.iter().enumerate() {
-        if n.kind == KIND_SUB {
-            sub_of.insert(id, next_sub);
-            next_sub += 1;
+    let sub_of: HashMap<usize, usize> =
+        r.nodes.iter().enumerate().filter(|(_, n)| n.kind == KIND_SUB).map(|(id, _)| id).enumerate().map(|(k, id)| (id, k)).collect();
+    let bind_roots: Vec<usize> = scope.binds.iter().map(|b| refs.resolve(&b.value, &mut r)).collect();
+    let export_roots: Vec<usize> = scope.exports.iter().map(|e| refs.resolve(&e.value, &mut r)).collect();
+
+    // Host-instantiated rules, from scalar facts.
+    //
+    // Demand pushdown: a reducer that reads no values equals the same reducer over its input
+    // with the values projected away. The narrowed twin is cheaper by the values' width, so
+    // extraction takes it wherever there were values to drop.
+    let reduce_nodes: Vec<usize> = (0..r.nodes.len()).filter(|&n| r.nodes[n].kind == KIND_REDUCE).collect();
+    for n in reduce_nodes {
+        let reducer = r.reducers[r.nodes[n].payload as usize].clone();
+        let input = r.nodes[n].children[0];
+        let Some((k, v)) = r.nodes[input].width else { continue };
+        if scalar::reducer_reads_values(&reducer) || v == 0 {
+            continue;
+        }
+        let narrow_op = scalar::keep_key_only();
+        let payload = r.intern(KIND_OP, &narrow_op, |r| &mut r.ops);
+        let narrowed = r.push(KIND_OP, payload, vec![input], Some((k, 0)));
+        let (reduce_payload, width) = (r.nodes[n].payload, r.nodes[n].width);
+        let twin = r.push(KIND_REDUCE, reduce_payload, vec![narrowed], width);
+        r.equal.push((n, twin));
+    }
+    // Demand pushdown through a join: a join that reads only some fields of an input's values
+    // equals the join over that input with the other fields projected away, reading the kept
+    // fields by their new positions. Each side alone, and both together, are minted.
+    let join_nodes: Vec<usize> = (0..r.nodes.len()).filter(|&n| r.nodes[n].kind == KIND_JOIN).collect();
+    for &n in &join_nodes {
+        let projection = r.projections[r.nodes[n].payload as usize].clone();
+        let children = r.nodes[n].children.clone();
+        let mut narrowings: Vec<(usize, usize, BTreeMap<usize, usize>)> = Vec::new(); // (side, narrowed node, map)
+        for side in [1usize, 2] {
+            // narrow below an Arrange, which is where the rows are held
+            let (input, arranged) = match r.nodes[children[side - 1]].kind {
+                KIND_ARRANGE => (r.nodes[children[side - 1]].children[0], true),
+                _ => (children[side - 1], false),
+            };
+            let Some((k, v)) = r.nodes[input].width else { continue };
+            let scalar::Demand::Fields(fields) = scalar::projection_demand(&projection, side) else { continue };
+            if fields.len() >= v {
+                continue;
+            }
+            let (op, map) = scalar::keep_fields(&fields);
+            let payload = r.intern(KIND_OP, &op, |r| &mut r.ops);
+            let mut narrowed = r.push(KIND_OP, payload, vec![input], Some((k, fields.len())));
+            if arranged {
+                narrowed = r.push(KIND_ARRANGE, 0, vec![narrowed], Some((k, fields.len())));
+            }
+            narrowings.push((side, narrowed, map));
+        }
+        let mut variants: Vec<Vec<&(usize, usize, BTreeMap<usize, usize>)>> = narrowings.iter().map(|x| vec![x]).collect();
+        if narrowings.len() == 2 {
+            variants.push(narrowings.iter().collect());
+        }
+        for chosen in variants {
+            let mut kids = children.clone();
+            let mut p = projection.clone();
+            for (side, narrowed, map) in chosen {
+                kids[*side - 1] = *narrowed;
+                p = scalar::narrow_join(&p, *side, map);
+            }
+            let payload = r.intern(KIND_JOIN, &p, |r| &mut r.projections);
+            let width = r.nodes[n].width;
+            let twin = r.push(KIND_JOIN, payload, kids, width);
+            r.equal.push((n, twin));
         }
     }
-    let bind_roots: Vec<usize> = scope.binds.iter().map(|b| resolve(&b.value, &mut r, &item_nodes, &mut child_exports)).collect();
-    let export_roots: Vec<usize> = scope.exports.iter().map(|e| resolve(&e.value, &mut r, &item_nodes, &mut child_exports)).collect();
+    // Join commutativity: a join equals the join of its inputs swapped, reading them swapped.
+    for &n in &join_nodes {
+        let projection = r.projections[r.nodes[n].payload as usize].clone();
+        let swapped = scalar::swap_join(&projection);
+        let payload = r.intern(KIND_JOIN, &swapped, |r| &mut r.projections);
+        let kids = vec![r.nodes[n].children[1], r.nodes[n].children[0]];
+        let width = r.nodes[n].width;
+        let twin = r.push(KIND_JOIN, payload, kids, width);
+        r.equal.push((n, twin));
+    }
 
     // Saturate and extract, as a DDIR program on the vec backend.
+    let int = |n: usize| Value::Int(n as i64);
     let node_rows: Vec<(Value, Value)> = r
         .nodes
         .iter()
         .enumerate()
-        .map(|(id, n)| (Value::Tuple(vec![Value::Int(id as i64), Value::Int(n.kind), Value::Int(n.payload)]), Value::unit()))
+        .map(|(id, n)| {
+            let priced = n.priced(&r.nodes).map_or(0, |(k, v)| (k + v) as i64);
+            (Value::Tuple(vec![int(id), Value::Int(n.kind), Value::Int(n.payload), Value::Int(priced)]), Value::unit())
+        })
         .collect();
     let edge_rows: Vec<(Value, Value)> = r
         .nodes
         .iter()
         .enumerate()
-        .flat_map(|(id, n)| {
-            n.children.iter().enumerate().map(move |(pos, &c)| {
-                (Value::Tuple(vec![Value::Int(id as i64), Value::Int(pos as i64), Value::Int(c as i64)]), Value::unit())
-            })
-        })
+        .flat_map(|(id, n)| n.children.iter().enumerate().map(move |(pos, &c)| (Value::Tuple(vec![int(id), int(pos), int(c)]), Value::unit())))
         .collect();
-    let out = vec::evaluate(optimizer(), &[node_rows, edge_rows]);
+    let equal_rows: Vec<(Value, Value)> = r.equal.iter().map(|&(a, b)| (Value::Tuple(vec![int(a), int(b)]), Value::unit())).collect();
+    let out = vec::evaluate(optimizer(), &[node_rows, edge_rows, equal_rows]);
     let ints = |v: &Value| -> Vec<i64> {
         match v {
             Value::Tuple(xs) => xs.iter().map(|x| x.as_int()).collect(),
             other => vec![other.as_int()],
         }
     };
-    let classes: BTreeMap<usize, usize> = out["classes"]
-        .iter()
-        .filter(|(_, d)| *d > 0)
-        .map(|((k, v), _)| (ints(k)[0] as usize, ints(v)[0] as usize))
-        .collect();
-    let best: BTreeMap<usize, usize> = out["best"]
-        .iter()
-        .filter(|(_, d)| *d > 0)
-        .map(|((k, v), _)| (ints(k)[0] as usize, ints(v)[0] as usize))
-        .collect();
+    let classes: BTreeMap<usize, usize> =
+        out["classes"].iter().filter(|(_, d)| *d > 0).map(|((k, v), _)| (ints(k)[0] as usize, ints(v)[0] as usize)).collect();
+    let best: BTreeMap<usize, usize> =
+        out["best"].iter().filter(|(_, d)| *d > 0).map(|((k, v), _)| (ints(k)[0] as usize, ints(v)[0] as usize)).collect();
     let chosen = |node: usize| -> usize {
         let class = classes[&node];
         *best.get(&class).unwrap_or_else(|| panic!("class {class} has no extracted node"))
     };
 
     // Consumers per class in the extracted DAG (reachable from the roots), so a chain of steps
-    // with one consumer folds into one `Linear`.
+    // with one consumer folds into one `Linear`. The roots (binds, exports) consume their classes
+    // too, so a chain ending at a root is not folded into the step that follows it.
     let mut consumers: HashMap<usize, usize> = HashMap::new();
     let mut seen: std::collections::HashSet<usize> = Default::default();
     let mut stack: Vec<usize> = bind_roots.iter().chain(&export_roots).map(|&n| chosen(n)).collect();
-    // the roots (binds, exports) consume their classes too, so a chain ending at a root is not
-    // folded into the step that follows it.
     for &n in bind_roots.iter().chain(&export_roots) {
         *consumers.entry(classes[&n]).or_insert(0) += 1;
     }
@@ -236,48 +492,60 @@ fn optimize_scope(scope: &Scope) -> Scope {
     }
 
     // Rebuild the scope from the chosen nodes, children before parents.
-    let mut out_scope = Scope {
-        name: scope.name.clone(),
-        imports: scope.imports.clone(),
-        vars: scope.vars.clone(),
-        ..Scope::default()
-    };
+    let mut out_scope = Scope { name: scope.name.clone(), imports: scope.imports.clone(), vars: scope.vars.clone(), ..Scope::default() };
+    let ctx = Rebuild { r: &r, classes: &classes, best: &best, consumers: &consumers, sub_of: &sub_of };
     let mut emitted: HashMap<usize, Ref> = HashMap::new(); // by class
-    fn emit(
-        node: usize,
-        r: &Reified,
-        classes: &BTreeMap<usize, usize>,
-        best: &BTreeMap<usize, usize>,
-        consumers: &HashMap<usize, usize>,
-        sub_of: &HashMap<usize, usize>,
-        emitted: &mut HashMap<usize, Ref>,
-        out: &mut Scope,
-    ) -> Ref {
-        let class = classes[&node];
+    for (b, &root) in scope.binds.iter().zip(&bind_roots) {
+        let value = ctx.emit(root, &mut emitted, &mut out_scope);
+        out_scope.binds.push(Bind { var: b.var, value });
+    }
+    for (e, &root) in scope.exports.iter().zip(&export_roots) {
+        let value = ctx.emit(root, &mut emitted, &mut out_scope);
+        out_scope.exports.push(Export { name: e.name.clone(), value });
+    }
+    let export_widths: Vec<Option<Width>> = export_roots.iter().map(|&n| r.nodes[n].width).collect();
+    (out_scope, export_widths)
+}
+
+/// What rebuilding a scope reads: the reified nodes, the classes, the choice per class, the
+/// consumer counts per class, and which child scope each Sub node stands for.
+struct Rebuild<'a> {
+    r: &'a Reified,
+    classes: &'a BTreeMap<usize, usize>,
+    best: &'a BTreeMap<usize, usize>,
+    consumers: &'a HashMap<usize, usize>,
+    sub_of: &'a HashMap<usize, usize>,
+}
+
+impl Rebuild<'_> {
+    fn local(out: &mut Scope, node: Node) -> Ref {
+        out.items.push(Item::Op(node));
+        Ref::Local(out.items.len() - 1)
+    }
+
+    /// Emit the chosen node of `node`'s class into `out` (its children first), memoized by class.
+    fn emit(&self, node: usize, emitted: &mut HashMap<usize, Ref>, out: &mut Scope) -> Ref {
+        let class = self.classes[&node];
         if let Some(rf) = emitted.get(&class) {
             return rf.clone();
         }
-        let n = best[&class];
-        let rn = &r.nodes[n];
-        let kid = |k: usize, emitted: &mut HashMap<usize, Ref>, out: &mut Scope| {
-            emit(rn.children[k], r, classes, best, consumers, sub_of, emitted, out)
-        };
+        let n = self.best[&class];
+        let rn = &self.r.nodes[n];
         let rf = match rn.kind {
             KIND_IMPORT => Ref::Import(rn.payload as usize),
             KIND_VAR => Ref::Var(rn.payload as usize),
-            KIND_CHILD_EXPORT => match kid(0, emitted, out) {
+            KIND_CHILD_EXPORT => match self.emit(rn.children[0], emitted, out) {
                 Ref::Local(i) => Ref::ChildExport(i, rn.payload as usize),
                 other => panic!("a child export's scope emitted as {other:?}"),
             },
             KIND_OP => {
-                let input = kid(0, emitted, out);
-                let op = r.ops[rn.payload as usize].clone();
+                let input = self.emit(rn.children[0], emitted, out);
+                let op = self.r.ops[rn.payload as usize].clone();
                 // extend a single-consumer `Linear` in place, else start one
-                let input_class = classes[&rn.children[0]];
+                let input_class = self.classes[&rn.children[0]];
                 let extend = match &input {
                     Ref::Local(i) => {
-                        consumers.get(&input_class).copied().unwrap_or(0) == 1
-                            && matches!(out.items[*i], Item::Op(Node::Linear { .. }))
+                        self.consumers.get(&input_class).copied().unwrap_or(0) == 1 && matches!(out.items[*i], Item::Op(Node::Linear { .. }))
                     }
                     _ => false,
                 };
@@ -285,42 +553,35 @@ fn optimize_scope(scope: &Scope) -> Scope {
                     let Ref::Local(i) = input else { unreachable!() };
                     let Item::Op(Node::Linear { ops, .. }) = &mut out.items[i] else { unreachable!() };
                     ops.push(op);
-                    // the extended item now stands for this class too
                     emitted.insert(class, Ref::Local(i));
                     return Ref::Local(i);
                 }
-                out.items.push(Item::Op(Node::Linear { input, ops: vec![op] }));
-                Ref::Local(out.items.len() - 1)
+                Self::local(out, Node::Linear { input, ops: vec![op] })
             }
             KIND_CONCAT => {
-                let kids: Vec<Ref> = (0..rn.children.len()).map(|k| kid(k, emitted, out)).collect();
-                out.items.push(Item::Op(Node::Concat(kids)));
-                Ref::Local(out.items.len() - 1)
+                let kids: Vec<Ref> = rn.children.iter().map(|&c| self.emit(c, emitted, out)).collect();
+                Self::local(out, Node::Concat(kids))
             }
             KIND_ARRANGE => {
-                let input = kid(0, emitted, out);
-                out.items.push(Item::Op(Node::Arrange(input)));
-                Ref::Local(out.items.len() - 1)
+                let input = self.emit(rn.children[0], emitted, out);
+                Self::local(out, Node::Arrange(input))
             }
             KIND_JOIN => {
-                let left = kid(0, emitted, out);
-                let right = kid(1, emitted, out);
-                out.items.push(Item::Op(Node::Join { left, right, projection: r.projections[rn.payload as usize].clone() }));
-                Ref::Local(out.items.len() - 1)
+                let left = self.emit(rn.children[0], emitted, out);
+                let right = self.emit(rn.children[1], emitted, out);
+                Self::local(out, Node::Join { left, right, projection: self.r.projections[rn.payload as usize].clone() })
             }
             KIND_REDUCE => {
-                let input = kid(0, emitted, out);
-                out.items.push(Item::Op(Node::Reduce { input, reducer: r.reducers[rn.payload as usize].clone() }));
-                Ref::Local(out.items.len() - 1)
+                let input = self.emit(rn.children[0], emitted, out);
+                Self::local(out, Node::Reduce { input, reducer: self.r.reducers[rn.payload as usize].clone() })
             }
             KIND_INSPECT => {
-                let input = kid(0, emitted, out);
-                out.items.push(Item::Op(Node::Inspect { input, label: r.labels[rn.payload as usize].clone() }));
-                Ref::Local(out.items.len() - 1)
+                let input = self.emit(rn.children[0], emitted, out);
+                Self::local(out, Node::Inspect { input, label: self.r.labels[rn.payload as usize].clone() })
             }
             KIND_SUB => {
-                let kids: Vec<Ref> = (0..rn.children.len()).map(|k| kid(k, emitted, out)).collect();
-                let mut child = r.subs[sub_of[&n]].clone();
+                let kids: Vec<Ref> = rn.children.iter().map(|&c| self.emit(c, emitted, out)).collect();
+                let mut child = self.r.subs[self.sub_of[&n]].clone();
                 for (imp, rf) in child.imports.iter_mut().zip(kids) {
                     imp.from = Source::Parent(rf);
                 }
@@ -332,13 +593,4 @@ fn optimize_scope(scope: &Scope) -> Scope {
         emitted.insert(class, rf.clone());
         rf
     }
-    for (b, &root) in scope.binds.iter().zip(&bind_roots) {
-        let value = emit(root, &r, &classes, &best, &consumers, &sub_of, &mut emitted, &mut out_scope);
-        out_scope.binds.push(Bind { var: b.var, value });
-    }
-    for (e, &root) in scope.exports.iter().zip(&export_roots) {
-        let value = emit(root, &r, &classes, &best, &consumers, &sub_of, &mut emitted, &mut out_scope);
-        out_scope.exports.push(Export { name: e.name.clone(), value });
-    }
-    out_scope
 }

--- a/interactive/src/egraph/mod.rs
+++ b/interactive/src/egraph/mod.rs
@@ -1,0 +1,344 @@
+//! The DDIR optimizer as a DDIR program: each scope of a program is reified into a term table,
+//! an equality-saturation program (`optimize.ddp`, itself DDIR) computes the e-classes and the
+//! cheapest node per class, and the scope is rebuilt from that choice.
+//!
+//! What the e-graph sees is the scope's operator DAG at the grain of one node per linear step,
+//! with everything an operator closes over — a projection, a predicate, a reducer, a child
+//! scope's body — interned to an opaque id. Two nodes are equal when their kinds, payloads, and
+//! children's classes agree (congruence), or when a rule says so; today the one rule is arrange
+//! idempotence. Extraction picks, per class, the node with the least tree cost, and the host
+//! regroups single-consumer chains of steps back into `Linear` operators.
+//!
+//! Child scopes are opaque leaves of their parent's e-graph, optimized on their own first: a scope
+//! boundary is a semantic barrier, so nothing merges across one.
+
+use std::collections::{BTreeMap, HashMap};
+
+use crate::backend::vec;
+use crate::ir::{LinearOp, Value};
+use crate::parse::{Projection, Reducer};
+use crate::scope_ir::{Bind, Export, Item, Node, Program, Ref, Scope, Source};
+
+const KIND_IMPORT: i64 = 0;
+const KIND_VAR: i64 = 1;
+const KIND_CHILD_EXPORT: i64 = 2;
+const KIND_OP: i64 = 3;
+const KIND_CONCAT: i64 = 4;
+const KIND_ARRANGE: i64 = 5;
+const KIND_JOIN: i64 = 6;
+const KIND_REDUCE: i64 = 7;
+const KIND_INSPECT: i64 = 8;
+const KIND_SUB: i64 = 9;
+
+/// The optimizer program, parsed and lowered once.
+fn optimizer() -> &'static Program {
+    static PROGRAM: std::sync::OnceLock<Program> = std::sync::OnceLock::new();
+    PROGRAM.get_or_init(|| {
+        let src = include_str!("optimize.ddp");
+        let mut tree = crate::lower::lower_tree(crate::parse::pipe::parse(src));
+        tree.optimize();
+        tree
+    })
+}
+
+/// Optimize every scope of `program`, innermost first, through the e-graph.
+pub fn optimize(program: &Program) -> Program {
+    Program { root: optimize_scope(&program.root) }
+}
+
+/// One node of a reified scope.
+#[derive(Clone, Debug)]
+struct RNode {
+    kind: i64,
+    payload: i64,
+    children: Vec<usize>,
+}
+
+/// A scope reified for the e-graph: its nodes, and the tables its payloads intern into.
+#[derive(Default)]
+struct Reified {
+    nodes: Vec<RNode>,
+    ops: Vec<LinearOp>,
+    projections: Vec<Projection>,
+    reducers: Vec<Reducer>,
+    labels: Vec<String>,
+    subs: Vec<Scope>,
+    /// interned payloads by kind: (kind, debug rendering) -> payload id
+    interned: HashMap<(i64, String), i64>,
+}
+
+impl Reified {
+    fn push(&mut self, kind: i64, payload: i64, children: Vec<usize>) -> usize {
+        self.nodes.push(RNode { kind, payload, children });
+        self.nodes.len() - 1
+    }
+    fn intern<T: std::fmt::Debug + Clone>(&mut self, kind: i64, value: &T, table: fn(&mut Self) -> &mut Vec<T>) -> i64 {
+        let key = (kind, format!("{value:?}"));
+        if let Some(&id) = self.interned.get(&key) {
+            return id;
+        }
+        let t = table(self);
+        t.push(value.clone());
+        let id = (t.len() - 1) as i64;
+        self.interned.insert(key, id);
+        id
+    }
+}
+
+/// A child scope's body, as the parent's e-graph should see it: everything but where its imports
+/// come from (those are its children edges).
+fn sub_body(s: &Scope) -> String {
+    let imports: Vec<&str> = s.imports.iter().map(|i| i.name.as_str()).collect();
+    format!("{:?} {:?} {:?} {:?} {:?}", imports, s.vars, s.items, s.binds, s.exports)
+}
+
+fn optimize_scope(scope: &Scope) -> Scope {
+    // Reify. Children scopes are optimized first and enter as opaque `Sub` nodes.
+    let mut r = Reified::default();
+    let import_nodes: Vec<usize> = (0..scope.imports.len()).map(|k| r.push(KIND_IMPORT, k as i64, vec![])).collect();
+    let var_nodes: Vec<usize> = (0..scope.vars.len()).map(|v| r.push(KIND_VAR, v as i64, vec![])).collect();
+    let mut item_nodes: Vec<usize> = Vec::with_capacity(scope.items.len());
+    let mut child_exports: HashMap<(usize, usize), usize> = HashMap::new();
+    let resolve = |rf: &Ref, rr: &mut Reified, items: &[usize], exports: &mut HashMap<(usize, usize), usize>| -> usize {
+        match rf {
+            Ref::Local(i) => items[*i],
+            Ref::Import(k) => import_nodes[*k],
+            Ref::Var(v) => var_nodes[*v],
+            Ref::ChildExport(i, k) => *exports
+                .entry((*i, *k))
+                .or_insert_with(|| rr.push(KIND_CHILD_EXPORT, *k as i64, vec![items[*i]])),
+        }
+    };
+    for item in &scope.items {
+        let node = match item {
+            Item::Op(Node::Linear { input, ops }) => {
+                let mut prev = resolve(input, &mut r, &item_nodes, &mut child_exports);
+                for op in ops {
+                    let payload = r.intern(KIND_OP, op, |r| &mut r.ops);
+                    prev = r.push(KIND_OP, payload, vec![prev]);
+                }
+                prev
+            }
+            Item::Op(Node::Concat(refs)) => {
+                let kids: Vec<usize> = refs.iter().map(|x| resolve(x, &mut r, &item_nodes, &mut child_exports)).collect();
+                r.push(KIND_CONCAT, 0, kids)
+            }
+            Item::Op(Node::Arrange(input)) => {
+                let kid = resolve(input, &mut r, &item_nodes, &mut child_exports);
+                r.push(KIND_ARRANGE, 0, vec![kid])
+            }
+            Item::Op(Node::Join { left, right, projection }) => {
+                let l = resolve(left, &mut r, &item_nodes, &mut child_exports);
+                let rr = resolve(right, &mut r, &item_nodes, &mut child_exports);
+                let payload = r.intern(KIND_JOIN, projection, |r| &mut r.projections);
+                r.push(KIND_JOIN, payload, vec![l, rr])
+            }
+            Item::Op(Node::Reduce { input, reducer }) => {
+                let kid = resolve(input, &mut r, &item_nodes, &mut child_exports);
+                let payload = r.intern(KIND_REDUCE, reducer, |r| &mut r.reducers);
+                r.push(KIND_REDUCE, payload, vec![kid])
+            }
+            Item::Op(Node::Inspect { input, label }) => {
+                let kid = resolve(input, &mut r, &item_nodes, &mut child_exports);
+                let payload = r.intern(KIND_INSPECT, label, |r| &mut r.labels);
+                r.push(KIND_INSPECT, payload, vec![kid])
+            }
+            Item::Sub(child) => {
+                let optimized = optimize_scope(child);
+                let kids: Vec<usize> = optimized
+                    .imports
+                    .iter()
+                    .map(|imp| match &imp.from {
+                        Source::Parent(rf) => resolve(rf, &mut r, &item_nodes, &mut child_exports),
+                        other => panic!("a child scope imports from {other:?}, not its parent"),
+                    })
+                    .collect();
+                let body = sub_body(&optimized);
+                let payload = r.intern(KIND_SUB, &body, |r| &mut r.labels);
+                r.subs.push(optimized);
+                // the payload interns the body; `subs` keeps every child (one per Sub item) so the
+                // rebuilt scope can take the body from the node that survives extraction.
+                r.push(KIND_SUB, payload, kids)
+            }
+        };
+        item_nodes.push(node);
+    }
+    // the child scope behind each Sub node, by node id.
+    let mut sub_of: HashMap<usize, usize> = HashMap::new();
+    let mut next_sub = 0;
+    for (id, n) in r.nodes.iter().enumerate() {
+        if n.kind == KIND_SUB {
+            sub_of.insert(id, next_sub);
+            next_sub += 1;
+        }
+    }
+    let bind_roots: Vec<usize> = scope.binds.iter().map(|b| resolve(&b.value, &mut r, &item_nodes, &mut child_exports)).collect();
+    let export_roots: Vec<usize> = scope.exports.iter().map(|e| resolve(&e.value, &mut r, &item_nodes, &mut child_exports)).collect();
+
+    // Saturate and extract, as a DDIR program on the vec backend.
+    let node_rows: Vec<(Value, Value)> = r
+        .nodes
+        .iter()
+        .enumerate()
+        .map(|(id, n)| (Value::Tuple(vec![Value::Int(id as i64), Value::Int(n.kind), Value::Int(n.payload)]), Value::unit()))
+        .collect();
+    let edge_rows: Vec<(Value, Value)> = r
+        .nodes
+        .iter()
+        .enumerate()
+        .flat_map(|(id, n)| {
+            n.children.iter().enumerate().map(move |(pos, &c)| {
+                (Value::Tuple(vec![Value::Int(id as i64), Value::Int(pos as i64), Value::Int(c as i64)]), Value::unit())
+            })
+        })
+        .collect();
+    let out = vec::evaluate(optimizer(), &[node_rows, edge_rows]);
+    let ints = |v: &Value| -> Vec<i64> {
+        match v {
+            Value::Tuple(xs) => xs.iter().map(|x| x.as_int()).collect(),
+            other => vec![other.as_int()],
+        }
+    };
+    let classes: BTreeMap<usize, usize> = out["classes"]
+        .iter()
+        .filter(|(_, d)| *d > 0)
+        .map(|((k, v), _)| (ints(k)[0] as usize, ints(v)[0] as usize))
+        .collect();
+    let best: BTreeMap<usize, usize> = out["best"]
+        .iter()
+        .filter(|(_, d)| *d > 0)
+        .map(|((k, v), _)| (ints(k)[0] as usize, ints(v)[0] as usize))
+        .collect();
+    let chosen = |node: usize| -> usize {
+        let class = classes[&node];
+        *best.get(&class).unwrap_or_else(|| panic!("class {class} has no extracted node"))
+    };
+
+    // Consumers per class in the extracted DAG (reachable from the roots), so a chain of steps
+    // with one consumer folds into one `Linear`.
+    let mut consumers: HashMap<usize, usize> = HashMap::new();
+    let mut seen: std::collections::HashSet<usize> = Default::default();
+    let mut stack: Vec<usize> = bind_roots.iter().chain(&export_roots).map(|&n| chosen(n)).collect();
+    // the roots (binds, exports) consume their classes too, so a chain ending at a root is not
+    // folded into the step that follows it.
+    for &n in bind_roots.iter().chain(&export_roots) {
+        *consumers.entry(classes[&n]).or_insert(0) += 1;
+    }
+    while let Some(n) = stack.pop() {
+        if !seen.insert(n) {
+            continue;
+        }
+        for &c in &r.nodes[n].children {
+            let cc = chosen(c);
+            *consumers.entry(classes[&cc]).or_insert(0) += 1;
+            stack.push(cc);
+        }
+    }
+
+    // Rebuild the scope from the chosen nodes, children before parents.
+    let mut out_scope = Scope {
+        name: scope.name.clone(),
+        imports: scope.imports.clone(),
+        vars: scope.vars.clone(),
+        ..Scope::default()
+    };
+    let mut emitted: HashMap<usize, Ref> = HashMap::new(); // by class
+    fn emit(
+        node: usize,
+        r: &Reified,
+        classes: &BTreeMap<usize, usize>,
+        best: &BTreeMap<usize, usize>,
+        consumers: &HashMap<usize, usize>,
+        sub_of: &HashMap<usize, usize>,
+        emitted: &mut HashMap<usize, Ref>,
+        out: &mut Scope,
+    ) -> Ref {
+        let class = classes[&node];
+        if let Some(rf) = emitted.get(&class) {
+            return rf.clone();
+        }
+        let n = best[&class];
+        let rn = &r.nodes[n];
+        let kid = |k: usize, emitted: &mut HashMap<usize, Ref>, out: &mut Scope| {
+            emit(rn.children[k], r, classes, best, consumers, sub_of, emitted, out)
+        };
+        let rf = match rn.kind {
+            KIND_IMPORT => Ref::Import(rn.payload as usize),
+            KIND_VAR => Ref::Var(rn.payload as usize),
+            KIND_CHILD_EXPORT => match kid(0, emitted, out) {
+                Ref::Local(i) => Ref::ChildExport(i, rn.payload as usize),
+                other => panic!("a child export's scope emitted as {other:?}"),
+            },
+            KIND_OP => {
+                let input = kid(0, emitted, out);
+                let op = r.ops[rn.payload as usize].clone();
+                // extend a single-consumer `Linear` in place, else start one
+                let input_class = classes[&rn.children[0]];
+                let extend = match &input {
+                    Ref::Local(i) => {
+                        consumers.get(&input_class).copied().unwrap_or(0) == 1
+                            && matches!(out.items[*i], Item::Op(Node::Linear { .. }))
+                    }
+                    _ => false,
+                };
+                if extend {
+                    let Ref::Local(i) = input else { unreachable!() };
+                    let Item::Op(Node::Linear { ops, .. }) = &mut out.items[i] else { unreachable!() };
+                    ops.push(op);
+                    // the extended item now stands for this class too
+                    emitted.insert(class, Ref::Local(i));
+                    return Ref::Local(i);
+                }
+                out.items.push(Item::Op(Node::Linear { input, ops: vec![op] }));
+                Ref::Local(out.items.len() - 1)
+            }
+            KIND_CONCAT => {
+                let kids: Vec<Ref> = (0..rn.children.len()).map(|k| kid(k, emitted, out)).collect();
+                out.items.push(Item::Op(Node::Concat(kids)));
+                Ref::Local(out.items.len() - 1)
+            }
+            KIND_ARRANGE => {
+                let input = kid(0, emitted, out);
+                out.items.push(Item::Op(Node::Arrange(input)));
+                Ref::Local(out.items.len() - 1)
+            }
+            KIND_JOIN => {
+                let left = kid(0, emitted, out);
+                let right = kid(1, emitted, out);
+                out.items.push(Item::Op(Node::Join { left, right, projection: r.projections[rn.payload as usize].clone() }));
+                Ref::Local(out.items.len() - 1)
+            }
+            KIND_REDUCE => {
+                let input = kid(0, emitted, out);
+                out.items.push(Item::Op(Node::Reduce { input, reducer: r.reducers[rn.payload as usize].clone() }));
+                Ref::Local(out.items.len() - 1)
+            }
+            KIND_INSPECT => {
+                let input = kid(0, emitted, out);
+                out.items.push(Item::Op(Node::Inspect { input, label: r.labels[rn.payload as usize].clone() }));
+                Ref::Local(out.items.len() - 1)
+            }
+            KIND_SUB => {
+                let kids: Vec<Ref> = (0..rn.children.len()).map(|k| kid(k, emitted, out)).collect();
+                let mut child = r.subs[sub_of[&n]].clone();
+                for (imp, rf) in child.imports.iter_mut().zip(kids) {
+                    imp.from = Source::Parent(rf);
+                }
+                out.items.push(Item::Sub(child));
+                Ref::Local(out.items.len() - 1)
+            }
+            other => panic!("unknown node kind {other}"),
+        };
+        emitted.insert(class, rf.clone());
+        rf
+    }
+    for (b, &root) in scope.binds.iter().zip(&bind_roots) {
+        let value = emit(root, &r, &classes, &best, &consumers, &sub_of, &mut emitted, &mut out_scope);
+        out_scope.binds.push(Bind { var: b.var, value });
+    }
+    for (e, &root) in scope.exports.iter().zip(&export_roots) {
+        let value = emit(root, &r, &classes, &best, &consumers, &sub_of, &mut emitted, &mut out_scope);
+        out_scope.exports.push(Export { name: e.name.clone(), value });
+    }
+    out_scope
+}

--- a/interactive/src/egraph/mod.rs
+++ b/interactive/src/egraph/mod.rs
@@ -12,7 +12,11 @@
 //! that reads only some of an input's fields, the same operator over a projection of that input
 //! keeping just those fields, and asserts the two equal; join commutativity mints each join with
 //! its inputs swapped.
-//! Extraction picks, per class, the node with the least tree cost, and the host regroups
+//! Extraction picks one node per class: the program computes the least *tree* cost per class
+//! (a dynamic program, which counts a shared subterm once per use), and the host refines that
+//! choice against the *DAG* cost — the weight of what the choices materialize from the roots,
+//! shared subterms once — by hill-climbing to a local optimum (optimal DAG extraction is
+//! NP-hard; this is the standard greedy, seeded by the tree optimum). The host then regroups
 //! single-consumer chains of steps back into `Linear` operators.
 //!
 //! Child scopes are opaque leaves of their parent's e-graph, optimized on their own first: a scope
@@ -70,7 +74,7 @@ fn optimizer() -> &'static Program {
     PROGRAM.get_or_init(|| {
         let src = include_str!("optimize.ddp");
         let mut tree = crate::lower::lower_tree(crate::parse::pipe::parse(src));
-        tree.optimize();
+        tree.root.optimize(); // the hand-written optimizer: the e-graph cannot optimize itself
         tree
     })
 }
@@ -466,6 +470,8 @@ fn optimize_scope(scope: &Scope, import_widths: &[Option<Width>]) -> (Scope, Vec
         out["classes"].iter().filter(|(_, d)| *d > 0).map(|((k, v), _)| (ints(k)[0] as usize, ints(v)[0] as usize)).collect();
     let best: BTreeMap<usize, usize> =
         out["best"].iter().filter(|(_, d)| *d > 0).map(|((k, v), _)| (ints(k)[0] as usize, ints(v)[0] as usize)).collect();
+    let roots: Vec<usize> = bind_roots.iter().chain(&export_roots).copied().collect();
+    let best = refine_dag(&r, &classes, &roots, best);
     let chosen = |node: usize| -> usize {
         let class = classes[&node];
         *best.get(&class).unwrap_or_else(|| panic!("class {class} has no extracted node"))
@@ -505,6 +511,86 @@ fn optimize_scope(scope: &Scope, import_widths: &[Option<Width>]) -> (Scope, Vec
     }
     let export_widths: Vec<Option<Width>> = export_roots.iter().map(|&n| r.nodes[n].width).collect();
     (out_scope, export_widths)
+}
+
+/// DAG-aware extraction: starting from a choice per class (the tree-cost optimum), hill-climb on
+/// the weight of the DAG the choices materialize from the roots — every reached class's node
+/// once, however many consumers it has. A move changes one reached class's node and is taken
+/// when the whole DAG gets strictly lighter (so a move that makes the choices cyclic, or that
+/// pays for a second copy of something a sibling already materializes, is never taken).
+/// Optimal DAG extraction is NP-hard; this is the standard greedy, seeded by the tree optimum.
+fn refine_dag(r: &Reified, classes: &BTreeMap<usize, usize>, roots: &[usize], mut pick: BTreeMap<usize, usize>) -> BTreeMap<usize, usize> {
+    let w: Vec<i64> = r.nodes.iter().map(|x| price(x.kind, x.priced(&r.nodes))).collect();
+    let mut members: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for (&node, &class) in classes {
+        members.entry(class).or_default().push(node);
+    }
+    let root_classes: Vec<usize> = roots.iter().map(|&n| classes[&n]).collect();
+
+    /// The chosen DAG's walker: from a class, sum weights and list the classes reached;
+    /// `false` on a cycle or a class without a choice.
+    struct Walk<'a> {
+        r: &'a Reified,
+        classes: &'a BTreeMap<usize, usize>,
+        w: &'a [i64],
+    }
+    impl Walk<'_> {
+        fn visit(&self, class: usize, choice: &BTreeMap<usize, usize>, state: &mut HashMap<usize, u8>, sum: &mut i64, reached: &mut Vec<usize>) -> bool {
+            match state.get(&class) {
+                Some(1) => return false,
+                Some(_) => return true,
+                None => {}
+            }
+            let Some(&p) = choice.get(&class) else { return false };
+            state.insert(class, 1);
+            *sum += self.w[p];
+            reached.push(class);
+            for &k in &self.r.nodes[p].children {
+                if !self.visit(self.classes[&k], choice, state, sum, reached) {
+                    return false;
+                }
+            }
+            state.insert(class, 2);
+            true
+        }
+    }
+    let walk = Walk { r, classes, w: &w };
+    let total = |choice: &BTreeMap<usize, usize>| -> Option<(i64, Vec<usize>)> {
+        let mut state = HashMap::new();
+        let (mut sum, mut reached) = (0, Vec::new());
+        for &rc in &root_classes {
+            if !walk.visit(rc, choice, &mut state, &mut sum, &mut reached) {
+                return None;
+            }
+        }
+        Some((sum, reached))
+    };
+
+    let (mut best, mut reached) = total(&pick).expect("the tree-cost extraction is acyclic and complete");
+    loop {
+        let mut improved = false;
+        'moves: for &class in &reached {
+            let cur = pick[&class];
+            for &node in &members[&class] {
+                if node == cur {
+                    continue;
+                }
+                pick.insert(class, node);
+                if let Some((t, rr)) = total(&pick) {
+                    if t < best {
+                        best = t;
+                        reached = rr;
+                        improved = true;
+                        break 'moves;
+                    }
+                }
+                pick.insert(class, cur);
+            }
+        }
+        if !improved {
+            return pick;
+        }
+    }
 }
 
 /// What rebuilding a scope reads: the reified nodes, the classes, the choice per class, the

--- a/interactive/src/egraph/optimize.ddp
+++ b/interactive/src/egraph/optimize.ddp
@@ -1,9 +1,9 @@
 -- The DDIR optimizer as a DDIR program: an e-graph over one scope's operators.
 --
--- input 0: nodes  (id, kind, payload, width) ;   input 1: edges  (parent, pos, child) ;
--- (width: the row width the node is priced by — its input's for an Arrange or a Reduce, which
--- hold those rows; its output's for everything else)
+-- input 0: nodes  (id, kind, payload, price) ;   input 1: edges  (parent, pos, child) ;
 -- input 2: equal  (a, b) ; -- equalities the host asserted from facts about scalar operators
+-- (price: what the host charges for the node — an op weight, times the width of the rows it
+-- holds or produces, times their relative volume)
 --
 -- kind: 0 Import  1 Var  2 ChildExport  3 Op (one linear step)  4 Concat  5 Arrange  6 Join
 --       7 Reduce  8 Inspect  9 Sub (a child scope)
@@ -12,24 +12,34 @@
 --
 -- Congruence closure (`arrange_idem.ddp`'s core): a node's signature is (kind, payload, the
 -- classes of its children by position); nodes with equal signatures are equal. `Concat`'s
--- children are unordered, so its signature lists their classes without positions, which makes
--- commutativity and idempotence of concatenation free (a `Concat` of one class twice is a
--- different node from a `Concat` of it once — a multiset — and that is right: concat is union
--- with multiplicity).
+-- children are unordered, and taken through nested `Concat`s to their leaves, so its signature
+-- lists the classes of its leaves without positions, which makes commutativity and associativity
+-- of concatenation free (a `Concat` of one class twice is a different node from a `Concat` of it
+-- once — a multiset — and that is right: concat is union with multiplicity).
 --
 -- Rules:
 --   arrange_idem   Arrange(x) ≡ x when x's class already holds an Arrange or a Reduce.
 --   input 2        whatever the host instantiated from scalar facts (demand pushdown: a reducer
 --                  that reads no values equals itself over a key-only projection of its input).
 --
--- Extraction: each class's cost is the cheapest node in it — an op weight times one plus its
--- width, plus its children's class costs (a tree cost); "best" names that node. The host rebuilds
--- the scope from "best".
+-- Extraction: each class's cost is the cheapest node in it — its price plus its children's class
+-- costs (a tree cost); "best" names that node. The host refines the choice against the DAG cost
+-- and rebuilds the scope from it.
 
-let node  = input 0 | key($0[0] ; $0[1], $0[2], $0[3]);          -- id ; (kind, payload, width)
+let node  = input 0 | key($0[0] ; $0[1], $0[2], $0[3]);          -- id ; (kind, payload, price)
 let given = input 2 | key($0[0] ; $0[1]);                         -- a ; b
 let edge  = input 1 | key($0[2] ; $0[0], $0[1]);                 -- child ; (parent, pos)
 let edge_by_parent = input 1 | key($0[0] ; $0[1], $0[2]);        -- parent ; (pos, child)
+
+-- a Concat's leaves: its children that are not Concats, and its Concat children's leaves
+let cc = edge_by_parent | join(node, ($0[0] ; $1[1], $2[0])) | filter($1[1] == 4) | map($0[0] ; $1[0]);   -- concat ; child
+let cc_kind = cc | key($1[0] ; $0[0]) | join(node, ($1[0] ; $0[0], $2[0]));                              -- concat ; (child, child kind)
+flat: {
+    let direct  = cc_kind | filter(not($1[1] == 4)) | map($0[0] ; $1[0]);                                 -- concat ; leaf
+    let through = cc_kind | filter($1[1] == 4) | key($1[0] ; $0[0]) | join(parts, ($1[0] ; $2[0]));       -- concat ; leaf, via a nested concat
+    var parts = direct + through;
+}
+let cparts = flat::parts;
 
 eqsat: {
     let elems = node | map($0[0] ; $0[0]);                       -- id ; id
@@ -38,7 +48,7 @@ eqsat: {
     let canon = edge | join(eq, ($1[0] ; $1[1], $2[0]));           -- parent ; (pos, class)
     let ckind = canon | join(node, ($0[0], $2[0], $2[1] ; $1[0], $1[1]));   -- (parent, kind, payload) ; (pos, class)
     let cpos  = ckind | filter(not($0[1] == 4)) | map($0 ; $1[0], $1[1]);   -- positional children keep their slot
-    let cset  = ckind | filter($0[1] == 4)      | map($0 ; 0, $1[1]);       -- concat children: slot 0, so they sort by class
+    let cset  = cparts | key($1[0] ; $0[0]) | join(eq, ($1[0] ; $2[0])) | map($0[0], 4, 0 ; 0, $1[0]);   -- concat leaves: slot 0, so they sort by class
     let bsig  = (cpos + cset) | collect | map($0[1], $0[2], ($1) ; $0[0]);  -- (kind, payload, [(pos, class)]) ; id
     -- leaves (Import, Var) have no children to collect; each signs with its own id, so it is its
     -- own class unless a rule says otherwise.
@@ -60,9 +70,8 @@ eqsat: {
 
 let classes = eqsat::eq;
 
--- extraction: op weights by kind (Arrange 3, Join 5, Reduce 4, Sub 8, everything else 1), times
--- one plus the node's width
-let weight = node | map($0[0] ; if($1[0] == 5, 3, if($1[0] == 6, 5, if($1[0] == 7, 4, if($1[0] == 9, 8, 1)))) * (1 + $1[2]));
+-- extraction: each node's price, from the host
+let weight = node | map($0[0] ; $1[2]);
 let nkids  = edge_by_parent | count;                             -- parent ; (n)
 let leaves = node | filter(or($1[0] == 0, $1[0] == 1)) | map($0[0] ; 0);
 extract: {

--- a/interactive/src/egraph/optimize.ddp
+++ b/interactive/src/egraph/optimize.ddp
@@ -1,6 +1,9 @@
 -- The DDIR optimizer as a DDIR program: an e-graph over one scope's operators.
 --
--- input 0: nodes  (id, kind, payload) ;   input 1: edges  (parent, pos, child) ;
+-- input 0: nodes  (id, kind, payload, width) ;   input 1: edges  (parent, pos, child) ;
+-- (width: the row width the node is priced by — its input's for an Arrange or a Reduce, which
+-- hold those rows; its output's for everything else)
+-- input 2: equal  (a, b) ; -- equalities the host asserted from facts about scalar operators
 --
 -- kind: 0 Import  1 Var  2 ChildExport  3 Op (one linear step)  4 Concat  5 Arrange  6 Join
 --       7 Reduce  8 Inspect  9 Sub (a child scope)
@@ -16,11 +19,15 @@
 --
 -- Rules:
 --   arrange_idem   Arrange(x) ≡ x when x's class already holds an Arrange or a Reduce.
+--   input 2        whatever the host instantiated from scalar facts (demand pushdown: a reducer
+--                  that reads no values equals itself over a key-only projection of its input).
 --
--- Extraction: each class's cost is the cheapest node in it (an op weight plus its children's
--- class costs, a tree cost); "best" names that node. The host rebuilds the scope from "best".
+-- Extraction: each class's cost is the cheapest node in it — an op weight times one plus its
+-- width, plus its children's class costs (a tree cost); "best" names that node. The host rebuilds
+-- the scope from "best".
 
-let node  = input 0 | key($0[0] ; $0[1], $0[2]);                 -- id ; (kind, payload)
+let node  = input 0 | key($0[0] ; $0[1], $0[2], $0[3]);          -- id ; (kind, payload, width)
+let given = input 2 | key($0[0] ; $0[1]);                         -- a ; b
 let edge  = input 1 | key($0[2] ; $0[0], $0[1]);                 -- child ; (parent, pos)
 let edge_by_parent = input 1 | key($0[0] ; $0[1], $0[2]);        -- parent ; (pos, child)
 
@@ -45,7 +52,7 @@ eqsat: {
     let arr_cls  = arr | key($1[0] ; $0[0]) | join(eq, ($2[0] ; $1[0]));                  -- child class ; arrange
     let rule     = arr_cls | join(arranged, ($1[0] ; $0[0]));                               -- arrange ; child class
 
-    let edges0 = cong + rule;
+    let edges0 = cong + rule + given;
     let edges  = edges0 + (edges0 | key($1[0] ; $0[0]));
     let prop   = eq | join(edges, ($2[0] ; $1[0]));
     var eq   = (elems + prop) | min;
@@ -53,8 +60,9 @@ eqsat: {
 
 let classes = eqsat::eq;
 
--- extraction: op weights by kind (Arrange 3, Join 5, Reduce 4, Sub 8, everything else 1)
-let weight = node | map($0[0] ; if($1[0] == 5, 3, if($1[0] == 6, 5, if($1[0] == 7, 4, if($1[0] == 9, 8, 1)))));
+-- extraction: op weights by kind (Arrange 3, Join 5, Reduce 4, Sub 8, everything else 1), times
+-- one plus the node's width
+let weight = node | map($0[0] ; if($1[0] == 5, 3, if($1[0] == 6, 5, if($1[0] == 7, 4, if($1[0] == 9, 8, 1)))) * (1 + $1[2]));
 let nkids  = edge_by_parent | count;                             -- parent ; (n)
 let leaves = node | filter(or($1[0] == 0, $1[0] == 1)) | map($0[0] ; 0);
 extract: {

--- a/interactive/src/egraph/optimize.ddp
+++ b/interactive/src/egraph/optimize.ddp
@@ -1,0 +1,80 @@
+-- The DDIR optimizer as a DDIR program: an e-graph over one scope's operators.
+--
+-- input 0: nodes  (id, kind, payload) ;   input 1: edges  (parent, pos, child) ;
+--
+-- kind: 0 Import  1 Var  2 ChildExport  3 Op (one linear step)  4 Concat  5 Arrange  6 Join
+--       7 Reduce  8 Inspect  9 Sub (a child scope)
+-- payload: an interned id for whatever the node closes over (the op, projection, reducer,
+-- label, export index, or the child scope's body); 0 when there is nothing to close over.
+--
+-- Congruence closure (`arrange_idem.ddp`'s core): a node's signature is (kind, payload, the
+-- classes of its children by position); nodes with equal signatures are equal. `Concat`'s
+-- children are unordered, so its signature lists their classes without positions, which makes
+-- commutativity and idempotence of concatenation free (a `Concat` of one class twice is a
+-- different node from a `Concat` of it once — a multiset — and that is right: concat is union
+-- with multiplicity).
+--
+-- Rules:
+--   arrange_idem   Arrange(x) ≡ x when x's class already holds an Arrange or a Reduce.
+--
+-- Extraction: each class's cost is the cheapest node in it (an op weight plus its children's
+-- class costs, a tree cost); "best" names that node. The host rebuilds the scope from "best".
+
+let node  = input 0 | key($0[0] ; $0[1], $0[2]);                 -- id ; (kind, payload)
+let edge  = input 1 | key($0[2] ; $0[0], $0[1]);                 -- child ; (parent, pos)
+let edge_by_parent = input 1 | key($0[0] ; $0[1], $0[2]);        -- parent ; (pos, child)
+
+eqsat: {
+    let elems = node | map($0[0] ; $0[0]);                       -- id ; id
+
+    -- canonicalize each child through the class map, regroup into signatures
+    let canon = edge | join(eq, ($1[0] ; $1[1], $2[0]));           -- parent ; (pos, class)
+    let ckind = canon | join(node, ($0[0], $2[0], $2[1] ; $1[0], $1[1]));   -- (parent, kind, payload) ; (pos, class)
+    let cpos  = ckind | filter(not($0[1] == 4)) | map($0 ; $1[0], $1[1]);   -- positional children keep their slot
+    let cset  = ckind | filter($0[1] == 4)      | map($0 ; 0, $1[1]);       -- concat children: slot 0, so they sort by class
+    let bsig  = (cpos + cset) | collect | map($0[1], $0[2], ($1) ; $0[0]);  -- (kind, payload, [(pos, class)]) ; id
+    -- leaves (Import, Var) have no children to collect; each signs with its own id, so it is its
+    -- own class unless a rule says otherwise.
+    let sig   = bsig + (node | filter(or($1[0] == 0, $1[0] == 1)) | map($1[0], $1[1], list(tuple(0, $0[0])) ; $0[0]));
+    let reps  = sig | min;                                      -- signature ; min id
+    let cong  = sig | join(reps, ($1[0] ; $2[0]));              -- id ; representative
+
+    -- RULE arrange_idem: an Arrange whose child's class holds an Arrange or a Reduce equals it.
+    let arr   = node | filter($1[0] == 5) | join(edge_by_parent, ($0[0] ; $2[1]));   -- arrange ; child
+    let arranged = node | filter(or($1[0] == 5, $1[0] == 7)) | join(eq, ($2[0] ;)) | distinct;   -- class ;
+    let arr_cls  = arr | key($1[0] ; $0[0]) | join(eq, ($2[0] ; $1[0]));                  -- child class ; arrange
+    let rule     = arr_cls | join(arranged, ($1[0] ; $0[0]));                               -- arrange ; child class
+
+    let edges0 = cong + rule;
+    let edges  = edges0 + (edges0 | key($1[0] ; $0[0]));
+    let prop   = eq | join(edges, ($2[0] ; $1[0]));
+    var eq   = (elems + prop) | min;
+}
+
+let classes = eqsat::eq;
+
+-- extraction: op weights by kind (Arrange 3, Join 5, Reduce 4, Sub 8, everything else 1)
+let weight = node | map($0[0] ; if($1[0] == 5, 3, if($1[0] == 6, 5, if($1[0] == 7, 4, if($1[0] == 9, 8, 1)))));
+let nkids  = edge_by_parent | count;                             -- parent ; (n)
+let leaves = node | filter(or($1[0] == 0, $1[0] == 1)) | map($0[0] ; 0);
+extract: {
+    let leafc = leaves | join(weight, ($0[0] ; $2[0])) | join(classes, ($2[0] ; $1[0]));   -- class ; w
+    let kc = edge_by_parent
+        | map($1[1] ; $0[0], $1[0])                                -- child ; (parent, pos)
+        | join(classes, ($2[0] ; $1[0], $1[1]))                    -- class ; (parent, pos)
+        | join(cost, ($1[0] ; $1[1], $2[0]))                       -- parent ; (pos, c)
+        | collect                                                  -- parent ; [(pos, c)]
+        | join(nkids, ($0[0] ; ($1), $2[0]))                       -- parent ; (list, n)
+        | filter(len($1[0]) == $1[1])
+        | join(weight, ($0[0] ; $1[0], $2[0]))                     -- parent ; (list, w)
+        | map($0[0] ; $1[1] + fold($1[0], 0, ^1 + ^0[1]));          -- id ; node cost
+    let classc = kc | join(classes, ($2[0] ; $1[0])) | min;
+    var cost = (leafc + classc) | min;
+}
+
+export "classes" = classes | arrange;
+export "best" = (extract::kc + (leaves | join(weight, ($0[0] ; $2[0]))))
+    | join(classes, ($2[0] ; $0[0], $1[0]))
+    | join(extract::cost, ($0[0] ; $1[0], $1[1], $2[0]))
+    | filter($1[1] == $1[2]) | map($0[0] ; $1[0]) | min
+    | arrange;

--- a/interactive/src/egraph/scalar.rs
+++ b/interactive/src/egraph/scalar.rs
@@ -11,7 +11,10 @@
 //!     projected away before it;
 //!   * **narrowing** — the operator that keeps only what a consumer demands, and the consumer
 //!     rewritten to read the narrowed row;
-//!   * **renaming** — an operator with two inputs, with its inputs swapped.
+//!   * **renaming** — an operator with two inputs, with its inputs swapped;
+//!   * **composition** — a predicate over an operator's output, as a predicate over its input,
+//!     so a filter can sink below the operator;
+//!   * **volume** — how a step changes the number of rows (a filter halves it, an estimate).
 //!
 //! `None` for a width means the language cannot tell statically (a `Spread` of something whose
 //! arity is not fixed); the optimizer then neither prices nor narrows that row. The intended
@@ -214,4 +217,85 @@ pub fn reducer_reads_values(r: &Reducer) -> bool {
 /// The step that keeps a row's key and drops its value: `map($0 ;)`.
 pub fn keep_key_only() -> LinearOp {
     LinearOp::Project(Projection { key: Term::Tuple(vec![Term::Spread(Box::new(Term::Var(0)))]), val: Term::Tuple(vec![]) })
+}
+
+/// The relative row volume after a linear step: a filter keeps half (an estimate, there to
+/// order the alternatives a rule proposes, with no claim to more).
+pub fn volume_after(op: &LinearOp, v: i64) -> i64 {
+    match op {
+        LinearOp::Filter(_) => (v + 1) / 2,
+        _ => v,
+    }
+}
+
+/// The term for field `i` of what a tuple term produces over rows of the given widths, through
+/// any `Spread`s; `None` when a spread reaches an unknown arity or `i` is out of range.
+pub fn field_term(t: &Term, i: usize, env: &[usize]) -> Option<Term> {
+    match t {
+        Term::Tuple(fields) => {
+            let mut idx = i;
+            for f in fields {
+                match f {
+                    Term::Spread(inner) => match &**inner {
+                        Term::Var(n) => {
+                            let w = *env.get(*n)?;
+                            if idx < w {
+                                return Some(Term::Proj(Box::new(Term::Var(*n)), idx));
+                            }
+                            idx -= w;
+                        }
+                        _ => return None,
+                    },
+                    other => {
+                        if idx == 0 {
+                            return Some(other.clone());
+                        }
+                        idx -= 1;
+                    }
+                }
+            }
+            None
+        }
+        Term::Var(n) => Some(Term::Proj(Box::new(Term::Var(*n)), i)),
+        _ => None,
+    }
+}
+
+/// A predicate over a projection's output rows as a predicate over its input rows: every
+/// `$0[i]` becomes the key's `i`th field term, every `$1[j]` the value's. `None` when the
+/// predicate uses an output row whole or a field cannot be resolved.
+pub fn compose(p: &Term, q: &Projection, env: &[usize]) -> Option<Term> {
+    let c = |x: &Term| compose(x, q, env);
+    Some(match p {
+        Term::Var(_) => return None,
+        Term::Proj(inner, i) => match &**inner {
+            Term::Var(0) => field_term(&q.key, *i, env)?,
+            Term::Var(1) => field_term(&q.val, *i, env)?,
+            Term::Var(_) => return None,
+            other => Term::Proj(Box::new(c(other)?), *i),
+        },
+        Term::Bound(_) | Term::Int(_) => p.clone(),
+        Term::Spread(inner) => Term::Spread(Box::new(c(inner)?)),
+        Term::Unary(op, inner) => Term::Unary(*op, Box::new(c(inner)?)),
+        Term::Tuple(xs) => Term::Tuple(xs.iter().map(c).collect::<Option<_>>()?),
+        Term::List(xs) => Term::List(xs.iter().map(c).collect::<Option<_>>()?),
+        Term::Hash(xs) => Term::Hash(xs.iter().map(c).collect::<Option<_>>()?),
+        Term::Inject { tag, payload, sum } => Term::Inject { tag: Box::new(c(tag)?), payload: Box::new(c(payload)?), sum: sum.clone() },
+        Term::Case { scrutinee, arms, default } => Term::Case {
+            scrutinee: Box::new(c(scrutinee)?),
+            arms: arms.iter().map(c).collect::<Option<_>>()?,
+            default: match default {
+                Some(d) => Some(Box::new(c(d)?)),
+                None => None,
+            },
+        },
+        Term::Fold { list, init, step } => Term::Fold { list: Box::new(c(list)?), init: Box::new(c(init)?), step: Box::new(c(step)?) },
+        Term::If { cond, then, els } => Term::If { cond: Box::new(c(cond)?), then: Box::new(c(then)?), els: Box::new(c(els)?) },
+        Term::Binary(op, a, b) => Term::Binary(*op, Box::new(c(a)?), Box::new(c(b)?)),
+    })
+}
+
+/// `t` with rows renamed: `$n` becomes `$rows[n]` (identity when absent).
+pub fn rename_rows(t: &Term, rows: &BTreeMap<usize, usize>) -> Term {
+    rewrite(t, usize::MAX, &BTreeMap::new(), rows)
 }

--- a/interactive/src/egraph/scalar.rs
+++ b/interactive/src/egraph/scalar.rs
@@ -1,0 +1,217 @@
+//! What the optimizer needs to know about scalar operators, and nothing more.
+//!
+//! The e-graph never looks inside a term: a projection, a predicate, a reducer is an opaque
+//! payload. What it needs from the scalar language is a handful of *facts about composition*,
+//! answered here for DDIR's `Term`/`Projection`/`Reducer` vocabulary:
+//!
+//!   * **widths** — how many fields a row has after an operator, given how many it had before,
+//!     so a cost can price a row by its width and a narrowing can be recognized;
+//!   * **demand** — which fields of a row an operator reads (`count` and `distinct` read no
+//!     values; a projection reads the fields its terms index), so what it does not read can be
+//!     projected away before it;
+//!   * **narrowing** — the operator that keeps only what a consumer demands, and the consumer
+//!     rewritten to read the narrowed row;
+//!   * **renaming** — an operator with two inputs, with its inputs swapped.
+//!
+//! `None` for a width means the language cannot tell statically (a `Spread` of something whose
+//! arity is not fixed); the optimizer then neither prices nor narrows that row. The intended
+//! growth of this interface is the rest of the list — fuse two operators, extract common
+//! subexpressions between two terms, report the equalities an operator implies — each as a
+//! question about how scalar parts compose, not about any one language's syntax.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::ir::LinearOp;
+use crate::parse::{Projection, Reducer, Term};
+
+/// A row's width: (key fields, value fields). DDIR unit is width 0.
+pub type Width = (usize, usize);
+
+/// The number of fields a projection term produces over rows of the given widths (`env[n]` is
+/// the width of `$n`'s row), or `None` when a `Spread` reaches something of unknown arity.
+pub fn term_width(t: &Term, env: &[usize]) -> Option<usize> {
+    match t {
+        Term::Tuple(fields) => {
+            let mut w = 0;
+            for f in fields {
+                w += match f {
+                    Term::Spread(inner) => match &**inner {
+                        Term::Var(n) => *env.get(*n)?,
+                        _ => return None,
+                    },
+                    _ => 1,
+                };
+            }
+            Some(w)
+        }
+        Term::Var(n) => env.get(*n).copied(),
+        _ => Some(1),
+    }
+}
+
+/// Which fields of a row a term reads: a set of field indices when every read is a `$n[i]`,
+/// `All` when the row is used whole (`$n`, `..$n`) or through anything but a direct index.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Demand {
+    All,
+    Fields(BTreeSet<usize>),
+}
+
+impl Demand {
+    fn union(self, other: Demand) -> Demand {
+        match (self, other) {
+            (Demand::Fields(mut a), Demand::Fields(b)) => {
+                a.extend(b);
+                Demand::Fields(a)
+            }
+            _ => Demand::All,
+        }
+    }
+}
+
+/// The fields of row `$var` that `t` reads.
+pub fn demand(t: &Term, var: usize) -> Demand {
+    let mut fields = BTreeSet::new();
+    let mut all = false;
+    walk(t, var, &mut fields, &mut all);
+    if all { Demand::All } else { Demand::Fields(fields) }
+}
+
+/// The fields of row `$var` a projection reads.
+pub fn projection_demand(p: &Projection, var: usize) -> Demand {
+    demand(&p.key, var).union(demand(&p.val, var))
+}
+
+fn walk(t: &Term, var: usize, fields: &mut BTreeSet<usize>, all: &mut bool) {
+    match t {
+        Term::Var(n) => {
+            if *n == var {
+                *all = true;
+            }
+        }
+        Term::Proj(inner, i) => match &**inner {
+            Term::Var(n) if *n == var => {
+                fields.insert(*i);
+            }
+            other => walk(other, var, fields, all),
+        },
+        Term::Bound(_) | Term::Int(_) => {}
+        Term::Spread(inner) | Term::Unary(_, inner) => walk(inner, var, fields, all),
+        Term::Tuple(xs) | Term::List(xs) | Term::Hash(xs) => xs.iter().for_each(|x| walk(x, var, fields, all)),
+        Term::Inject { tag, payload, .. } => {
+            walk(tag, var, fields, all);
+            walk(payload, var, fields, all);
+        }
+        Term::Case { scrutinee, arms, default } => {
+            walk(scrutinee, var, fields, all);
+            arms.iter().for_each(|x| walk(x, var, fields, all));
+            if let Some(d) = default {
+                walk(d, var, fields, all);
+            }
+        }
+        Term::Fold { list, init, step } => {
+            walk(list, var, fields, all);
+            walk(init, var, fields, all);
+            walk(step, var, fields, all);
+        }
+        Term::If { cond, then, els } => {
+            walk(cond, var, fields, all);
+            walk(then, var, fields, all);
+            walk(els, var, fields, all);
+        }
+        Term::Binary(_, a, b) => {
+            walk(a, var, fields, all);
+            walk(b, var, fields, all);
+        }
+    }
+}
+
+/// `t` with every `$var[i]` read through `map` (`$var[i]` becomes `$var[map[i]]`) and every
+/// row `$n` renamed through `rows` (`$n` becomes `$rows[n]`, identity when absent). The two
+/// halves of narrowing and of renaming an operator's inputs.
+pub fn rewrite(t: &Term, var: usize, map: &BTreeMap<usize, usize>, rows: &BTreeMap<usize, usize>) -> Term {
+    let r = |x: &Term| rewrite(x, var, map, rows);
+    let rename = |n: usize| rows.get(&n).copied().unwrap_or(n);
+    match t {
+        Term::Var(n) => Term::Var(rename(*n)),
+        Term::Proj(inner, i) => match &**inner {
+            Term::Var(n) if *n == var => Term::Proj(Box::new(Term::Var(rename(*n))), *map.get(i).unwrap_or(i)),
+            other => Term::Proj(Box::new(r(other)), *i),
+        },
+        Term::Bound(_) | Term::Int(_) => t.clone(),
+        Term::Spread(inner) => Term::Spread(Box::new(r(inner))),
+        Term::Unary(op, inner) => Term::Unary(*op, Box::new(r(inner))),
+        Term::Tuple(xs) => Term::Tuple(xs.iter().map(r).collect()),
+        Term::List(xs) => Term::List(xs.iter().map(r).collect()),
+        Term::Hash(xs) => Term::Hash(xs.iter().map(r).collect()),
+        Term::Inject { tag, payload, sum } => Term::Inject { tag: Box::new(r(tag)), payload: Box::new(r(payload)), sum: sum.clone() },
+        Term::Case { scrutinee, arms, default } => Term::Case {
+            scrutinee: Box::new(r(scrutinee)),
+            arms: arms.iter().map(r).collect(),
+            default: default.as_ref().map(|d| Box::new(r(d))),
+        },
+        Term::Fold { list, init, step } => Term::Fold { list: Box::new(r(list)), init: Box::new(r(init)), step: Box::new(r(step)) },
+        Term::If { cond, then, els } => Term::If { cond: Box::new(r(cond)), then: Box::new(r(then)), els: Box::new(r(els)) },
+        Term::Binary(op, a, b) => Term::Binary(*op, Box::new(r(a)), Box::new(r(b))),
+    }
+}
+
+/// The step that keeps a row's key and only the value fields in `fields` (in order), and the map
+/// from old to new value field indices a consumer must read through.
+pub fn keep_fields(fields: &BTreeSet<usize>) -> (LinearOp, BTreeMap<usize, usize>) {
+    let map: BTreeMap<usize, usize> = fields.iter().enumerate().map(|(new, &old)| (old, new)).collect();
+    let val = Term::Tuple(fields.iter().map(|&i| Term::Proj(Box::new(Term::Var(1)), i)).collect());
+    (LinearOp::Project(Projection { key: Term::Tuple(vec![Term::Spread(Box::new(Term::Var(0)))]), val }), map)
+}
+
+/// A join projection with its value rows narrowed: `$var` read through `map`.
+pub fn narrow_join(p: &Projection, var: usize, map: &BTreeMap<usize, usize>) -> Projection {
+    let none = BTreeMap::new();
+    Projection { key: rewrite(&p.key, var, map, &none), val: rewrite(&p.val, var, map, &none) }
+}
+
+/// A join projection for the same join with its inputs swapped: `$1` and `$2` exchanged.
+pub fn swap_join(p: &Projection) -> Projection {
+    let rows: BTreeMap<usize, usize> = [(1, 2), (2, 1)].into_iter().collect();
+    let none = BTreeMap::new();
+    Projection { key: rewrite(&p.key, usize::MAX, &none, &rows), val: rewrite(&p.val, usize::MAX, &none, &rows) }
+}
+
+/// The row width after a linear step over rows of width `w`.
+pub fn width_after(op: &LinearOp, w: Width) -> Option<Width> {
+    match op {
+        LinearOp::Project(p) => {
+            let env = [w.0, w.1];
+            Some((term_width(&p.key, &env)?, term_width(&p.val, &env)?))
+        }
+        LinearOp::Filter(_) | LinearOp::Negate | LinearOp::EnterAt(_) => Some(w),
+        LinearOp::LiftIter => Some((w.0, w.1 + 1)),
+        LinearOp::FlatMap(_) => Some((w.0, 2)),
+    }
+}
+
+/// The row width after a reducer over rows of width `w`.
+pub fn reducer_width(r: &Reducer, w: Width) -> Width {
+    match r {
+        Reducer::Count => (w.0, 1),
+        Reducer::Distinct => (w.0, 0),
+        Reducer::Min => w,
+        Reducer::Collect => (w.0, 1),
+    }
+}
+
+/// The row width after a join projection over `(key, left value, right value)` rows.
+pub fn join_width(p: &Projection, wk: usize, w0: usize, w1: usize) -> Option<Width> {
+    let env = [wk, w0, w1];
+    Some((term_width(&p.key, &env)?, term_width(&p.val, &env)?))
+}
+
+/// Does the reducer read its input's values? `count` and `distinct` see only keys.
+pub fn reducer_reads_values(r: &Reducer) -> bool {
+    !matches!(r, Reducer::Count | Reducer::Distinct)
+}
+
+/// The step that keeps a row's key and drops its value: `map($0 ;)`.
+pub fn keep_key_only() -> LinearOp {
+    LinearOp::Project(Projection { key: Term::Tuple(vec![Term::Spread(Box::new(Term::Var(0)))]), val: Term::Tuple(vec![]) })
+}

--- a/interactive/src/lib.rs
+++ b/interactive/src/lib.rs
@@ -5,6 +5,7 @@ pub mod lower;
 pub mod scope_ir;
 pub mod backend;
 pub mod explain;
+pub mod egraph;
 pub mod server;
 // `folded` (the flat `[i64]` per-coordinate time-filter algebra) is retired:
 // the Value reverse model implements `time_le`/`strip` directly over the nested

--- a/interactive/src/scope_ir.rs
+++ b/interactive/src/scope_ir.rs
@@ -144,9 +144,18 @@ pub struct Program {
 }
 
 impl Program {
-    /// Optimize every scope in place. See `Scope::optimize`.
+    /// Optimize every scope in place, through the e-graph (`crate::egraph`), with the root
+    /// inputs' row widths unknown: rows are then priced by operator alone, and the rewrites that
+    /// narrow rows do not fire. `Scope::optimize` is the hand-written optimizer the e-graph
+    /// subsumes.
     pub fn optimize(&mut self) {
-        self.root.optimize();
+        self.optimize_with_widths(&[]);
+    }
+
+    /// Optimize every scope in place through the e-graph, with each root input's row width
+    /// (key fields, value fields) where known, so the rewrites that narrow rows can pay.
+    pub fn optimize_with_widths(&mut self, source_widths: &[Option<(usize, usize)>]) {
+        *self = crate::egraph::optimize(self, source_widths);
     }
 
     /// Print the tree as indented structural text (readability, not

--- a/interactive/tests/corgi_backend.rs
+++ b/interactive/tests/corgi_backend.rs
@@ -12,6 +12,26 @@ fn rows(rs: &[&[i64]]) -> Vec<(Value, Value)> {
     rs.iter().map(|f| (tup(f), Value::unit())).collect()
 }
 
+/// A random term DAG for the e-graph programs: row `(id, op, x, y)` with op 0 = Num(x),
+/// 1 = Var(x), 2 = Add(x, y), 3 = Mul(x, y), 4 = Neg(x); children are earlier ids. Small
+/// constants (0, 1, 2) so the identity and folding rules fire.
+fn egraph_rows(n: u64, seed: u64) -> Vec<(Value, Value)> {
+    let mut s = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    let mut next = move || { s ^= s << 13; s ^= s >> 7; s ^= s << 17; s };
+    (0..n)
+        .map(|id| {
+            let (op, x, y) = if id < 2 {
+                ((next() % 2) as i64, (next() % 3) as i64, 0)
+            } else {
+                let op = match next() % 8 { 0 => 0, 1 => 1, 2 | 3 => 2, 4 | 5 => 3, _ => 4 };
+                let (x, y) = if op < 2 { ((next() % 3) as i64, 0) } else { ((next() % id) as i64, (next() % id) as i64) };
+                (op, x, y)
+            };
+            (tup(&[id as i64, op, x, y]), Value::unit())
+        })
+        .collect()
+}
+
 /// Per-program inputs (arity matches each `.ddp`'s `input N` usage).
 fn inputs_for(prog: &str) -> Vec<Vec<(Value, Value)>> {
     let edges = rows(&[&[1, 2], &[2, 3], &[3, 4], &[5, 6], &[4, 2]]);
@@ -59,6 +79,7 @@ fn inputs_for(prog: &str) -> Vec<Vec<(Value, Value)>> {
             rows(&[&[1, 2], &[2, 3], &[3, 1], &[3, 4], &[5, 2]]),
             rows(&[&[1], &[5]]),
         ],
+        "egraph_math" => vec![egraph_rows(48, 1)],
         other => panic!("no inputs configured for {other}"),
     }
 }
@@ -123,3 +144,4 @@ fn serializing(n: usize) -> timely::Config {
 #[test] fn tour() { assert_backends_agree("tour"); }
 #[test] fn pair_keys() { assert_backends_agree("pair_keys"); }
 #[test] fn signed_min() { assert_backends_agree("signed_min"); }
+#[test] fn egraph_math() { assert_backends_agree("egraph_math"); }

--- a/interactive/tests/egraph.rs
+++ b/interactive/tests/egraph.rs
@@ -1,0 +1,217 @@
+//! The e-graph program against a reference: a small Rust equality-saturation engine with the
+//! same rules (congruence, commutativity, constant folding, x+0, x*1, x*0, double negation) run
+//! to a fixpoint on the same random DAGs. The partition of the INPUT nodes must agree exactly,
+//! every class cost must agree, and no minted name may collide.
+
+use std::collections::{BTreeMap, HashMap};
+
+use interactive::backend::vec;
+use interactive::ir::Value;
+use interactive::{lower, parse};
+
+fn tup(fields: &[i64]) -> Value {
+    Value::Tuple(fields.iter().map(|&n| Value::Int(n)).collect())
+}
+
+/// The same generator as `tests/corgi_backend.rs`.
+fn egraph_rows(n: u64, seed: u64) -> Vec<(Value, Value)> {
+    let mut s = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    let mut next = move || { s ^= s << 13; s ^= s >> 7; s ^= s << 17; s };
+    (0..n)
+        .map(|id| {
+            let (op, x, y) = if id < 2 {
+                ((next() % 2) as i64, (next() % 3) as i64, 0)
+            } else {
+                let op = match next() % 8 { 0 => 0, 1 => 1, 2 | 3 => 2, 4 | 5 => 3, _ => 4 };
+                let (x, y) = if op < 2 { ((next() % 3) as i64, 0) } else { ((next() % id) as i64, (next() % id) as i64) };
+                (op, x, y)
+            };
+            (tup(&[id as i64, op, x, y]), Value::unit())
+        })
+        .collect()
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
+enum Term { Num(u64), Var(u64), Add(u64, u64), Mul(u64, u64), Neg(u64) }
+
+/// A reference e-graph: nodes by id, a union-find over ids, and rebuild + rules to a fixpoint.
+struct Ref {
+    nodes: BTreeMap<u64, Term>,
+    parent: HashMap<u64, u64>,
+    next_id: u64,
+}
+
+impl Ref {
+    fn find(&mut self, x: u64) -> u64 {
+        let p = *self.parent.get(&x).unwrap_or(&x);
+        if p == x { return x; }
+        let r = self.find(p);
+        self.parent.insert(x, r);
+        r
+    }
+    /// union by smaller id, so leaders are comparable with the program's min-leader.
+    fn union(&mut self, a: u64, b: u64) -> bool {
+        let (ra, rb) = (self.find(a), self.find(b));
+        if ra == rb { return false; }
+        let (lo, hi) = if ra < rb { (ra, rb) } else { (rb, ra) };
+        self.parent.insert(hi, lo);
+        true
+    }
+    fn canon(&mut self, t: Term) -> Term {
+        match t {
+            Term::Add(a, b) => Term::Add(self.find(a), self.find(b)),
+            Term::Mul(a, b) => Term::Mul(self.find(a), self.find(b)),
+            Term::Neg(a) => Term::Neg(self.find(a)),
+            leaf => leaf,
+        }
+    }
+    /// the node for a canonical term, minted if absent.
+    fn mint(&mut self, t: Term) -> u64 {
+        let ids: Vec<u64> = self.nodes.keys().copied().collect();
+        for id in ids {
+            if self.canon(self.nodes[&id]) == t { return id; }
+        }
+        let id = self.next_id;
+        self.next_id += 1;
+        self.nodes.insert(id, t);
+        id
+    }
+    fn const_of(&mut self, class: u64) -> Option<u64> {
+        let ids: Vec<u64> = self.nodes.keys().copied().collect();
+        let mut best = None;
+        for id in ids {
+            if let Term::Num(n) = self.nodes[&id] {
+                if self.find(id) == class { best = Some(best.map_or(n, |b: u64| b.min(n))); }
+            }
+        }
+        best
+    }
+    fn saturate(&mut self) {
+        loop {
+            let mut changed = false;
+            // congruence: equal canonical signatures merge
+            let mut by_sig: HashMap<Term, u64> = HashMap::new();
+            let ids: Vec<u64> = self.nodes.keys().copied().collect();
+            for &id in &ids {
+                let sig = self.canon(self.nodes[&id]);
+                match by_sig.get(&sig) {
+                    Some(&other) => changed |= self.union(id, other),
+                    None => { by_sig.insert(sig, id); }
+                }
+            }
+            // rules
+            for &id in &ids {
+                match self.canon(self.nodes[&id]) {
+                    Term::Add(a, b) => {
+                        let m = self.mint(Term::Add(b, a));
+                        changed |= self.union(id, m);
+                        if let (Some(x), Some(y)) = (self.const_of(a), self.const_of(b)) {
+                            let m = self.mint(Term::Num(x.wrapping_add(y)));
+                            changed |= self.union(id, m);
+                        }
+                        if self.const_of(b) == Some(0) { changed |= self.union(id, a); }
+                    }
+                    Term::Mul(a, b) => {
+                        let m = self.mint(Term::Mul(b, a));
+                        changed |= self.union(id, m);
+                        if let (Some(x), Some(y)) = (self.const_of(a), self.const_of(b)) {
+                            let m = self.mint(Term::Num(x.wrapping_mul(y)));
+                            changed |= self.union(id, m);
+                        }
+                        if self.const_of(b) == Some(1) { changed |= self.union(id, a); }
+                        if self.const_of(b) == Some(0) { changed |= self.union(id, b); }
+                    }
+                    Term::Neg(a) => {
+                        for &other in &ids {
+                            if let Term::Neg(c) = self.canon(self.nodes[&other]) {
+                                if self.find(other) == a { changed |= self.union(id, c); }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if !changed { break; }
+        }
+    }
+    /// cost per class: min over its nodes of 1 + the children's class costs, to a fixpoint.
+    fn costs(&mut self) -> HashMap<u64, u64> {
+        let mut cost: HashMap<u64, u64> = HashMap::new();
+        loop {
+            let mut changed = false;
+            let ids: Vec<u64> = self.nodes.keys().copied().collect();
+            for id in ids {
+                let c = match self.canon(self.nodes[&id]) {
+                    Term::Num(_) | Term::Var(_) => Some(1),
+                    Term::Add(a, b) | Term::Mul(a, b) => cost.get(&a).and_then(|x| cost.get(&b).map(|y| 1 + x + y)),
+                    Term::Neg(a) => cost.get(&a).map(|x| 1 + x),
+                };
+                if let Some(c) = c {
+                    let class = self.find(id);
+                    let cur = cost.get(&class).copied();
+                    if cur.map_or(true, |k| c < k) {
+                        cost.insert(class, c);
+                        changed = true;
+                    }
+                }
+            }
+            if !changed { break; }
+        }
+        cost
+    }
+}
+
+fn ints(v: &Value) -> Vec<i64> {
+    match v {
+        Value::Tuple(xs) => xs.iter().map(|x| x.as_int()).collect(),
+        Value::Int(n) => vec![*n],
+        other => panic!("expected ints, got {other:?}"),
+    }
+}
+
+#[test]
+fn egraph_math_matches_reference() {
+    let path = format!("{}/tests/programs/egraph_math.ddp", env!("CARGO_MANIFEST_DIR"));
+    let mut tree = lower::lower_tree(parse::pipe::parse(&interactive::load_program(&path)));
+    tree.optimize();
+    for seed in 1..=6u64 {
+        let n = 40;
+        let rows = egraph_rows(n, seed);
+        let out = vec::evaluate(&tree, &[rows.clone()]);
+
+        // the reference over the same DAG
+        let mut r = Ref { nodes: BTreeMap::new(), parent: HashMap::new(), next_id: 1 << 40 };
+        for (k, _) in &rows {
+            let f = ints(k);
+            let (id, op, x, y) = (f[0] as u64, f[1], f[2] as u64, f[3] as u64);
+            let t = match op { 0 => Term::Num(x), 1 => Term::Var(x), 2 => Term::Add(x, y), 3 => Term::Mul(x, y), _ => Term::Neg(x) };
+            r.nodes.insert(id, t);
+        }
+        r.saturate();
+        let ref_cost = r.costs();
+
+        // partition of the input nodes: same leader in the program iff same class in the reference
+        let classes: HashMap<u64, u64> = out["classes"]
+            .iter()
+            .filter(|(_, d)| *d > 0)
+            .map(|((k, v), _)| (ints(k)[0] as u64, ints(v)[0] as u64))
+            .collect();
+        for i in 0..n {
+            assert!(classes.contains_key(&i), "seed {seed}: input node {i} has no class");
+            for j in 0..n {
+                let same_prog = classes[&i] == classes[&j];
+                let same_ref = r.find(i) == r.find(j);
+                assert_eq!(same_prog, same_ref, "seed {seed}: nodes {i} and {j} — program says same={same_prog}, reference says same={same_ref}");
+            }
+        }
+        // costs of the input nodes' classes agree
+        let costs: HashMap<u64, u64> = out["cost"].iter().filter(|(_, d)| *d > 0).map(|((k, v), _)| (ints(k)[0] as u64, ints(v)[0] as u64)).collect();
+        for i in 0..n {
+            let leader = classes[&i];
+            let want = ref_cost[&r.find(i)];
+            assert_eq!(costs.get(&leader).copied(), Some(want), "seed {seed}: cost of node {i}'s class");
+        }
+        // no minted name collided
+        assert!(out["collisions"].iter().all(|(_, d)| *d <= 0), "seed {seed}: a minted name collided");
+    }
+}

--- a/interactive/tests/egraph_opt.rs
+++ b/interactive/tests/egraph_opt.rs
@@ -1,0 +1,80 @@
+//! The e-graph optimizer against the hand-written one: on every corpus program, and on its
+//! explanation rewrite (a large, mechanically generated, redundant IR), the e-graph-optimized
+//! program must evaluate to the same outputs as the original, and reach an operator count no
+//! worse than `Scope::optimize`'s.
+
+use interactive::backend::vec;
+use interactive::ir::Value;
+use interactive::{egraph, explain, lower, parse, scope_ir};
+
+fn tup(fields: &[i64]) -> Value {
+    Value::Tuple(fields.iter().map(|&n| Value::Int(n)).collect())
+}
+fn rows(rs: &[&[i64]]) -> Vec<(Value, Value)> {
+    rs.iter().map(|f| (tup(f), Value::unit())).collect()
+}
+
+/// Per-program inputs (as in `tests/corgi_backend.rs`).
+fn inputs_for(prog: &str) -> Vec<Vec<(Value, Value)>> {
+    let edges = rows(&[&[1, 2], &[2, 3], &[3, 4], &[5, 6], &[4, 2]]);
+    match prog {
+        "reach" => vec![edges, rows(&[&[1]])],
+        "scc" => vec![edges],
+        "stable" => vec![rows(&[&[1, 1, 10, 1], &[1, 2, 11, 1], &[2, 1, 10, 2], &[2, 2, 11, 2]])],
+        "unnest" => vec![rows(&[&[1, 2], &[3, 4]])],
+        "adt" => vec![edges.clone()],
+        "ast" => vec![edges],
+        "binders" => vec![rows(&[&[1, 2], &[3, 4]])],
+        "tour" => vec![rows(&[&[1, 2], &[2, 3], &[3, 1], &[3, 4], &[5, 2]]), rows(&[&[1], &[5]])],
+        other => panic!("no inputs configured for {other}"),
+    }
+}
+
+fn load(prog: &str) -> scope_ir::Program {
+    let path = format!("{}/examples/programs/{prog}.ddp", env!("CARGO_MANIFEST_DIR"));
+    lower::lower_tree(parse::pipe::parse(&interactive::load_program(&path)))
+}
+
+/// Optimize `tree` both ways; check the e-graph result evaluates like the original and is no
+/// bigger than the hand-written optimizer's. Returns (original, rust, egraph) op counts.
+fn check(name: &str, tree: &scope_ir::Program, inputs: &[Vec<(Value, Value)>]) -> (usize, usize, usize) {
+    let want = vec::evaluate(tree, inputs);
+    let mut rust = tree.clone();
+    rust.optimize();
+    let eg = egraph::optimize(tree);
+    assert_eq!(vec::evaluate(&eg, inputs), want, "{name}: the e-graph-optimized program changed the outputs");
+    let counts = (tree.op_count(), rust.op_count(), eg.op_count());
+    assert!(counts.2 <= counts.1, "{name}: e-graph left {} ops, the hand-written optimizer {}", counts.2, counts.1);
+    counts
+}
+
+#[test]
+fn corpus_programs() {
+    for prog in ["reach", "scc", "stable", "unnest", "adt", "ast", "binders", "tour"] {
+        let tree = load(prog);
+        let (o, r, e) = check(prog, &tree, &inputs_for(prog));
+        println!("{prog:>8}: {o} ops -> rust {r}, egraph {e}");
+    }
+}
+
+#[test]
+fn explain_corpus() {
+    // the explanation rewrite is the redundant corpus: reach and scc grow ten-fold.
+    for prog in ["reach", "scc"] {
+        let tree = load(prog);
+        let inputs0 = inputs_for(prog);
+        // each input's (key arity, value arity), read off its rows
+        let shapes: Vec<(usize, usize)> = inputs0
+            .iter()
+            .map(|rows| match &rows[0].0 { Value::Tuple(xs) => (xs.len(), 0usize), _ => (1, 0) })
+            .collect();
+        let rewritten = explain::explain(&tree, &shapes);
+        // the explained program has an extra (query) input; feed it nothing.
+        let mut inputs = inputs0;
+        while inputs.len() < rewritten.root.imports.len() {
+            inputs.push(Vec::new());
+        }
+        let (o, r, e) = check(&format!("explain({prog})"), &rewritten, &inputs);
+        println!("explain({prog}): {o} ops -> rust {r}, egraph {e}");
+    }
+}

--- a/interactive/tests/egraph_opt.rs
+++ b/interactive/tests/egraph_opt.rs
@@ -237,6 +237,38 @@ fn filter_sinks_through_concat() {
     assert!(parts_filter, "the concatenation's parts do not each filter");
 }
 
+/// The cost model is extraction's alone: any acyclic choice per class is the same program.
+/// Random choices exercise the alternatives the cost never picks — swapped joins, pushed
+/// filters, narrowed inputs — on every corpus program and both explanation rewrites.
+#[test]
+fn random_extraction_is_equivalent() {
+    let mut programs: Vec<(String, scope_ir::Program, Vec<Vec<(Value, Value)>>)> = Vec::new();
+    for prog in ["reach", "scc", "stable", "unnest", "adt", "ast", "binders", "tour"] {
+        programs.push((prog.to_string(), load(prog), inputs_for(prog)));
+    }
+    for prog in ["reach", "scc"] {
+        let tree = load(prog);
+        let inputs0 = inputs_for(prog);
+        let shapes: Vec<(usize, usize)> = inputs0.iter().map(|rows| (arity(&rows[0].0), 0)).collect();
+        let rewritten = explain::explain(&tree, &shapes);
+        let mut inputs = inputs0;
+        while inputs.len() < rewritten.root.imports.len() {
+            inputs.push(Vec::new());
+        }
+        programs.push((format!("explain({prog})"), rewritten, inputs));
+    }
+    for (name, tree, inputs) in &programs {
+        let want = vec::evaluate(tree, inputs);
+        let mut counts = Vec::new();
+        for seed in 1..=4 {
+            let eg = egraph::optimize_with(tree, &widths_of(inputs), egraph::Extraction::Random(seed));
+            assert_eq!(vec::evaluate(&eg, inputs), want, "{name}, seed {seed}: a random extraction changed the outputs");
+            counts.push(eg.op_count());
+        }
+        println!("{name:>14}: cheapest {} ops; random {counts:?}", egraph::optimize(tree, &widths_of(inputs)).op_count());
+    }
+}
+
 #[test]
 fn corpus_programs() {
     for prog in ["reach", "scc", "stable", "unnest", "adt", "ast", "binders", "tour"] {

--- a/interactive/tests/egraph_opt.rs
+++ b/interactive/tests/egraph_opt.rs
@@ -150,6 +150,93 @@ fn dag_extraction_keeps_a_shared_arrangement() {
     assert_eq!(arranges, 5);
 }
 
+/// Nested concatenations, however associated, are one concatenation.
+#[test]
+fn concat_flattening_merges_spellings() {
+    let src = "let a = input 0 | key($0[0] ; $0[1]);\n\
+               let b = input 1 | key($0[0] ; $0[1]);\n\
+               let c = input 0 | key($0[1] ; $0[0]);\n\
+               let s1 = (a + b) + c;\n\
+               let s2 = a + (b + c);\n\
+               export \"s1\" = s1 | arrange;\n\
+               export \"s2\" = s2 | arrange;\n";
+    let tree = lower::lower_tree(parse::pipe::parse(src));
+    let inputs = vec![rows(&[&[1, 2], &[2, 5]]), rows(&[&[1, 9], &[2, 8]])];
+    let eg = egraph::optimize(&tree, &widths_of(&inputs));
+    assert_eq!(vec::evaluate(&eg, &inputs), vec::evaluate(&tree, &inputs));
+    let concats: Vec<usize> = eg.root.items.iter().filter_map(|it| match it {
+        scope_ir::Item::Op(scope_ir::Node::Concat(xs)) => Some(xs.len()),
+        _ => None,
+    }).collect();
+    if concats != vec![3] {
+        eg.dump();
+    }
+    assert_eq!(concats, vec![3], "one concatenation of three parts");
+}
+
+/// A filter after a join that reads one input's fields sinks to that input, below its arrange
+/// and through the projection that built it.
+#[test]
+fn filter_sinks_below_join() {
+    let src = "let wide = input 0 | key($0[0] ; $0[1], $0[0] * $0[1], $0[1] + 7);\n\
+               let left = input 1 | key($0[0] ; $0[1]);\n\
+               let j = left | join(wide, ($0[0] ; $1[0], $2[2])) | filter($1[0] > 8);\n\
+               export \"j\" = j | arrange;\n";
+    let tree = lower::lower_tree(parse::pipe::parse(src));
+    let inputs = vec![rows(&[&[1, 2], &[1, 3], &[2, 5]]), rows(&[&[1, 9], &[2, 8]])];
+    let eg = egraph::optimize(&tree, &widths_of(&inputs));
+    assert_eq!(vec::evaluate(&eg, &inputs), vec::evaluate(&tree, &inputs));
+    // no filter reads the join; the join's left side is a chain from input 1 that filters
+    let mut filtered_join = false;
+    let mut left_filters = false;
+    for it in &eg.root.items {
+        if let scope_ir::Item::Op(scope_ir::Node::Join { left, .. }) = it {
+            let scope_ir::Ref::Local(i) = left else { panic!("join reads {left:?}") };
+            let i = match &eg.root.items[*i] {
+                scope_ir::Item::Op(scope_ir::Node::Arrange(scope_ir::Ref::Local(j))) => *j,
+                _ => *i,
+            };
+            if let scope_ir::Item::Op(scope_ir::Node::Linear { input, ops }) = &eg.root.items[i] {
+                left_filters = matches!(input, scope_ir::Ref::Import(1)) && ops.iter().any(|op| matches!(op, interactive::ir::LinearOp::Filter(_)));
+            }
+        }
+        if let scope_ir::Item::Op(scope_ir::Node::Linear { input: scope_ir::Ref::Local(i), ops }) = it {
+            if matches!(eg.root.items[*i], scope_ir::Item::Op(scope_ir::Node::Join { .. })) && ops.iter().any(|op| matches!(op, interactive::ir::LinearOp::Filter(_))) {
+                filtered_join = true;
+            }
+        }
+    }
+    if filtered_join || !left_filters {
+        eg.dump();
+    }
+    assert!(!filtered_join, "a filter still reads the join");
+    assert!(left_filters, "the join's left side does not filter");
+}
+
+/// A filter after a concatenation sinks into each part.
+#[test]
+fn filter_sinks_through_concat() {
+    let src = "let a = input 0 | key($0[0] ; $0[1]);\n\
+               let b = input 1 | key($0[0] ; $0[1]);\n\
+               let s = (a + b) | filter($1[0] > 4);\n\
+               export \"s\" = s | arrange;\n";
+    let tree = lower::lower_tree(parse::pipe::parse(src));
+    let inputs = vec![rows(&[&[1, 2], &[2, 5]]), rows(&[&[1, 9], &[2, 8]])];
+    let eg = egraph::optimize(&tree, &widths_of(&inputs));
+    assert_eq!(vec::evaluate(&eg, &inputs), vec::evaluate(&tree, &inputs));
+    let parts_filter = eg.root.items.iter().find_map(|it| match it {
+        scope_ir::Item::Op(scope_ir::Node::Concat(xs)) => Some(xs.iter().all(|x| match x {
+            scope_ir::Ref::Local(i) => matches!(&eg.root.items[*i], scope_ir::Item::Op(scope_ir::Node::Linear { ops, .. }) if ops.iter().any(|op| matches!(op, interactive::ir::LinearOp::Filter(_)))),
+            _ => false,
+        })),
+        _ => None,
+    }).expect("a concatenation");
+    if !parts_filter {
+        eg.dump();
+    }
+    assert!(parts_filter, "the concatenation's parts do not each filter");
+}
+
 #[test]
 fn corpus_programs() {
     for prog in ["reach", "scc", "stable", "unnest", "adt", "ast", "binders", "tour"] {

--- a/interactive/tests/egraph_opt.rs
+++ b/interactive/tests/egraph_opt.rs
@@ -1,7 +1,7 @@
 //! The e-graph optimizer against the hand-written one: on every corpus program, and on its
 //! explanation rewrite (a large, mechanically generated, redundant IR), the e-graph-optimized
-//! program must evaluate to the same outputs as the original, and reach an operator count no
-//! worse than `Scope::optimize`'s.
+//! program must evaluate to the same outputs as the original, and cost no more than
+//! `Scope::optimize`'s result under the e-graph's own model.
 
 use interactive::backend::vec;
 use interactive::ir::Value;
@@ -53,7 +53,7 @@ fn check(name: &str, tree: &scope_ir::Program, inputs: &[Vec<(Value, Value)>]) -
     let widths = widths_of(inputs);
     let want = vec::evaluate(tree, inputs);
     let mut rust = tree.clone();
-    rust.optimize();
+    rust.root.optimize();
     let eg = egraph::optimize(tree, &widths);
     assert_eq!(vec::evaluate(&eg, inputs), want, "{name}: the e-graph-optimized program changed the outputs");
     let costs = (egraph::cost(tree, &widths), egraph::cost(&rust, &widths), egraph::cost(&eg, &widths));
@@ -127,6 +127,29 @@ fn join_commutativity_merges() {
     assert_eq!(joins, 1, "{:#?}", eg.root);
 }
 
+/// Tree extraction would narrow a join input that another join needs whole, paying for a second
+/// arrangement of it; DAG-aware extraction sees the shared arrangement is already paid for.
+#[test]
+fn dag_extraction_keeps_a_shared_arrangement() {
+    let src = "let wide = input 0 | key($0[0] ; $0[1], $0[0] * $0[1], $0[1] + 7);\n\
+               let left = input 1 | key($0[0] ; $0[1]);\n\
+               let other = input 1 | key($0[1] ; $0[0]);\n\
+               let j1 = left | join(wide, ($0[0] ; $2[2], $1[0]));\n\
+               let j2 = other | join(wide, ($0[0] ; $2[0], $2[1], $2[2], $1[0]));\n\
+               export \"j1\" = j1 | arrange;\n\
+               export \"j2\" = j2 | arrange;\n";
+    let tree = lower::lower_tree(parse::pipe::parse(src));
+    let inputs = vec![rows(&[&[1, 2], &[1, 3], &[2, 5]]), rows(&[&[1, 9], &[2, 8]])];
+    let eg = egraph::optimize(&tree, &widths_of(&inputs));
+    assert_eq!(vec::evaluate(&eg, &inputs), vec::evaluate(&tree, &inputs));
+    let arranges = eg.root.items.iter().filter(|it| matches!(it, scope_ir::Item::Op(scope_ir::Node::Arrange(_)))).count();
+    // wide, left, other, and the two exports: no second arrangement of wide
+    if arranges != 5 {
+        eg.dump();
+    }
+    assert_eq!(arranges, 5);
+}
+
 #[test]
 fn corpus_programs() {
     for prog in ["reach", "scc", "stable", "unnest", "adt", "ast", "binders", "tour"] {
@@ -153,6 +176,13 @@ fn explain_corpus() {
         while inputs.len() < rewritten.root.imports.len() {
             inputs.push(Vec::new());
         }
+        let t = std::time::Instant::now();
+        let _ = egraph::optimize(&rewritten, &widths_of(&inputs));
+        let t_eg = t.elapsed();
+        let t_hand = std::time::Instant::now();
+        let mut hand = rewritten.clone();
+        hand.root.optimize();
+        println!("explain({prog}): e-graph optimize {t_eg:?}, hand-written {:?}", t_hand.elapsed());
         let (o, r, e) = check(&format!("explain({prog})"), &rewritten, &inputs);
         println!("explain({prog}): {o} ops -> rust {r}, egraph {e}");
     }

--- a/interactive/tests/egraph_opt.rs
+++ b/interactive/tests/egraph_opt.rs
@@ -35,17 +35,96 @@ fn load(prog: &str) -> scope_ir::Program {
     lower::lower_tree(parse::pipe::parse(&interactive::load_program(&path)))
 }
 
-/// Optimize `tree` both ways; check the e-graph result evaluates like the original and is no
-/// bigger than the hand-written optimizer's. Returns (original, rust, egraph) op counts.
+/// The inputs' row widths, read off their first rows (an empty input has no known width).
+fn widths_of(inputs: &[Vec<(Value, Value)>]) -> Vec<Option<(usize, usize)>> {
+    inputs
+        .iter()
+        .map(|rows| rows.first().map(|(k, v)| (arity(k), arity(v))))
+        .collect()
+}
+fn arity(v: &Value) -> usize {
+    match v { Value::Tuple(xs) => xs.len(), _ => 1 }
+}
+
+/// Optimize `tree` both ways; check the e-graph result evaluates like the original and costs no
+/// more than the hand-written optimizer's under the e-graph's own model. Returns
+/// (original, rust, egraph) op counts, printing costs alongside.
 fn check(name: &str, tree: &scope_ir::Program, inputs: &[Vec<(Value, Value)>]) -> (usize, usize, usize) {
+    let widths = widths_of(inputs);
     let want = vec::evaluate(tree, inputs);
     let mut rust = tree.clone();
     rust.optimize();
-    let eg = egraph::optimize(tree);
+    let eg = egraph::optimize(tree, &widths);
     assert_eq!(vec::evaluate(&eg, inputs), want, "{name}: the e-graph-optimized program changed the outputs");
-    let counts = (tree.op_count(), rust.op_count(), eg.op_count());
-    assert!(counts.2 <= counts.1, "{name}: e-graph left {} ops, the hand-written optimizer {}", counts.2, counts.1);
-    counts
+    let costs = (egraph::cost(tree, &widths), egraph::cost(&rust, &widths), egraph::cost(&eg, &widths));
+    assert!(costs.2 <= costs.1, "{name}: e-graph cost {} exceeds the hand-written optimizer's {}", costs.2, costs.1);
+    println!("{name:>14}: cost {} -> rust {}, egraph {}", costs.0, costs.1, costs.2);
+    (tree.op_count(), rust.op_count(), eg.op_count())
+}
+
+/// A reducer that reads no values gets a key-only projection pushed in front of it.
+#[test]
+fn demand_pushdown_narrows_before_count() {
+    let src = "let rows = input 0 | key($0[0] ; $0[1], $0[0] * $0[1], $0[1] + 7);\n\
+               let n = rows | count;\n\
+               export \"n\" = n | arrange;\n";
+    let tree = lower::lower_tree(parse::pipe::parse(src));
+    let inputs = vec![rows(&[&[1, 2], &[1, 3], &[2, 5]])];
+    let eg = egraph::optimize(&tree, &widths_of(&inputs));
+    assert_eq!(vec::evaluate(&eg, &inputs), vec::evaluate(&tree, &inputs));
+    // the count's input is a Linear whose last step keeps only the key
+    let reduce_input = eg.root.items.iter().find_map(|it| match it {
+        scope_ir::Item::Op(scope_ir::Node::Reduce { input, .. }) => Some(input.clone()),
+        _ => None,
+    }).expect("a count");
+    let scope_ir::Ref::Local(i) = reduce_input else { panic!("count reads {reduce_input:?}") };
+    let scope_ir::Item::Op(scope_ir::Node::Linear { ops, .. }) = &eg.root.items[i] else { panic!("count's input is not linear: {:#?}", eg.root) };
+    let last = ops.last().expect("a step");
+    assert!(matches!(last, interactive::ir::LinearOp::Project(p) if matches!(&p.val, parse::Term::Tuple(fs) if fs.is_empty())), "last step {last:?} keeps values");
+}
+
+/// A join that reads only some fields of an input's values gets that input narrowed to them.
+#[test]
+fn demand_pushdown_narrows_join_input() {
+    let src = "let wide = input 0 | key($0[0] ; $0[1], $0[0] * $0[1], $0[1] + 7);\n\
+               let left = input 1 | key($0[0] ; $0[1]);\n\
+               let j = left | join(wide, ($0[0] ; $2[2], $1[0]));\n\
+               export \"j\" = j | arrange;\n";
+    let tree = lower::lower_tree(parse::pipe::parse(src));
+    let inputs = vec![rows(&[&[1, 2], &[1, 3], &[2, 5]]), rows(&[&[1, 9], &[2, 8]])];
+    let eg = egraph::optimize(&tree, &widths_of(&inputs));
+    assert_eq!(vec::evaluate(&eg, &inputs), vec::evaluate(&tree, &inputs));
+    let (right, projection) = eg.root.items.iter().find_map(|it| match it {
+        scope_ir::Item::Op(scope_ir::Node::Join { right, projection, .. }) => Some((right.clone(), projection.clone())),
+        _ => None,
+    }).expect("a join");
+    let scope_ir::Ref::Local(i) = right else { panic!("join reads {right:?}") };
+    // through the arrange the join's input is held in
+    let i = match &eg.root.items[i] {
+        scope_ir::Item::Op(scope_ir::Node::Arrange(scope_ir::Ref::Local(j))) => *j,
+        _ => i,
+    };
+    let scope_ir::Item::Op(scope_ir::Node::Linear { ops, .. }) = &eg.root.items[i] else { panic!("join's right input is not linear: {:#?}", eg.root) };
+    let last = ops.last().expect("a step");
+    assert!(matches!(last, interactive::ir::LinearOp::Project(p) if matches!(&p.val, parse::Term::Tuple(fs) if fs.len() == 1)), "last step {last:?} does not keep one field");
+    // and the join now reads that one field at position 0
+    assert_eq!(egraph::scalar::projection_demand(&projection, 2), egraph::scalar::Demand::Fields([0].into_iter().collect()));
+}
+
+/// The same join written both ways around is one join.
+#[test]
+fn join_commutativity_merges() {
+    let src = "let a = input 0 | key($0[0] ; $0[1]);\n\
+               let b = input 1 | key($0[0] ; $0[1]);\n\
+               let j1 = a | join(b, ($0[0] ; $1[0], $2[0]));\n\
+               let j2 = b | join(a, ($0[0] ; $2[0], $1[0]));\n\
+               export \"j\" = (j1 + j2) | arrange;\n";
+    let tree = lower::lower_tree(parse::pipe::parse(src));
+    let inputs = vec![rows(&[&[1, 2], &[2, 5]]), rows(&[&[1, 9], &[2, 8]])];
+    let eg = egraph::optimize(&tree, &widths_of(&inputs));
+    assert_eq!(vec::evaluate(&eg, &inputs), vec::evaluate(&tree, &inputs));
+    let joins = eg.root.items.iter().filter(|it| matches!(it, scope_ir::Item::Op(scope_ir::Node::Join { .. }))).count();
+    assert_eq!(joins, 1, "{:#?}", eg.root);
 }
 
 #[test]

--- a/interactive/tests/identifiers.rs
+++ b/interactive/tests/identifiers.rs
@@ -1,0 +1,64 @@
+//! DD's `identifiers` algorithm as a DDIR program: every record proposes `hash(round, record)`
+//! as its id; among records proposing one id the least `(round, record)` wins and the losers
+//! propose again at the next round. Written with `hash`, `min`, `negate`, and a `var`, over a
+//! hash space small enough to force collisions, it still gives every record its own id — the
+//! primitive an e-graph rule needs to mint a node for a new term inside the program.
+
+use interactive::backend::vec;
+use interactive::ir::Value;
+use interactive::{lower, parse};
+
+const PROGRAM_SRC: &str = "\
+-- input 0: records (r) ;
+let init = input 0 | key(0, $0[0] ; );                                   -- (round, record) ;
+ids: {
+    let all   = init + diff;                                              -- (round, record) ;
+    let keyed = all | key(hash(HASHBOUND, $0[0], $0[1]) ; $0[0], $0[1]);         -- id ; (round, record)
+    let win   = keyed | min;                                              -- id ; the least (round, record)
+    let lose  = keyed + (win | negate);                                   -- id ; the rest
+    -- a winner past round 0 has moved from its round-0 proposal; a loser moves on to the next round
+    let moved = (win | filter($1[0] > 0) | map($1[0], $1[1] ; )) + (lose | map($1[0] + 1, $1[1] ; ));
+    let orig  = moved | map(0, $0[1] ; ) | negate;                        -- less their round-0 proposals
+    var diff  = moved + orig;
+}
+export \"ids\" = (init + ids::diff) | key($0[1] ; hash(HASHBOUND, $0[0], $0[1])) | arrange;   -- record ; id
+export \"rounds\" = (init + ids::diff) | key($0[0] ; ) | count | arrange;               -- round ; how many settled there
+";
+
+fn int(v: &Value) -> i64 {
+    match v {
+        Value::Tuple(xs) => xs[0].as_int(),
+        other => other.as_int(),
+    }
+}
+
+fn run(bound: i64, n: i64) -> std::collections::BTreeMap<String, Vec<((Value, Value), i64)>> {
+    let src = PROGRAM_SRC.replace("HASHBOUND", &bound.to_string());
+    let tree = lower::lower_tree(parse::pipe::parse(&src));
+    let records: Vec<(Value, Value)> = (1..=n).map(|n| (Value::Tuple(vec![Value::Int(n)]), Value::unit())).collect();
+    vec::evaluate(&tree, &[records])
+}
+
+#[test]
+fn identifiers_without_collisions() {
+    let out = run(1 << 40, 8);
+    let ids: Vec<(i64, i64)> = out["ids"].iter().filter(|(_, d)| *d > 0).map(|((k, v), _)| (int(k), int(v))).collect();
+    println!("ids: {ids:?}");
+    assert_eq!(ids.len(), 8);
+}
+
+#[test]
+fn identifiers_are_unique_despite_collisions() {
+    let out = run(64, 32);
+    let ids: Vec<(i64, i64)> = out["ids"]
+        .iter()
+        .filter(|(_, d)| *d > 0)
+        .map(|((k, v), _)| (int(k), int(v)))
+        .collect();
+    assert_eq!(ids.len(), 32, "every record has an id: {ids:?}");
+    let distinct: std::collections::BTreeSet<i64> = ids.iter().map(|(_, id)| *id).collect();
+    assert_eq!(distinct.len(), 32, "ids are unique: {ids:?}");
+    let rounds: Vec<(i64, i64)> = out["rounds"].iter().filter(|(_, d)| *d > 0).map(|((k, v), _)| (int(k), int(v))).collect();
+    println!("records per round: {rounds:?}");
+    assert!(rounds.iter().any(|(round, _)| *round > 0), "the hash space was wide enough that nothing collided; narrow it");
+}

--- a/interactive/tests/programs/egraph_math.ddp
+++ b/interactive/tests/programs/egraph_math.ddp
@@ -1,0 +1,129 @@
+-- An arithmetic e-graph: equality saturation over a term DAG, as one differential dataflow.
+--
+-- Terms are a declared sum; children name e-classes by id. The saturation core is the one
+-- `arrange_idem.ddp` established (congruence closure by canonical signature, min-leader
+-- propagation to a fixpoint), and it is where node-CREATING rewrites now live: a rule that
+-- builds a term mints it with `hash(0, ..)` of its canonical form, and congruence folds the
+-- new node into its class. Identity is EXACT: signatures and terms are keys, compared
+-- structurally; the hash is only the minted node's name, and `collisions` (two signatures
+-- sharing a name) is exported so an accidental collision is seen rather than merged.
+--
+-- input 0: (id, op, x, y) ;   op 0 = Num(x), 1 = Var(x), 2 = Add(x, y), 3 = Mul(x, y), 4 = Neg(x);
+--          children (x, y for ops 2-4) are ids of earlier rows, so the input is a DAG.
+--
+-- Rules: commutativity (Add, Mul), constant folding (Add, Mul over two Nums), x + 0 ≡ x,
+-- x * 1 ≡ x, x * 0 ≡ 0, ¬¬x ≡ x. All terminate: minting is bounded by the classes' leaders.
+--
+-- Exports: "classes" (id ; leader), "cost" (class ; cheapest term size), "best" (class ; the
+-- node achieving it), "collisions" (must be empty).
+
+type Term = Num u64 | Var u64 | Add (u64, u64) | Mul (u64, u64) | Neg u64;
+
+let raw = input 0 | key($0[0] ; $0[1], $0[2], $0[3]);          -- id ; (op, x, y)
+let node0 = raw | map($0[0] ;
+    if($1[0] == 0, Num($1[1]),
+    if($1[0] == 1, Var($1[1]),
+    if($1[0] == 2, Add($1[1], $1[2]),
+    if($1[0] == 3, Mul($1[1], $1[2]),
+                   Neg($1[1]))))));                           -- id ; term
+
+eqsat: {
+    let elems = node | map($0[0] ; $0[0]);                     -- id ; id   (seed each to itself)
+
+    -- every node's op code and children, and each leaf's signature (no canonicalization needed)
+    let kids = node
+        | filter(not(istag(0, $1[0])) && not(istag(1, $1[0])))
+        | map($0[0] ; case $1[0] { Add(a, b) => 2, Mul(a, b) => 3, Neg(a) => 4, _ => 9 },
+                      case $1[0] { Add(a, b) => list(a, b), Mul(a, b) => list(a, b), Neg(a) => list(a), _ => list(0) });
+    let leafsig = node
+        | filter(or(istag(0, $1[0]), istag(1, $1[0])))
+        | map(case $1[0] { Num(n) => 0, _ => 1 },
+              case $1[0] { Num(n) => list(tuple(0, n)), Var(v) => list(tuple(0, v)), _ => list(tuple(0, 0)) } ; $0[0]);
+
+    -- congruence closure: canonicalize each child through the class map, regroup into a signature
+    let pc    = kids | map($0[0], $1[0] ; $1[1]) | flatmap($1[0]) | map($1[1] ; $0[0], $0[1], $1[0]);  -- child ; (id, op, pos)
+    let canon = pc | join(eq, ($1[0], $1[1] ; $1[2], $2[0]));  -- (id, op) ; (pos, class)
+    let bsig  = (canon | collect | map($0[1], ($1) ; $0[0])) + leafsig; -- signature ; id
+    let reps  = bsig | min;                                    -- signature ; min id
+    let cong  = bsig | join(reps, ($1[0] ; $2[0]));            -- id ; representative
+
+    -- binary nodes with their children's leaders: id ; (is_mul, la, lb)
+    let bin  = node
+        | filter(or(istag(2, $1[0]), istag(3, $1[0])))
+        | map($0[0] ; istag(3, $1[0]),
+                      case $1[0] { Add(a, b) => a, Mul(a, b) => a, _ => 0 },
+                      case $1[0] { Add(a, b) => b, Mul(a, b) => b, _ => 0 });
+    let binl = bin
+        | key($1[1] ; $0[0], $1[0], $1[2]) | join(eq, ($1[0] ; $1[1], $2[0], $1[2]))
+        | key($1[2] ; $0[0], $1[0], $1[1]) | join(eq, ($1[0] ; $1[1], $1[2], $2[0]));
+
+    -- RULE commutativity: mint the mirror over the leaders, equate it with the node.
+    let mirror      = binl | map(hash(0, 7, $1[0], $1[2], $1[1]) ; if($1[0] == 1, Mul($1[2], $1[1]), Add($1[2], $1[1])));
+    let mirror_edge = binl | map($0[0] ; hash(0, 7, $1[0], $1[2], $1[1]));
+
+    -- classes with a known constant value (a class holds one value; `min` is a safe pick)
+    let cval = node | filter(istag(0, $1[0])) | map($0[0] ; case $1[0] { Num(n) => n, _ => 0 })
+                    | join(eq, ($2[0] ; $1[0])) | min;         -- class ; value
+    let zero = cval | filter($1[0] == 0) | map($0[0] ;);        -- class ;
+    let one  = cval | filter($1[0] == 1) | map($0[0] ;);
+
+    -- RULE constant folding: a binary node over two constant classes mints its value.
+    let binc = binl
+        | key($1[1] ; $0[0], $1[0], $1[2]) | join(cval, ($1[0] ; $1[1], $2[0], $1[2]))
+        | key($1[2] ; $0[0], $1[0], $1[1]) | join(cval, ($1[0] ; $1[1], $1[2], $2[0]));   -- id ; (is_mul, x, y)
+    let folded      = binc | map(hash(0, 8, if($1[0] == 1, $1[1] * $1[2], $1[1] + $1[2])) ; Num(if($1[0] == 1, $1[1] * $1[2], $1[1] + $1[2])));
+    let folded_edge = binc | map($0[0] ; hash(0, 8, if($1[0] == 1, $1[1] * $1[2], $1[1] + $1[2])));
+
+    -- RULES x + 0 ≡ x, x * 1 ≡ x, x * 0 ≡ 0 (the mirror rule covers the other operand order)
+    let add_zero = binl | filter($1[0] == 0) | key($1[2] ; $0[0], $1[1]) | join(zero, ($1[0] ; $1[1]));
+    let mul_one  = binl | filter($1[0] == 1) | key($1[2] ; $0[0], $1[1]) | join(one,  ($1[0] ; $1[1]));
+    let mul_zero = binl | filter($1[0] == 1) | key($1[2] ; $0[0])        | join(zero, ($1[0] ; $0[0]));
+
+    -- RULE ¬¬x ≡ x: a Neg whose child class holds a Neg(c) equates with c's class.
+    let negs   = node | filter(istag(4, $1[0])) | map($0[0] ; case $1[0] { Neg(a) => a, _ => 0 })
+                      | key($1[0] ; $0[0]) | join(eq, ($1[0] ; $2[0]));        -- neg_id ; la
+    let negc   = negs | join(eq, ($2[0] ; $1[0]));                              -- class(neg_id) ; la
+    let negneg = negs | key($1[0] ; $0[0]) | join(negc, ($1[0] ; $2[0]));       -- neg_id ; class(c)
+
+    -- all equalities, symmetrized, then one min-label hop
+    let edges0 = cong + mirror_edge + folded_edge + add_zero + mul_one + mul_zero + negneg;
+    let edges  = edges0 + (edges0 | key($1[0] ; $0[0]));
+    let prop   = eq | join(edges, ($2[0] ; $1[0]));
+    var eq   = (elems + prop) | min;
+
+    -- the node table grows with what the rules mint (distinct, since many nodes mint one term)
+    let minted = mirror + folded;
+    var node = (node0 + minted) | key($0[0], $1[0] ;) | distinct | map($0[0] ; $0[1]);
+}
+
+let classes = eqsat::eq;                                        -- id ; leader
+let nodes   = eqsat::node;                                      -- id ; term
+let kids2   = nodes
+    | filter(not(istag(0, $1[0])) && not(istag(1, $1[0])))
+    | map($0[0] ; case $1[0] { Add(a, b) => list(a, b), Mul(a, b) => list(a, b), Neg(a) => list(a), _ => list(0) });
+let nkids   = kids2 | map($0[0] ; len($1[0]));
+
+-- extraction: a class's cost is the cheapest term in it, one plus its children's class costs
+extract: {
+    let leafc = nodes | filter(or(istag(0, $1[0]), istag(1, $1[0]))) | join(classes, ($2[0] ; 1));   -- class ; 1
+    let kc = kids2
+        | flatmap($1[0]) | map($1[1] ; $0[0], $1[0])              -- child ; (id, pos)
+        | join(classes, ($2[0] ; $1[0], $1[1]))                    -- class ; (id, pos)
+        | join(cost, ($1[0] ; $1[1], $2[0]))                       -- id ; (pos, c)
+        | collect                                                  -- id ; [(pos, c)]
+        | join(nkids, ($0[0] ; ($1), $2[0]))                       -- id ; (list, n)
+        | filter(len($1[0]) == $1[1])                              -- every child priced
+        | map($0[0] ; 1 + fold($1[0], 0, ^1 + ^0[1]));              -- id ; node cost
+    let classc = kc | join(classes, ($2[0] ; $1[0])) | min;        -- class ; min cost
+    var cost = (leafc + classc) | min;
+}
+
+export "classes" = classes | arrange | inspect(classes);
+export "cost" = extract::cost | arrange | inspect(cost);
+export "best" = extract::kc
+    | join(classes, ($2[0] ; $0[0], $1[0]))
+    | join(extract::cost, ($0[0] ; $1[0], $1[1], $2[0]))
+    | filter($1[1] == $1[2]) | map($0[0] ; $1[0]) | min
+    | arrange | inspect(best);
+export "collisions" = nodes | map($0[0], $1[0] ;) | distinct | map($0[0] ;) | count | filter($1[0] > 1)
+    | arrange | inspect(collisions);


### PR DESCRIPTION
Stacked on #855 (the first four commits here are that PR; merge it first and this diff shrinks to the e-graph).

**What.** `Program::optimize` now runs an equality-saturation optimizer written in DDIR (`interactive/src/egraph/optimize.ddp`) over each scope of a program, innermost first, and rebuilds the scope from the extraction. `Scope::optimize`, the hand-written pass, remains: the e-graph program is optimized by it (it cannot optimize itself), and the tests compare against it.

**The e-graph.** Each scope is reified at the grain of one node per linear step, with everything an operator closes over (a projection, a predicate, a reducer, a child scope's body) interned to an opaque id, and each node priced by the host. The program computes congruence closure (a concatenation's children are the unordered multiset of its leaves through nested concatenations, so commutativity and associativity are free), arrange idempotence, and a tree-cost extraction. The host instantiates the rules that need a fact about a scalar operator and hands them to the program as asserted equalities: demand pushdown (a reducer or join that reads only some of an input's fields equals itself over that input narrowed to them, below the input's arrange), join commutativity, and filter pushdown (a filter equals itself composed through the projection, negation, concatenation, or join below it). Rules apply to the nodes they mint too, to a fixpoint. `egraph/scalar.rs` is the whole interface to the scalar language: widths after an operator, which fields a term reads, rewriting a term to a narrowed or renamed row, composing a predicate through a projection.

**Extraction and cost.** The cost model lives entirely in extraction; saturation never sees a price. A node costs weight × (1 + row width) × a relative row volume (inputs carry a base volume, a filter halves it: an estimate there to order alternatives, nothing more). The program's tree-cost optimum is refined by the host against the DAG cost, what the choices materialize from the roots with sharing counted once, by hill-climbing (optimal DAG extraction is NP-hard). `Extraction::Random` walks random acyclic choices instead, and the test shows every corpus and explanation program evaluates identically under it.

**Results.** On the eight corpus programs the e-graph matches the hand-written optimizer's operator count exactly; where the new rules fire it costs less (adt, tour). On the explanation rewrites it finds three more merges than the hand-written pass on each (reach 168 -> 143 by hand, 140 here; scc 647 -> 519 vs 516), purely from phase ordering. Outputs are identical before and after everywhere. The whole interactive suite runs through the e-graph. The pass takes 20-35 ms in release on the explanation programs (about 40x the hand-written pass; roughly a third is Debug-string interning in the host and half is one DD evaluation per scope, both addressable).

Also here: the arithmetic e-graph program (`egraph_math.ddp`) with its Rust reference oracle, the exploration this grew from, and the ddir driver passing its inputs' widths so the narrowing rules can fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012k2GSwxmvD2LvckkoXi6GK