### PR TITLE
DDIR: corgi pin to 13f3ab8, and the chunk merge on survey_groups

### DIFF
--- a/interactive/Cargo.toml
+++ b/interactive/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 columnar = { workspace = true }
 # The columnar kernels for the interpreted backend, pinned by git rev.
-corgi = { git = "https://github.com/frankmcsherry/WIP", rev = "de0f2ac91d31ac63641035e5a5bb1b5640fe9424", features = ["serde"] }
+corgi = { git = "https://github.com/frankmcsherry/WIP", rev = "13f3ab8f84c7735c44ee9acca650e126495f7a11", features = ["serde"] }
 differential-dataflow = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 smallvec = "1.15.1"

--- a/interactive/src/corgi/chunk.rs
+++ b/interactive/src/corgi/chunk.rs
@@ -28,7 +28,7 @@ use timely::progress::frontier::AntichainRef;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::trace::chunk::{pack, Chunk, ChunkBatch};
 
-use corgi::arrange::{compare_adjacent, compare_at, gather, gather_lanes, group_bounds, sort_perm};
+use corgi::arrange::{compare_adjacent, gather, gather_lanes, group_bounds, sort_perm, survey_groups, GroupRun};
 use corgi::Value as CValue;
 
 use columnar::Columnar;
@@ -153,18 +153,13 @@ where
 
     fn len(&self) -> usize { self.0.times.len() }
 
-    /// Two-pointer merge of the two front chunks through their shared horizon, FULLY consolidating
-    /// equal `(key, val, time)` triples and pushing back the survivor's suffix (the fueled-merger
-    /// contract). NB a `survey`-based merge cannot be substituted as-is: survey aligns only
-    /// `(key, val)` (corgi owns no time), so its positional `Both` under-consolidates cross-side
-    /// times, and consuming both chunks with no push-back un-grades the chain; it would need a
-    /// group-RANGE `Both` (both sides' full equal-`(key,val)` group) to time-merge correctly.
-    ///
-    /// TODO: newer corgi revs export exactly that (`survey_groups` -> `GroupRun::{A, B, Both}`,
-    /// with `Both` carrying both sides' group ranges). Once the pin moves past it, rewrite this
-    /// merge batched: bulk-copy `A`/`B` runs (range gather + `push_range` + `extend_from_slice`),
-    /// row-merge times only within `Both` classes. This row-at-a-time loop is the largest
-    /// `compare_at`-in-a-hot-path residue in the backend (the ingest batcher's merge).
+    /// Merge of the two front chunks through their shared horizon, FULLY consolidating equal
+    /// `(key, val, time)` triples and pushing back the survivor's suffix (the fueled-merger
+    /// contract). Batched: corgi's `survey_groups` reports the interleaving of the two `(key, val)`
+    /// columns as maximal ranges exclusive to one side and equal classes as their ranges on BOTH
+    /// sides, so rows only one side holds are copied by range, and only the classes both sides
+    /// hold — where consolidation can happen — are merged row by row, on their times, which corgi
+    /// does not own. The shape is walked once per level per chunk, never once per row.
     fn merge(in1: &mut VecDeque<Self>, in2: &mut VecDeque<Self>, out: &mut VecDeque<Self>) {
         let c1 = in1.pop_front().unwrap();
         let c2 = in2.pop_front().unwrap();
@@ -173,20 +168,46 @@ where
         let (t1, d1) = (c1.times(), c1.diffs());
         let (t2, d2) = (c2.times(), c2.diffs());
 
-        let (mut tags, mut offs) = (Vec::new(), Vec::new());
-        let (mut times, mut diffs) = (ColTimes::new(), Vec::new());
-        let (mut p1, mut p2) = (0usize, 0usize);
-        while p1 < n1 && p2 < n2 {
-            // `(key, val)` structurally, then `time` in place via the columnar `Ref: Ord`.
-            let ord = compare_at(&kv1, p1, &kv2, p2).then_with(|| t1.cmp_cross(p1, t2, p2));
-            match ord {
-                Ordering::Less => { tags.push(0); offs.push(p1); times.push_ref(t1, p1); diffs.push(d1[p1].clone()); p1 += 1; }
-                Ordering::Greater => { tags.push(1); offs.push(p2); times.push_ref(t2, p2); diffs.push(d2[p2].clone()); p2 += 1; }
-                Ordering::Equal => {
-                    let mut d = d1[p1].clone();
-                    d.plus_equals(&d2[p2]);
-                    if !d.is_zero() { tags.push(0); offs.push(p1); times.push_ref(t1, p1); diffs.push(d); }
-                    p1 += 1; p2 += 1;
+        let runs = survey_groups(&kv1, &kv2);
+        let (mut tags, mut offs) = (Vec::with_capacity(n1 + n2), Vec::with_capacity(n1 + n2));
+        let (mut times, mut diffs): (ColTimes<T>, Vec<R>) = (ColTimes::new(), Vec::with_capacity(n1 + n2));
+        // Where the survivor's pushed-back suffix starts: the last run, if it is exclusive.
+        let (mut p1, mut p2) = (n1, n2);
+        let copy = |tags: &mut Vec<usize>, offs: &mut Vec<usize>, times: &mut ColTimes<T>, diffs: &mut Vec<R>, side: usize, lo: usize, hi: usize| {
+            let (t, d) = if side == 0 { (t1, d1) } else { (t2, d2) };
+            tags.resize(tags.len() + (hi - lo), side);
+            offs.extend(lo..hi);
+            times.push_range(t, lo, hi);
+            diffs.extend_from_slice(&d[lo..hi]);
+        };
+        for (r, run) in runs.iter().enumerate() {
+            let last = r + 1 == runs.len();
+            match *run {
+                GroupRun::A(lo, hi) => {
+                    if last { p1 = lo; } else { copy(&mut tags, &mut offs, &mut times, &mut diffs, 0, lo, hi); }
+                }
+                GroupRun::B(lo, hi) => {
+                    if last { p2 = lo; } else { copy(&mut tags, &mut offs, &mut times, &mut diffs, 1, lo, hi); }
+                }
+                GroupRun::Both(a_lo, a_hi, b_lo, b_hi) => {
+                    // Both classes hold one `(key, val)`, sorted by time: merge on time, summing the
+                    // diffs of equal times, which is the consolidation.
+                    let (mut i, mut j) = (a_lo, b_lo);
+                    while i < a_hi && j < b_hi {
+                        match t1.cmp_cross(i, t2, j) {
+                            Ordering::Less => { copy(&mut tags, &mut offs, &mut times, &mut diffs, 0, i, i + 1); i += 1; }
+                            Ordering::Greater => { copy(&mut tags, &mut offs, &mut times, &mut diffs, 1, j, j + 1); j += 1; }
+                            Ordering::Equal => {
+                                let mut d = d1[i].clone();
+                                d.plus_equals(&d2[j]);
+                                if !d.is_zero() { tags.push(0); offs.push(i); times.push_ref(t1, i); diffs.push(d); }
+                                i += 1;
+                                j += 1;
+                            }
+                        }
+                    }
+                    if i < a_hi { copy(&mut tags, &mut offs, &mut times, &mut diffs, 0, i, a_hi); }
+                    if j < b_hi { copy(&mut tags, &mut offs, &mut times, &mut diffs, 1, j, b_hi); }
                 }
             }
         }

--- a/interactive/src/corgi/chunk.rs
+++ b/interactive/src/corgi/chunk.rs
@@ -37,10 +37,19 @@ use crate::corgi::col_times::{ColTime, ColTimes};
 
 use std::cmp::Ordering;
 
-/// The grading target (also the merge/advance emit-chunk size). Larger than `VecChunk`'s 8192 to
-/// amortize corgi's per-chunk columnar set-up (each chunk boundary costs a `gather` materialization);
-/// bigger chunks mean fewer boundaries. Bounded so the fueled merger still yields.
-const TARGET: usize = 1 << 18;
+/// The chunk size the merge and the advance emit, and the unit the fueled merger yields on.
+/// Larger than `VecChunk`'s 8192 to amortize corgi's per-chunk columnar set-up (each chunk
+/// boundary costs a `gather` materialization). Swept at 1M nodes with `INGEST` at 2^24: 2^18 to
+/// 2^20 takes ast's initial epoch 6.98 to 5.46 s and kcore's 4.27 to 3.05 with churn epochs flat;
+/// 2^22 is within noise of that; 2^24 costs a merge-heavy churn epoch 11% (ast 2.42 -> 2.69 s).
+const TARGET: usize = 1 << 20;
+
+/// How many rows the chunker accumulates before sorting them into one chunk: the ingest bundle.
+/// A separate knob from `TARGET`, since a radix sort of a big bundle is cheaper than merging its
+/// pieces while the merger's granularity is `TARGET`'s to set. On its own, 2^18 to 2^22 at 1M
+/// nodes takes kcore's initial epoch 4.27 to 3.42 s and scc's 22.99 to 22.16 with churn flat;
+/// 2^24 sorts the whole of a large epoch's input at once.
+const INGEST: usize = 1 << 24;
 
 /// Shared, immutable chunk contents. `Clone` of a `CorgiChunk` is an `Rc` bump.
 ///
@@ -606,7 +615,7 @@ where
         self.v_blocks.push(std::mem::replace(&mut c.vals, CValue::Unit(0)));
         self.times.append(&mut c.times);
         self.diffs.append(&mut c.diffs);
-        if self.times.len() >= TARGET {
+        if self.times.len() >= INGEST {
             self.flush();
         }
     }


### PR DESCRIPTION
Two corgi PRs landed this weekend: the indexed sort ([WIP#24](https://github.com/frankmcsherry/WIP/pull/24)), which arranges a chunk and orders the reduce's candidates without gathering at every level of the shape, and the rank-at-a-time survey ([WIP#26](https://github.com/frankmcsherry/WIP/pull/26)), which reports the interleaving of two sorted columns as maximal exclusive ranges and equal classes as their ranges on both sides. This moves the pin to master 13f3ab8 and takes the second one up.

**The merge.** `CorgiChunk::merge` compared row by row with `compare_at`, and its own comment named `survey_groups` as the interface it was waiting for. It is now the exclusive runs copied by range (`push_range`, `extend_from_slice`) and each equal class merged once on its times, where consolidation happens; corgi walks the shape once per level per chunk. The group form is simpler than the pairwise one on `survey-merge`: no group-end scan, no done marks, no `u64_lanes`.

**Numbers.** Medium scale, one worker, corgi backend, medians of three, de0f2ac → here:

| workload | initial epoch before | after | churn epoch before | after |
|---|---|---|---|---|
| ast_hier | 948.6 ms | 685.8 ms | 19.5 ms | 19.2 ms |
| ast | 562.0 ms | 462.4 ms | 166.4 ms | 164.0 ms |
| kcore | 302.9 ms | 265.4 ms | 2.4 ms | 2.3 ms |
| scc | 1.98 s | 1.78 s | 58.0 ms | 57.8 ms |
| stable | 327.3 ms | 294.9 ms | 6.2 ms | 5.9 ms |
| tour | 745.4 ms | 704.4 ms | 13.3 ms | 13.1 ms |
| reach | 188.2 ms | 177.1 ms | 10.1 ms | 9.8 ms |
| unnest | 247.5 ms | 237.6 ms | 1.4 ms | 1.4 ms |
| adt | 44.0 ms | 41.8 ms | 13.6 ms | 13.5 ms |

**Chunk sizing, second commit.** The chunker accumulated `TARGET` rows before sorting them, so one constant set both the ingest bundle and the chunks the merge and advance emit. They are two knobs now: `INGEST` at 2^24, the whole of a large epoch's input in one radix sort, and `TARGET` at 2^20. Swept at 1M nodes, one worker, medians of two, initial epoch / churn epoch: target 2^18 as before, ast 6.98 s / 2.58 s, kcore 4.27 / 0.027, scc 22.99 / 0.711; ingest 2^22 with target 2^18, ast 6.19 / 2.59, kcore 3.42 / 0.026, scc 22.16 / 0.705; ingest 2^24 with target 2^20, ast 5.46 / 2.57, kcore 3.05 / 0.026, scc 22.66 / 0.685; target 2^24 for both roles, ast 5.07 / 2.69, kcore 2.85 / 0.026. The bundle alone is half to two thirds of the gain with churn untouched; the chunk size is the rest and the part that costs churn past 2^22. At medium scale the chunk size alone takes ast 462 to 419 ms and kcore 265 to 236, churn flat.

Of the initial-epoch gain from the first commit, the sort alone was 2 to 10%, measured at the intermediate pin 5bee8df; the merge is the rest. The numbers were taken with `bench-spike`'s harness copied in, since master-next does not carry it. Tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDsLC46QQW9aBrksaWad6T
