### PR TITLE
DDIR: preserve timestamp order across Corgi chunk boundaries

### DIFF
--- a/interactive/src/corgi/chunk.rs
+++ b/interactive/src/corgi/chunk.rs
@@ -215,6 +215,14 @@ where
                             }
                         }
                     }
+                    // Equal (key, val) classes can continue in the next chunk. Once either
+                    // whole input chunk is spent, its last timestamp is the shared horizon:
+                    // retain the other side's suffix, including the rest of this class.
+                    if i == n1 || j == n2 {
+                        p1 = i;
+                        p2 = j;
+                        break;
+                    }
                     if i < a_hi { copy(&mut tags, &mut offs, &mut times, &mut diffs, 0, i, a_hi); }
                     if j < b_hi { copy(&mut tags, &mut offs, &mut times, &mut diffs, 1, j, b_hi); }
                 }

--- a/interactive/tests/corgi_chunk_merge.rs
+++ b/interactive/tests/corgi_chunk_merge.rs
@@ -1,0 +1,37 @@
+//! Regression coverage for the sorted/consolidated chunk-chain merge contract.
+use corgi::Value;
+use differential_dataflow::batcher::merge::Merger;
+use differential_dataflow::trace::chunk::{Chunk, ChunkMerger};
+use interactive::corgi::chunk::CorgiChunk;
+
+fn chunk(times: &[u64]) -> CorgiChunk<u64, i64> {
+    CorgiChunk::from_columns(
+        Value::u64(vec![7; times.len()]),
+        Value::u64(vec![8; times.len()]),
+        times.to_vec(),
+        vec![1; times.len()],
+    )
+}
+
+fn check_horizon(prefix: usize) {
+    let n = prefix as u64;
+    let left = vec![chunk(&(0..n).collect::<Vec<_>>()), chunk(&[n + 1])];
+    let right = vec![chunk(&[n, n + 2])];
+    let mut output = Vec::new();
+    ChunkMerger::default().merge(left, right, &mut output, &mut Vec::new());
+    let times: Vec<_> = output.iter().flat_map(|c| (0..c.times().len()).map(|i| c.times().get(i))).collect();
+    assert_eq!(times.len(), prefix + 3);
+    assert_eq!(&times[prefix - 1..], [n - 1, n, n + 1, n + 2]);
+    assert!(times.windows(2).all(|pair| pair[0] < pair[1]));
+}
+
+#[test]
+fn merge_keeps_time_order_when_an_equal_value_class_crosses_a_chunk_boundary() {
+    check_horizon(1);
+}
+
+#[test]
+#[ignore = "scale confirmation with fully graded inputs; the small case tests the same merge contract"]
+fn merge_horizon_with_graded_input_chains() {
+    check_horizon(CorgiChunk::<u64, i64>::TARGET);
+}


### PR DESCRIPTION
The Corgi chunk merger added in #861 can emit timestamps out of order when an
equal `(key, value)` group continues across an input chunk boundary.

For identical keys/values (brackets are chunk boundaries):

```text
left:     [0] [2]
right:    [1, 3]
actual:   [0, 1, 3, 2]
expected: [0, 1, 2, 3]
```

`survey_groups` groups by key/value, not timestamp. The `Both` path merges
timestamps until one side's range ends, then copies the other range's suffix.
If the exhausted range also ends its whole input chunk, that suffix must wait
for the next chunk: it can contain timestamps beyond the shared merge horizon.

Stop at that boundary and return the unconsumed suffix through the existing
push-back path. The batched key/value survey is unchanged. Eight implementation
lines; no dependency, batch-size, query, or server-protocol changes.

The regression uses the plain ingest `ChunkMerger`. A later trace `advance`
can re-sort equal-value timestamps and hide the violation, so checking only
that path was insufficient. The test covers the small example and an opt-in
version with a `TARGET`-sized first chunk. The unpatched implementation was
observed to fail the small reproduction.

Validation: both cases pass on this branch with the existing public Corgi pin:

```sh
CARGO_PROFILE_RELEASE_DEBUG=0 cargo test --locked --offline --release \
  -p interactive --test corgi_chunk_merge -- --include-ignored
```

This fixes a sorted/consolidated merge-contract violation. It does not claim
to explain an LDBC performance result or a particular wrong query answer.
