### PR TITLE
Cursor-based clean-up

### DIFF
--- a/differential-dataflow/src/columnar/trace/chunk.rs
+++ b/differential-dataflow/src/columnar/trace/chunk.rs
@@ -42,7 +42,7 @@ use crate::consolidation::Consolidate;
 use crate::lattice::Lattice;
 use crate::trace::Navigable;
 use crate::trace::cursor::Cursor;
-use crate::trace::implementations::{BatchContainer, Layout, WithLayout};
+use crate::trace::implementations::{BatchContainer, Layout};
 
 use crate::columnar::layout::{ColumnarLayout, ColumnarUpdate, Coltainer};
 use crate::columnar::updates::{child_range, UpdatesBuilder, UpdatesTyped};
@@ -194,13 +194,6 @@ pub struct ColChunkCursor<U: ColumnarUpdate> {
     key_cursor: usize,
     val_cursor: usize,
     phantom: PhantomData<U>,
-}
-
-impl<U: ColumnarUpdate> WithLayout for ColChunk<U> {
-    type Layout = ColumnarLayout<U>;
-}
-impl<U: ColumnarUpdate> WithLayout for ColChunkCursor<U> {
-    type Layout = ColumnarLayout<U>;
 }
 
 impl<U: ColumnarUpdate> Cursor for ColChunkCursor<U> {

--- a/differential-dataflow/src/columnar/trace/chunk.rs
+++ b/differential-dataflow/src/columnar/trace/chunk.rs
@@ -327,7 +327,7 @@ where U::Time: 'static {
 
 impl<U: ColumnarUpdate> Chunk for ColChunk<U>
 where U::Time: 'static {
-    type Time = <<ColumnarLayout<U> as Layout>::TimeContainer as BatchContainer>::Owned;
+    type Time = U::Time;
 
     const TARGET: usize = TARGET;
 

--- a/differential-dataflow/src/trace/chunk/cursor.rs
+++ b/differential-dataflow/src/trace/chunk/cursor.rs
@@ -1,0 +1,229 @@
+//! Cursor navigation over chunks and chunk batches.
+//!
+//! Implementing [`NavigableChunk`] lets a [`ChunkBatch`] expose a [`ChunkBatchCursor`].
+//! This cursor joins key and value groups that span chunk boundaries, delegating navigation within each chunk to its cursor.
+//!
+//! Searches across chunks read resident [`bounds`](NavigableChunk::bounds) metadata.
+//! Key seeks gallop from a remembered chunk, and boundary crossings compare adjacent chunks' bounds.
+//! Chunk bodies are read when navigation reaches them.
+//! Implementors must keep `bounds` cheap even when a chunk's body is paged out.
+
+use crate::trace::Navigable;
+use crate::trace::cursor::Cursor;
+use crate::trace::implementations::BatchContainer;
+
+use super::{Chunk, ChunkBatch};
+
+/// The navigation capability: a [`Chunk`] whose contents can be read by cursor.
+///
+/// This is optional. Batch formation and trace maintenance need only [`Chunk`];
+/// implementing this trait additionally lets [`ChunkBatch`] offer the straddle
+/// cursor ([`ChunkBatchCursor`]), which is how cursor-driven operator paths read
+/// an arrangement. Chunks consumed only by whole-chunk logic (tactics) can skip it.
+///
+/// `bounds` must stay cheap even when a chunk's body is paged out: the straddle
+/// cursor consults chunk bounds throughout navigation — seeks binary-search them,
+/// boundary crossings compare against them — and opens a chunk's body only when a
+/// query touches it.
+pub trait NavigableChunk: Chunk + Navigable<Cursor: Cursor<Time = <Self as Chunk>::Time>> {
+    /// The first and last `(key, val, time)` triples in the chunk.
+    fn bounds(&self) -> (
+        (<Self::Cursor as Cursor>::Key<'_>, <Self::Cursor as Cursor>::Val<'_>, <Self::Cursor as Cursor>::TimeGat<'_>),
+        (<Self::Cursor as Cursor>::Key<'_>, <Self::Cursor as Cursor>::Val<'_>, <Self::Cursor as Cursor>::TimeGat<'_>),
+    );
+}
+
+type KeyCon<C> = <<C as Navigable>::Cursor as Cursor>::KeyContainer;
+type ValCon<C> = <<C as Navigable>::Cursor as Cursor>::ValContainer;
+
+impl<C: NavigableChunk> crate::trace::Navigable for ChunkBatch<C> {
+    type Cursor = ChunkBatchCursor<C>;
+    fn cursor(&self) -> Self::Cursor {
+        ChunkBatchCursor { key_chunk: 0, chunk: 0, inner: self.chunks.first().map(C::cursor) }
+    }
+}
+
+/// A cursor over a [`ChunkBatch`], merging the per-chunk cursors.
+///
+/// Chunk breakpoints are unconstrained, so a single key — or `(key, val)` — may
+/// straddle consecutive chunks. But the chunks are one globally-sorted sequence
+/// merely cut at arbitrary points, so the operation is *concatenation*, never a
+/// merge: across a boundary a key's vals concatenate and a `(key, val)`'s times
+/// concatenate. The cursor exploits this. It holds the chunk currently being read
+/// and a cursor into it; it seeks by galloping the chunks' resident
+/// [`bounds`](NavigableChunk::bounds) from a remembered hint (the current key's first
+/// chunk), and at boundaries it *continues* into the next chunk rather than merging —
+/// consulting the two neighbouring chunks' bounds to detect when a key or `(key, val)`
+/// spills forward, without touching chunk contents. No state is materialized up front:
+/// a monotone seek sweep costs `O(log Δ)` bounds reads per seek and a sequential pass two
+/// per boundary, so cursor construction is free.
+pub struct ChunkBatchCursor<C: NavigableChunk> {
+    /// First chunk of the current key's run; where `rewind_vals` returns to.
+    key_chunk: usize,
+    /// Chunk currently being read; `>= key_chunk`, within the current key's span.
+    chunk: usize,
+    /// Cursor into `chunk`; `None` once `chunk` is past the last chunk.
+    inner: Option<C::Cursor>,
+}
+
+impl<C: NavigableChunk> ChunkBatchCursor<C> {
+    /// Move the active chunk to `c`, opening a fresh inner cursor at its start.
+    fn goto(&mut self, c: usize, storage: &ChunkBatch<C>) {
+        self.chunk = c;
+        self.inner = storage.chunks.get(c).map(C::cursor);
+    }
+
+    /// Does key `k` span the boundary between chunks `c` and `c + 1` — chunk `c`
+    /// ends with it and chunk `c + 1` begins with it?
+    ///
+    /// Two resident [`bounds`](NavigableChunk::bounds) reads; the `reborrow`s
+    /// unify the (invariant) item lifetimes with `k`'s.
+    fn key_spills(s: &ChunkBatch<C>, c: usize, k: <C::Cursor as Cursor>::Key<'_>) -> bool {
+        <KeyCon<C> as BatchContainer>::reborrow(s.chunks[c].bounds().1.0) == <KeyCon<C> as BatchContainer>::reborrow(k)
+            && <KeyCon<C> as BatchContainer>::reborrow(s.chunks[c + 1].bounds().0.0) == <KeyCon<C> as BatchContainer>::reborrow(k)
+    }
+
+    /// Does `(k, v)` span the boundary between chunks `c` and `c + 1`?
+    fn val_spills(s: &ChunkBatch<C>, c: usize, k: <C::Cursor as Cursor>::Key<'_>, v: <C::Cursor as Cursor>::Val<'_>) -> bool {
+        Self::key_spills(s, c, k)
+            && <ValCon<C> as BatchContainer>::reborrow(s.chunks[c].bounds().1.1) == <ValCon<C> as BatchContainer>::reborrow(v)
+            && <ValCon<C> as BatchContainer>::reborrow(s.chunks[c + 1].bounds().0.1) == <ValCon<C> as BatchContainer>::reborrow(v)
+    }
+
+    /// The first chunk, at or after `hint`, whose last key is `>= key`: where `key`'s run
+    /// begins. `hint` — the current key's first chunk (`key_chunk`) — is a valid lower bound
+    /// for a forward seek; a backward seek is detected and served by a full search from the
+    /// front. Galloping keeps a monotone seek sweep at `O(log Δ)` bounds reads per seek rather
+    /// than `O(log chunks)`; only resident [`bounds`](NavigableChunk::bounds) are read.
+    fn locate_key(s: &ChunkBatch<C>, hint: usize, key: <C::Cursor as Cursor>::Key<'_>) -> usize {
+        let n = s.chunks.len();
+        // `last_key(i) < key`, from chunk `i`'s resident bounds.
+        let lt = |i: usize| <KeyCon<C> as BatchContainer>::reborrow(s.chunks[i].bounds().1.0)
+            .lt(&<KeyCon<C> as BatchContainer>::reborrow(key));
+        let hint = hint.min(n);
+        // The hint can skip the answer only on a backward seek; then search from the front.
+        let lo = if hint == 0 || lt(hint - 1) { hint } else { 0 };
+        if lo >= n || !lt(lo) { return lo; }
+        // Exponential search from `lo`, then binary within the final bracket.
+        let (mut prev, mut step) = (lo, 1usize);
+        while prev + step < n && lt(prev + step) { prev += step; step <<= 1; }
+        let (mut a, mut b) = (prev + 1, (prev + step).min(n));
+        while a < b { let m = a + (b - a) / 2; if lt(m) { a = m + 1; } else { b = m; } }
+        a
+    }
+}
+
+impl<C: NavigableChunk> Cursor for ChunkBatchCursor<C> {
+    type Storage = ChunkBatch<C>;
+
+    type KeyContainer = <C::Cursor as Cursor>::KeyContainer;
+    type Key<'a> = <C::Cursor as Cursor>::Key<'a>;
+    type ValContainer = <C::Cursor as Cursor>::ValContainer;
+    type Val<'a> = <C::Cursor as Cursor>::Val<'a>;
+    type ValOwn = <C::Cursor as Cursor>::ValOwn;
+    type TimeContainer = <C::Cursor as Cursor>::TimeContainer;
+    type TimeGat<'a> = <C::Cursor as Cursor>::TimeGat<'a>;
+    type Time = <C::Cursor as Cursor>::Time;
+    type DiffContainer = <C::Cursor as Cursor>::DiffContainer;
+    type DiffGat<'a> = <C::Cursor as Cursor>::DiffGat<'a>;
+    type Diff = <C::Cursor as Cursor>::Diff;
+
+    fn key_valid(&self, s: &Self::Storage) -> bool { self.chunk < s.chunks.len() && self.inner.as_ref().is_some_and(|i| i.key_valid(&s.chunks[self.chunk])) }
+    fn val_valid(&self, s: &Self::Storage) -> bool { self.chunk < s.chunks.len() && self.inner.as_ref().is_some_and(|i| i.val_valid(&s.chunks[self.chunk])) }
+    fn key<'a>(&self, s: &'a Self::Storage) -> Self::Key<'a> { self.inner.as_ref().unwrap().key(&s.chunks[self.chunk]) }
+    fn val<'a>(&self, s: &'a Self::Storage) -> Self::Val<'a> { self.inner.as_ref().unwrap().val(&s.chunks[self.chunk]) }
+    fn get_key<'a>(&self, s: &'a Self::Storage) -> Option<Self::Key<'a>> { if self.key_valid(s) { Some(self.key(s)) } else { None } }
+    fn get_val<'a>(&self, s: &'a Self::Storage) -> Option<Self::Val<'a>> { if self.val_valid(s) { Some(self.val(s)) } else { None } }
+
+    fn map_times<L: FnMut(Self::TimeGat<'_>, Self::DiffGat<'_>)>(&mut self, s: &Self::Storage, mut logic: L) {
+        if !self.val_valid(s) { return; }
+        let (k, v) = (self.key(s), self.val(s));
+        self.inner.as_mut().unwrap().map_times(&s.chunks[self.chunk], &mut logic);
+        // Follow the (key, val) forward across boundaries while it spills.
+        let mut c = self.chunk;
+        while c + 1 < s.chunks.len() && Self::val_spills(s, c, k, v) {
+            c += 1;
+            s.chunks[c].cursor().map_times(&s.chunks[c], &mut logic);
+        }
+    }
+
+    fn step_key(&mut self, s: &Self::Storage) {
+        if !self.key_valid(s) { return; }
+        let n = s.chunks.len();
+        let k = self.key(s);
+        // Advance to the last chunk the key spans.
+        while self.chunk + 1 < n && Self::key_spills(s, self.chunk, k) {
+            self.goto(self.chunk + 1, s);
+        }
+        // Step past the key within its last chunk.
+        {
+            let inner = self.inner.as_mut().unwrap();
+            inner.seek_key(&s.chunks[self.chunk], k);
+            inner.step_key(&s.chunks[self.chunk]);
+        }
+        // If that exhausted the chunk, the next key (if any) starts the next chunk.
+        if !self.inner.as_ref().unwrap().key_valid(&s.chunks[self.chunk]) && self.chunk + 1 < n {
+            self.goto(self.chunk + 1, s);
+        }
+        self.key_chunk = self.chunk;
+    }
+
+    fn seek_key(&mut self, s: &Self::Storage, key: Self::Key<'_>) {
+        let n = s.chunks.len();
+        // First chunk whose last key is `>= key`: where `key`'s run begins. Gallop from the
+        // current key's first chunk (`key_chunk`), a lower bound for forward seeks.
+        let lo = Self::locate_key(s, self.key_chunk, key);
+        self.goto(lo, s);
+        self.key_chunk = lo;
+        if lo < n { self.inner.as_mut().unwrap().seek_key(&s.chunks[lo], key); }
+    }
+
+    fn step_val(&mut self, s: &Self::Storage) {
+        if !self.val_valid(s) { return; }
+        let n = s.chunks.len();
+        let (k, v) = (self.key(s), self.val(s));
+        // Advance to the last chunk the (key, val) spans.
+        while self.chunk + 1 < n && Self::val_spills(s, self.chunk, k, v) {
+            self.goto(self.chunk + 1, s);
+        }
+        // Step past the (key, val) within that chunk.
+        self.inner.as_mut().unwrap().step_val(&s.chunks[self.chunk]);
+        // If the key's vals are exhausted here but the key spills, roll forward.
+        if !self.inner.as_ref().unwrap().val_valid(&s.chunks[self.chunk])
+            && self.chunk + 1 < n && Self::key_spills(s, self.chunk, k)
+        {
+            self.goto(self.chunk + 1, s);
+            self.inner.as_mut().unwrap().seek_key(&s.chunks[self.chunk], k);
+        }
+    }
+
+    fn seek_val(&mut self, s: &Self::Storage, val: Self::Val<'_>) {
+        if !self.key_valid(s) { return; }
+        let n = s.chunks.len();
+        let k = self.key(s);
+        loop {
+            self.inner.as_mut().unwrap().seek_val(&s.chunks[self.chunk], val);
+            if self.inner.as_ref().unwrap().val_valid(&s.chunks[self.chunk]) { return; }
+            // Key's vals exhausted in this chunk; if the key spills, retry in the next.
+            if self.chunk + 1 < n && Self::key_spills(s, self.chunk, k) {
+                self.goto(self.chunk + 1, s);
+                self.inner.as_mut().unwrap().seek_key(&s.chunks[self.chunk], k);
+            } else {
+                return;
+            }
+        }
+    }
+
+    fn rewind_keys(&mut self, s: &Self::Storage) {
+        self.key_chunk = 0;
+        self.goto(0, s);
+    }
+
+    fn rewind_vals(&mut self, s: &Self::Storage) {
+        if !self.key_valid(s) { return; }
+        let k = self.key(s);
+        let kc = self.key_chunk;
+        self.goto(kc, s);
+        self.inner.as_mut().unwrap().seek_key(&s.chunks[kc], k);
+    }
+}

--- a/differential-dataflow/src/trace/chunk/mod.rs
+++ b/differential-dataflow/src/trace/chunk/mod.rs
@@ -261,7 +261,7 @@ impl<C: NavigableChunk> crate::trace::Navigable for ChunkBatch<C> {
     }
 }
 
-impl<C: Chunk + Default + 'static> SpineBatch for ChunkBatch<C>
+impl<C: Chunk + 'static> SpineBatch for ChunkBatch<C>
 where
     C::Time: timely::progress::Timestamp + Lattice + Ord,
 {
@@ -579,7 +579,7 @@ pub struct ChunkBatchMerger<C: Chunk> {
 
 impl<C> crate::trace::implementations::spine_fueled::Merger<ChunkBatch<C>> for ChunkBatchMerger<C>
 where
-    C: Chunk + Default + 'static,
+    C: Chunk + 'static,
     C::Time: timely::progress::Timestamp + Lattice + Ord + 'static,
 {
     fn new(_source1: &ChunkBatch<C>, _source2: &ChunkBatch<C>, frontier: AntichainRef<C::Time>) -> Self {

--- a/differential-dataflow/src/trace/chunk/mod.rs
+++ b/differential-dataflow/src/trace/chunk/mod.rs
@@ -3,66 +3,50 @@
 //! A [`Chunk`] is a consolidated, sorted run of `(data, time, diff)` updates.
 //! A sequence of chunks is also expected to be consolidated and sorted.
 //!
-//! The [`Chunk`] trait exposes whole-chunk operations, so that the implementor
-//! can internally divert to their best implementations, with amortized overhead.
+//! The [`Chunk`] trait exposes whole-chunk operations, so that the implementor can internally divert to their best implementations, with amortized overhead.
 //! Each operation is invoked as if "streaming", providing input and output queues.
-//! An implementor is expected to drain as much as possible of the inputs, and any
-//! chunk written to the output is "committed" and likely to be shipped onward.
+//! An implementor is expected to drain as much as possible of the inputs, and any chunk written to the output is "committed" and likely to be shipped onward.
 //!
 //! # Wiring a `Chunk` into an arrangement
 //!
-//! Implementing [`Chunk`] for a type `C` is the only bespoke code needed; three
-//! aliases then expand into a full trace:
+//! Implementing [`Chunk`] for a type `C` is the only bespoke code needed; three aliases then expand into a full trace:
 //!
-//! * [`ChunkBatcher<C>`](ChunkBatcher) — the merge batcher.
+//! * [`ChunkBatcher<Chu, C>`](ChunkBatcher) — the merge batcher.
 //! * [`ChunkBuilder<C>`](ChunkBuilder) — the batch builder.
 //! * [`ChunkSpine<C>`](ChunkSpine) — the trace, a spine of `Rc`-shared batches.
 //!
-//! These are the `Batcher` / `Builder` / `Spine` to hand to
-//! [`arrange_core`](crate::operators::arrange::arrangement::arrange_core), along with a
-//! chunker that forms `C` from the input stream — typically
-//! [`ContainerChunker<C>`](crate::batcher::merge::chunker::ContainerChunker).
-//! Trace *maintenance* needs only [`Chunk`]; cursor-driven *consumption* of the
-//! arrangement additionally asks `C` for the [`NavigableChunk`] capability.
-//! Everything else here ([`ChunkBatch`], [`ChunkMerger`], [`ChunkBatchMerger`],
-//! [`ChunkBatchCursor`], [`ChunkBatchBuilder`]) is machinery those aliases expand to and is
-//! not named directly. The [`vec`](mod@vec) module is a worked `Chunk`
-//! that re-exports the three aliases specialized to its layout, and the `chunks` example
-//! stands one up.
+//! These are the `Batcher` / `Builder` / `Spine` to hand to [`arrange_core`](crate::operators::arrange::arrangement::arrange_core), along with a chunker that
+//! forms `C` from the input stream — typically [`ContainerChunker<C>`](crate::batcher::merge::chunker::ContainerChunker).
+//! These aliases use [`ChunkBatch`], [`ChunkMerger`], [`ChunkBatchMerger`], and [`ChunkBatchBuilder`] for batch formation and trace maintenance.
+//! The [`vec`](mod@vec) module provides a worked implementation and specializes the aliases for its chunk type.
+//! The `chunks` example builds an arrangement from it.
+//!
+//! Reading chunks through cursors is an optional capability provided by the [`cursor`] module.
 //!
 //! # Bounded footprint
 //!
 //! There is a `TARGET` associated constant that signals the intended chunk size.
-//! The constant should be chosen large enough to amortize overheads, but small
-//! enough that per-chunk work does not "stall" the system when invoked.
+//! The constant should be chosen large enough to amortize overheads, but small enough that per-chunk work does not "stall" the system when invoked.
 //! The implementor is trusted to make a reasonable choice here.
 //!
-//! The [`Chunk::settle`] method "settles" sequences of chunks, and is called as
-//! chunks are no longer expected to be needed in the near future. The implementor
-//! should ensure the chunks are "graded", in that the sequence of chunks are all
-//! at most `TARGET` in size, any two in order sum to strictly more than `TARGET`.
+//! The [`Chunk::settle`] method "settles" sequences of chunks, and is called as chunks are no longer expected to be needed in the near future.
+//! The implementor should ensure the chunks are "graded", in that the sequence of chunks are all at most `TARGET` in size, any two in order sum to strictly more than `TARGET`.
 //! This is also an opportunity to compress data, or spill to disk or cloud storage.
 //!
-//! The active (un-settled) chunk set is kept small from both sides. Every producer
-//! settles its committed output as it goes (see [`Chunk::settle`]), rather than
-//! building a whole sequence and settling at the end. And every walk over a whole
-//! chunk sequence reads only resident metadata — [`len`](Chunk::len) and
-//! [`bounds`](NavigableChunk::bounds) — never a chunk body: the straddle cursor
-//! seeks by galloping the chunks' bounds from a hint and opens only the chunk(s) a
-//! query touches. Implementors must therefore keep `len` and `bounds` cheap even
-//! when a chunk's body is paged out.
+//! Producers settle their committed output as they go, keeping the active, unsettled chunk set small.
+//! Implementors must keep [`len`](Chunk::len) cheap even when a chunk's body is paged out.
 
 use std::collections::VecDeque;
 
 use timely::progress::Antichain;
 use timely::progress::frontier::AntichainRef;
 use crate::lattice::Lattice;
-use crate::trace::Navigable;
 use crate::trace::implementations::spine_fueled::SpineBatch;
-use crate::trace::cursor::Cursor;
-use crate::trace::implementations::BatchContainer;
 
 pub mod vec;
+pub mod cursor;
+
+pub use cursor::{ChunkBatchCursor, NavigableChunk};
 
 /// A non-empty, bounded, consolidated, sorted sequence of `(data, time, diff)`.
 ///
@@ -74,14 +58,12 @@ pub mod vec;
 /// "one chunk's worth" of work at a time; they can afford to compress and page.
 /// The "metadata" operations provide chunk information, and should be lightweight.
 ///
-/// The trait has no opinion about keys, vals, or diffs — only time, which trace
-/// maintenance needs. Reading a chunk's contents is a separate, optional
-/// capability: see [`NavigableChunk`].
+/// The trait exposes only time, which trace maintenance needs.
+/// Reading a chunk's contents is a separate, optional capability: see the [`cursor`] module.
 pub trait Chunk: Sized + Clone {
     /// The timestamp type of the chunk's updates.
     ///
-    /// Key/val/diff opinions live on the optional [`NavigableChunk`] capability; the chunk itself
-    /// only needs time, to bound its interval and participate in advancement and compaction.
+    /// Trace maintenance uses time to describe intervals and to advance and compact updates.
     type Time: Lattice + timely::progress::Timestamp;
 
     /// The intended maximum chunk size.
@@ -147,25 +129,6 @@ pub trait Chunk: Sized + Clone {
     /// [`pack`] helper, supplying their layout's coalesce / split / commit closures.
     fn settle(input: &mut VecDeque<Self>, done: bool, out: &mut VecDeque<Self>);
 
-}
-
-/// The navigation capability: a [`Chunk`] whose contents can be read by cursor.
-///
-/// This is optional. Batch formation and trace maintenance need only [`Chunk`];
-/// implementing this trait additionally lets [`ChunkBatch`] offer the straddle
-/// cursor ([`ChunkBatchCursor`]), which is how cursor-driven operator paths read
-/// an arrangement. Chunks consumed only by whole-chunk logic (tactics) can skip it.
-///
-/// `bounds` must stay cheap even when a chunk's body is paged out: the straddle
-/// cursor consults chunk bounds throughout navigation — seeks binary-search them,
-/// boundary crossings compare against them — and opens a chunk's body only when a
-/// query touches it.
-pub trait NavigableChunk: Chunk + Navigable<Cursor: Cursor<Time = <Self as Chunk>::Time>> {
-    /// The first and last `(key, val, time)` triples in the chunk.
-    fn bounds(&self) -> (
-        (<Self::Cursor as Cursor>::Key<'_>, <Self::Cursor as Cursor>::Val<'_>, <Self::Cursor as Cursor>::TimeGat<'_>),
-        (<Self::Cursor as Cursor>::Key<'_>, <Self::Cursor as Cursor>::Val<'_>, <Self::Cursor as Cursor>::TimeGat<'_>),
-    );
 }
 
 /// Maximal-packing driver an implementor's [`Chunk::settle`] may delegate to.
@@ -235,9 +198,6 @@ where
     }
 }
 
-type KeyCon<C> = <<C as Navigable>::Cursor as Cursor>::KeyContainer;
-type ValCon<C> = <<C as Navigable>::Cursor as Cursor>::ValContainer;
-
 /// A batch: an ordered [`Chunk`] sequence whose concatenation is its updates.
 pub struct ChunkBatch<C: Chunk> {
     /// Ordered, consolidated chunks; their concatenation is the batch.
@@ -251,13 +211,6 @@ impl<C: Chunk> ChunkBatch<C> {
             assert!(chunk.len() > 0, "ChunkBatch chunks must be non-empty");
         }
         ChunkBatch { chunks }
-    }
-}
-
-impl<C: NavigableChunk> crate::trace::Navigable for ChunkBatch<C> {
-    type Cursor = ChunkBatchCursor<C>;
-    fn cursor(&self) -> Self::Cursor {
-        ChunkBatchCursor { key_chunk: 0, chunk: 0, inner: self.chunks.first().map(C::cursor) }
     }
 }
 
@@ -284,191 +237,6 @@ pub type ChunkSpine<C> = crate::trace::implementations::spine_fueled::Spine<std:
 
 /// A [`ChunkBatch`] builder over chunks of type `C`, emitting `Rc`-shared updates.
 pub type ChunkBuilder<C> = ChunkBatchBuilder<C>;
-
-/// A cursor over a [`ChunkBatch`], merging the per-chunk cursors.
-///
-/// Chunk breakpoints are unconstrained, so a single key — or `(key, val)` — may
-/// straddle consecutive chunks. But the chunks are one globally-sorted sequence
-/// merely cut at arbitrary points, so the operation is *concatenation*, never a
-/// merge: across a boundary a key's vals concatenate and a `(key, val)`'s times
-/// concatenate. The cursor exploits this. It holds the chunk currently being read
-/// and a cursor into it; it seeks by galloping the chunks' resident
-/// [`bounds`](NavigableChunk::bounds) from a remembered hint (the current key's first
-/// chunk), and at boundaries it *continues* into the next chunk rather than merging —
-/// consulting the two neighbouring chunks' bounds to detect when a key or `(key, val)`
-/// spills forward, without touching chunk contents. No state is materialized up front:
-/// a monotone seek sweep costs `O(log Δ)` bounds reads per seek and a sequential pass two
-/// per boundary, so cursor construction is free.
-pub struct ChunkBatchCursor<C: NavigableChunk> {
-    /// First chunk of the current key's run; where `rewind_vals` returns to.
-    key_chunk: usize,
-    /// Chunk currently being read; `>= key_chunk`, within the current key's span.
-    chunk: usize,
-    /// Cursor into `chunk`; `None` once `chunk` is past the last chunk.
-    inner: Option<C::Cursor>,
-}
-
-impl<C: NavigableChunk> ChunkBatchCursor<C> {
-    /// Move the active chunk to `c`, opening a fresh inner cursor at its start.
-    fn goto(&mut self, c: usize, storage: &ChunkBatch<C>) {
-        self.chunk = c;
-        self.inner = storage.chunks.get(c).map(C::cursor);
-    }
-
-    /// Does key `k` span the boundary between chunks `c` and `c + 1` — chunk `c`
-    /// ends with it and chunk `c + 1` begins with it?
-    ///
-    /// Two resident [`bounds`](NavigableChunk::bounds) reads; the `reborrow`s
-    /// unify the (invariant) item lifetimes with `k`'s.
-    fn key_spills(s: &ChunkBatch<C>, c: usize, k: <C::Cursor as Cursor>::Key<'_>) -> bool {
-        <KeyCon<C> as BatchContainer>::reborrow(s.chunks[c].bounds().1.0) == <KeyCon<C> as BatchContainer>::reborrow(k)
-            && <KeyCon<C> as BatchContainer>::reborrow(s.chunks[c + 1].bounds().0.0) == <KeyCon<C> as BatchContainer>::reborrow(k)
-    }
-
-    /// Does `(k, v)` span the boundary between chunks `c` and `c + 1`?
-    fn val_spills(s: &ChunkBatch<C>, c: usize, k: <C::Cursor as Cursor>::Key<'_>, v: <C::Cursor as Cursor>::Val<'_>) -> bool {
-        Self::key_spills(s, c, k)
-            && <ValCon<C> as BatchContainer>::reborrow(s.chunks[c].bounds().1.1) == <ValCon<C> as BatchContainer>::reborrow(v)
-            && <ValCon<C> as BatchContainer>::reborrow(s.chunks[c + 1].bounds().0.1) == <ValCon<C> as BatchContainer>::reborrow(v)
-    }
-
-    /// The first chunk, at or after `hint`, whose last key is `>= key`: where `key`'s run
-    /// begins. `hint` — the current key's first chunk (`key_chunk`) — is a valid lower bound
-    /// for a forward seek; a backward seek is detected and served by a full search from the
-    /// front. Galloping keeps a monotone seek sweep at `O(log Δ)` bounds reads per seek rather
-    /// than `O(log chunks)`; only resident [`bounds`](NavigableChunk::bounds) are read.
-    fn locate_key(s: &ChunkBatch<C>, hint: usize, key: <C::Cursor as Cursor>::Key<'_>) -> usize {
-        let n = s.chunks.len();
-        // `last_key(i) < key`, from chunk `i`'s resident bounds.
-        let lt = |i: usize| <KeyCon<C> as BatchContainer>::reborrow(s.chunks[i].bounds().1.0)
-            .lt(&<KeyCon<C> as BatchContainer>::reborrow(key));
-        let hint = hint.min(n);
-        // The hint can skip the answer only on a backward seek; then search from the front.
-        let lo = if hint == 0 || lt(hint - 1) { hint } else { 0 };
-        if lo >= n || !lt(lo) { return lo; }
-        // Exponential search from `lo`, then binary within the final bracket.
-        let (mut prev, mut step) = (lo, 1usize);
-        while prev + step < n && lt(prev + step) { prev += step; step <<= 1; }
-        let (mut a, mut b) = (prev + 1, (prev + step).min(n));
-        while a < b { let m = a + (b - a) / 2; if lt(m) { a = m + 1; } else { b = m; } }
-        a
-    }
-}
-
-impl<C: NavigableChunk> Cursor for ChunkBatchCursor<C> {
-    type Storage = ChunkBatch<C>;
-
-    type KeyContainer = <C::Cursor as Cursor>::KeyContainer;
-    type Key<'a> = <C::Cursor as Cursor>::Key<'a>;
-    type ValContainer = <C::Cursor as Cursor>::ValContainer;
-    type Val<'a> = <C::Cursor as Cursor>::Val<'a>;
-    type ValOwn = <C::Cursor as Cursor>::ValOwn;
-    type TimeContainer = <C::Cursor as Cursor>::TimeContainer;
-    type TimeGat<'a> = <C::Cursor as Cursor>::TimeGat<'a>;
-    type Time = <C::Cursor as Cursor>::Time;
-    type DiffContainer = <C::Cursor as Cursor>::DiffContainer;
-    type DiffGat<'a> = <C::Cursor as Cursor>::DiffGat<'a>;
-    type Diff = <C::Cursor as Cursor>::Diff;
-
-    fn key_valid(&self, s: &Self::Storage) -> bool { self.chunk < s.chunks.len() && self.inner.as_ref().is_some_and(|i| i.key_valid(&s.chunks[self.chunk])) }
-    fn val_valid(&self, s: &Self::Storage) -> bool { self.chunk < s.chunks.len() && self.inner.as_ref().is_some_and(|i| i.val_valid(&s.chunks[self.chunk])) }
-    fn key<'a>(&self, s: &'a Self::Storage) -> Self::Key<'a> { self.inner.as_ref().unwrap().key(&s.chunks[self.chunk]) }
-    fn val<'a>(&self, s: &'a Self::Storage) -> Self::Val<'a> { self.inner.as_ref().unwrap().val(&s.chunks[self.chunk]) }
-    fn get_key<'a>(&self, s: &'a Self::Storage) -> Option<Self::Key<'a>> { if self.key_valid(s) { Some(self.key(s)) } else { None } }
-    fn get_val<'a>(&self, s: &'a Self::Storage) -> Option<Self::Val<'a>> { if self.val_valid(s) { Some(self.val(s)) } else { None } }
-
-    fn map_times<L: FnMut(Self::TimeGat<'_>, Self::DiffGat<'_>)>(&mut self, s: &Self::Storage, mut logic: L) {
-        if !self.val_valid(s) { return; }
-        let (k, v) = (self.key(s), self.val(s));
-        self.inner.as_mut().unwrap().map_times(&s.chunks[self.chunk], &mut logic);
-        // Follow the (key, val) forward across boundaries while it spills.
-        let mut c = self.chunk;
-        while c + 1 < s.chunks.len() && Self::val_spills(s, c, k, v) {
-            c += 1;
-            s.chunks[c].cursor().map_times(&s.chunks[c], &mut logic);
-        }
-    }
-
-    fn step_key(&mut self, s: &Self::Storage) {
-        if !self.key_valid(s) { return; }
-        let n = s.chunks.len();
-        let k = self.key(s);
-        // Advance to the last chunk the key spans.
-        while self.chunk + 1 < n && Self::key_spills(s, self.chunk, k) {
-            self.goto(self.chunk + 1, s);
-        }
-        // Step past the key within its last chunk.
-        {
-            let inner = self.inner.as_mut().unwrap();
-            inner.seek_key(&s.chunks[self.chunk], k);
-            inner.step_key(&s.chunks[self.chunk]);
-        }
-        // If that exhausted the chunk, the next key (if any) starts the next chunk.
-        if !self.inner.as_ref().unwrap().key_valid(&s.chunks[self.chunk]) && self.chunk + 1 < n {
-            self.goto(self.chunk + 1, s);
-        }
-        self.key_chunk = self.chunk;
-    }
-
-    fn seek_key(&mut self, s: &Self::Storage, key: Self::Key<'_>) {
-        let n = s.chunks.len();
-        // First chunk whose last key is `>= key`: where `key`'s run begins. Gallop from the
-        // current key's first chunk (`key_chunk`), a lower bound for forward seeks.
-        let lo = Self::locate_key(s, self.key_chunk, key);
-        self.goto(lo, s);
-        self.key_chunk = lo;
-        if lo < n { self.inner.as_mut().unwrap().seek_key(&s.chunks[lo], key); }
-    }
-
-    fn step_val(&mut self, s: &Self::Storage) {
-        if !self.val_valid(s) { return; }
-        let n = s.chunks.len();
-        let (k, v) = (self.key(s), self.val(s));
-        // Advance to the last chunk the (key, val) spans.
-        while self.chunk + 1 < n && Self::val_spills(s, self.chunk, k, v) {
-            self.goto(self.chunk + 1, s);
-        }
-        // Step past the (key, val) within that chunk.
-        self.inner.as_mut().unwrap().step_val(&s.chunks[self.chunk]);
-        // If the key's vals are exhausted here but the key spills, roll forward.
-        if !self.inner.as_ref().unwrap().val_valid(&s.chunks[self.chunk])
-            && self.chunk + 1 < n && Self::key_spills(s, self.chunk, k)
-        {
-            self.goto(self.chunk + 1, s);
-            self.inner.as_mut().unwrap().seek_key(&s.chunks[self.chunk], k);
-        }
-    }
-
-    fn seek_val(&mut self, s: &Self::Storage, val: Self::Val<'_>) {
-        if !self.key_valid(s) { return; }
-        let n = s.chunks.len();
-        let k = self.key(s);
-        loop {
-            self.inner.as_mut().unwrap().seek_val(&s.chunks[self.chunk], val);
-            if self.inner.as_ref().unwrap().val_valid(&s.chunks[self.chunk]) { return; }
-            // Key's vals exhausted in this chunk; if the key spills, retry in the next.
-            if self.chunk + 1 < n && Self::key_spills(s, self.chunk, k) {
-                self.goto(self.chunk + 1, s);
-                self.inner.as_mut().unwrap().seek_key(&s.chunks[self.chunk], k);
-            } else {
-                return;
-            }
-        }
-    }
-
-    fn rewind_keys(&mut self, s: &Self::Storage) {
-        self.key_chunk = 0;
-        self.goto(0, s);
-    }
-
-    fn rewind_vals(&mut self, s: &Self::Storage) {
-        if !self.key_valid(s) { return; }
-        let k = self.key(s);
-        let kc = self.key_chunk;
-        self.goto(kc, s);
-        self.inner.as_mut().unwrap().seek_key(&s.chunks[kc], k);
-    }
-}
 
 /// A merge-batcher [`Merger`](crate::batcher::merge::Merger)
 /// over chains of [`Chunk`]s.

--- a/differential-dataflow/src/trace/chunk/vec.rs
+++ b/differential-dataflow/src/trace/chunk/vec.rs
@@ -293,7 +293,7 @@ pub mod cursor {
     use crate::lattice::Lattice;
     use crate::trace::Navigable;
     use crate::trace::cursor::Cursor;
-    use crate::trace::implementations::{BatchContainer, Layout, Vector, WithLayout};
+    use crate::trace::implementations::{BatchContainer, Layout, Vector};
 
     use crate::trace::chunk::vec::VecChunk;
 
@@ -305,16 +305,6 @@ pub mod cursor {
         key_pos: usize,
         val_pos: usize,
         phantom: PhantomData<(K, V, T, R)>,
-    }
-
-    impl<K, V, T, R> WithLayout for VecChunk<K, V, T, R>
-    where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+Semigroup+'static {
-        type Layout = Vector<((K, V), T, R)>;
-    }
-
-    impl<K, V, T, R> WithLayout for VecChunkCursor<K, V, T, R>
-    where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+Semigroup+'static {
-        type Layout = Vector<((K, V), T, R)>;
     }
 
     impl<K, V, T, R> Cursor for VecChunkCursor<K, V, T, R>

--- a/differential-dataflow/src/trace/chunk/vec.rs
+++ b/differential-dataflow/src/trace/chunk/vec.rs
@@ -14,7 +14,6 @@
 //! copying them.
 
 use std::collections::VecDeque;
-use std::marker::PhantomData;
 use std::rc::Rc;
 
 use timely::Accountable;
@@ -25,9 +24,6 @@ use timely::progress::frontier::AntichainRef;
 use crate::consolidation::Consolidate;
 use crate::difference::Semigroup;
 use crate::lattice::Lattice;
-use crate::trace::Navigable;
-use crate::trace::cursor::Cursor;
-use crate::trace::implementations::{BatchContainer, Layout, Vector, WithLayout};
 
 use super::Chunk;
 
@@ -86,136 +82,14 @@ where K: Clone+'static, V: Clone+'static, T: Clone+'static, R: Clone+'static {
     fn push_into(&mut self, item: ((K, V), T, R)) { Rc::make_mut(&mut self.0).push(item); }
 }
 
-/// First index `>= start` at which `pred` turns false, by galloping (exponential)
-/// search. `pred` must hold for a prefix then not — i.e. `|u| u < target`.
-/// O(log distance), so O(1) for short hops and logarithmic for long ones.
-fn gallop<U>(s: &[U], start: usize, pred: impl Fn(&U) -> bool) -> usize {
-    let mut pos = start;
-    if pos < s.len() && pred(&s[pos]) {
-        let mut step = 1;
-        while pos + step < s.len() && pred(&s[pos + step]) { pos += step; step <<= 1; }
-        step >>= 1;
-        while step > 0 {
-            if pos + step < s.len() && pred(&s[pos + step]) { pos += step; }
-            step >>= 1;
-        }
-        pos += 1;
-    }
-    pos
-}
-
-/// A cursor over a [`VecChunk`], tracking the current key and `(key, val)`
-/// group starts as indices into the flat vector.
-pub struct VecChunkCursor<K, V, T, R> {
-    key_pos: usize,
-    val_pos: usize,
-    phantom: PhantomData<(K, V, T, R)>,
-}
-
-impl<K, V, T, R> WithLayout for VecChunk<K, V, T, R>
-where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+Semigroup+'static {
-    type Layout = Vector<((K, V), T, R)>;
-}
-
-impl<K, V, T, R> WithLayout for VecChunkCursor<K, V, T, R>
-where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+Semigroup+'static {
-    type Layout = Vector<((K, V), T, R)>;
-}
-
-impl<K, V, T, R> Cursor for VecChunkCursor<K, V, T, R>
-where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+Semigroup+'static {
-    type Storage = VecChunk<K, V, T, R>;
-
-    type KeyContainer = <Vector<((K, V), T, R)> as Layout>::KeyContainer;
-    type Key<'a> = <<Vector<((K, V), T, R)> as Layout>::KeyContainer as BatchContainer>::ReadItem<'a>;
-    type ValContainer = <Vector<((K, V), T, R)> as Layout>::ValContainer;
-    type Val<'a> = <<Vector<((K, V), T, R)> as Layout>::ValContainer as BatchContainer>::ReadItem<'a>;
-    type ValOwn = <<Vector<((K, V), T, R)> as Layout>::ValContainer as BatchContainer>::Owned;
-    type TimeContainer = <Vector<((K, V), T, R)> as Layout>::TimeContainer;
-    type TimeGat<'a> = <<Vector<((K, V), T, R)> as Layout>::TimeContainer as BatchContainer>::ReadItem<'a>;
-    type Time = <<Vector<((K, V), T, R)> as Layout>::TimeContainer as BatchContainer>::Owned;
-    type DiffContainer = <Vector<((K, V), T, R)> as Layout>::DiffContainer;
-    type DiffGat<'a> = <<Vector<((K, V), T, R)> as Layout>::DiffContainer as BatchContainer>::ReadItem<'a>;
-    type Diff = <<Vector<((K, V), T, R)> as Layout>::DiffContainer as BatchContainer>::Owned;
-
-    fn key_valid(&self, s: &Self::Storage) -> bool { self.key_pos < s.0.len() }
-    fn val_valid(&self, s: &Self::Storage) -> bool {
-        self.key_pos < s.0.len() && self.val_pos < s.0.len() && s.0[self.val_pos].0.0 == s.0[self.key_pos].0.0
-    }
-    fn key<'a>(&self, s: &'a Self::Storage) -> &'a K { &s.0[self.key_pos].0.0 }
-    fn val<'a>(&self, s: &'a Self::Storage) -> &'a V { &s.0[self.val_pos].0.1 }
-    fn get_key<'a>(&self, s: &'a Self::Storage) -> Option<&'a K> {
-        if self.key_valid(s) { Some(self.key(s)) } else { None }
-    }
-    fn get_val<'a>(&self, s: &'a Self::Storage) -> Option<&'a V> {
-        if self.val_valid(s) { Some(self.val(s)) } else { None }
-    }
-    fn map_times<L: FnMut(&T, &R)>(&mut self, s: &Self::Storage, mut logic: L) {
-        if !self.val_valid(s) { return; }
-        let kv = &s.0[self.val_pos].0;
-        let mut i = self.val_pos;
-        while i < s.0.len() && &s.0[i].0 == kv {
-            logic(&s.0[i].1, &s.0[i].2);
-            i += 1;
-        }
-    }
-    fn step_key(&mut self, s: &Self::Storage) {
-        // Linear: stepping is a short hop to the next group; an inlined scan
-        // beats a gallop call for the common small-group case.
-        if self.key_pos >= s.0.len() { return; }
-        let key = s.0[self.key_pos].0.0.clone();
-        let mut i = self.key_pos;
-        while i < s.0.len() && s.0[i].0.0 == key { i += 1; }
-        self.key_pos = i;
-        self.val_pos = i;
-    }
-    fn seek_key(&mut self, s: &Self::Storage, key: &K) {
-        // Logarithmic: O(log distance), independent of chunk size.
-        self.key_pos = gallop(&s.0, self.key_pos, |u| &u.0.0 < key);
-        self.val_pos = self.key_pos;
-    }
-    fn step_val(&mut self, s: &Self::Storage) {
-        if !self.val_valid(s) { return; }
-        let kv = s.0[self.val_pos].0.clone();
-        let mut i = self.val_pos;
-        while i < s.0.len() && s.0[i].0 == kv { i += 1; }
-        self.val_pos = i;
-    }
-    fn seek_val(&mut self, s: &Self::Storage, val: &V) {
-        if !self.key_valid(s) { return; }
-        let key = s.0[self.key_pos].0.0.clone();
-        self.val_pos = gallop(&s.0, self.val_pos, |u| (&u.0.0, &u.0.1) < (&key, val));
-    }
-    fn rewind_keys(&mut self, _s: &Self::Storage) { self.key_pos = 0; self.val_pos = 0; }
-    fn rewind_vals(&mut self, _s: &Self::Storage) { self.val_pos = self.key_pos; }
-}
-
 /// Take the `Vec` out of a chunk, copying only if the `Rc` is shared.
 fn take<K: Clone, V: Clone, T: Clone, R: Clone>(chunk: VecChunk<K, V, T, R>) -> Vec<((K, V), T, R)> {
     Rc::try_unwrap(chunk.0).unwrap_or_else(|rc| (*rc).clone())
 }
 
-impl<K, V, T, R> Navigable for VecChunk<K, V, T, R>
-where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+Semigroup+'static {
-    type Cursor = VecChunkCursor<K, V, T, R>;
-
-    fn cursor(&self) -> Self::Cursor {
-        VecChunkCursor { key_pos: 0, val_pos: 0, phantom: PhantomData }
-    }
-}
-
-impl<K, V, T, R> super::NavigableChunk for VecChunk<K, V, T, R>
-where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+Semigroup+'static {
-    fn bounds(&self) -> ((&K, &V, &T), (&K, &V, &T)) {
-        let s = &self.0[..];
-        let (f, l) = (&s[0], &s[s.len() - 1]);
-        ((&f.0.0, &f.0.1, &f.1), (&l.0.0, &l.0.1, &l.1))
-    }
-}
-
 impl<K, V, T, R> Chunk for VecChunk<K, V, T, R>
-where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+Semigroup+'static {
-    type Time = <<Vector<((K, V), T, R)> as Layout>::TimeContainer as BatchContainer>::Owned;
+where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Semigroup+'static {
+    type Time = T;
 
     const TARGET: usize = TARGET;
 
@@ -387,6 +261,146 @@ where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+S
             |chunk, n| { let mut rows = take(chunk); let rest = rows.split_off(n); (VecChunk(Rc::new(rows)), VecChunk(Rc::new(rest))) },
             |chunk| chunk,
         );
+    }
+}
+
+/// First index `>= start` at which `pred` turns false, by galloping (exponential)
+/// search. `pred` must hold for a prefix then not — i.e. `|u| u < target`.
+/// O(log distance), so O(1) for short hops and logarithmic for long ones.
+fn gallop<U>(s: &[U], start: usize, pred: impl Fn(&U) -> bool) -> usize {
+    let mut pos = start;
+    if pos < s.len() && pred(&s[pos]) {
+        let mut step = 1;
+        while pos + step < s.len() && pred(&s[pos + step]) { pos += step; step <<= 1; }
+        step >>= 1;
+        while step > 0 {
+            if pos + step < s.len() && pred(&s[pos + step]) { pos += step; }
+            step >>= 1;
+        }
+        pos += 1;
+    }
+    pos
+}
+
+/// Implementations specific to the `Cursor` trait.
+pub mod cursor {
+
+    use std::marker::PhantomData;
+
+    use timely::progress::Timestamp;
+
+    use crate::difference::Semigroup;
+    use crate::lattice::Lattice;
+    use crate::trace::Navigable;
+    use crate::trace::cursor::Cursor;
+    use crate::trace::implementations::{BatchContainer, Layout, Vector, WithLayout};
+
+    use crate::trace::chunk::vec::VecChunk;
+
+    use super::gallop;
+
+    /// A cursor over a [`VecChunk`], tracking the current key and `(key, val)`
+    /// group starts as indices into the flat vector.
+    pub struct VecChunkCursor<K, V, T, R> {
+        key_pos: usize,
+        val_pos: usize,
+        phantom: PhantomData<(K, V, T, R)>,
+    }
+
+    impl<K, V, T, R> WithLayout for VecChunk<K, V, T, R>
+    where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+Semigroup+'static {
+        type Layout = Vector<((K, V), T, R)>;
+    }
+
+    impl<K, V, T, R> WithLayout for VecChunkCursor<K, V, T, R>
+    where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+Semigroup+'static {
+        type Layout = Vector<((K, V), T, R)>;
+    }
+
+    impl<K, V, T, R> Cursor for VecChunkCursor<K, V, T, R>
+    where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+Semigroup+'static {
+        type Storage = VecChunk<K, V, T, R>;
+
+        type KeyContainer = <Vector<((K, V), T, R)> as Layout>::KeyContainer;
+        type Key<'a> = <<Vector<((K, V), T, R)> as Layout>::KeyContainer as BatchContainer>::ReadItem<'a>;
+        type ValContainer = <Vector<((K, V), T, R)> as Layout>::ValContainer;
+        type Val<'a> = <<Vector<((K, V), T, R)> as Layout>::ValContainer as BatchContainer>::ReadItem<'a>;
+        type ValOwn = <<Vector<((K, V), T, R)> as Layout>::ValContainer as BatchContainer>::Owned;
+        type TimeContainer = <Vector<((K, V), T, R)> as Layout>::TimeContainer;
+        type TimeGat<'a> = <<Vector<((K, V), T, R)> as Layout>::TimeContainer as BatchContainer>::ReadItem<'a>;
+        type Time = <<Vector<((K, V), T, R)> as Layout>::TimeContainer as BatchContainer>::Owned;
+        type DiffContainer = <Vector<((K, V), T, R)> as Layout>::DiffContainer;
+        type DiffGat<'a> = <<Vector<((K, V), T, R)> as Layout>::DiffContainer as BatchContainer>::ReadItem<'a>;
+        type Diff = <<Vector<((K, V), T, R)> as Layout>::DiffContainer as BatchContainer>::Owned;
+
+        fn key_valid(&self, s: &Self::Storage) -> bool { self.key_pos < s.0.len() }
+        fn val_valid(&self, s: &Self::Storage) -> bool {
+            self.key_pos < s.0.len() && self.val_pos < s.0.len() && s.0[self.val_pos].0.0 == s.0[self.key_pos].0.0
+        }
+        fn key<'a>(&self, s: &'a Self::Storage) -> &'a K { &s.0[self.key_pos].0.0 }
+        fn val<'a>(&self, s: &'a Self::Storage) -> &'a V { &s.0[self.val_pos].0.1 }
+        fn get_key<'a>(&self, s: &'a Self::Storage) -> Option<&'a K> {
+            if self.key_valid(s) { Some(self.key(s)) } else { None }
+        }
+        fn get_val<'a>(&self, s: &'a Self::Storage) -> Option<&'a V> {
+            if self.val_valid(s) { Some(self.val(s)) } else { None }
+        }
+        fn map_times<L: FnMut(&T, &R)>(&mut self, s: &Self::Storage, mut logic: L) {
+            if !self.val_valid(s) { return; }
+            let kv = &s.0[self.val_pos].0;
+            let mut i = self.val_pos;
+            while i < s.0.len() && &s.0[i].0 == kv {
+                logic(&s.0[i].1, &s.0[i].2);
+                i += 1;
+            }
+        }
+        fn step_key(&mut self, s: &Self::Storage) {
+            // Linear: stepping is a short hop to the next group; an inlined scan
+            // beats a gallop call for the common small-group case.
+            if self.key_pos >= s.0.len() { return; }
+            let key = s.0[self.key_pos].0.0.clone();
+            let mut i = self.key_pos;
+            while i < s.0.len() && s.0[i].0.0 == key { i += 1; }
+            self.key_pos = i;
+            self.val_pos = i;
+        }
+        fn seek_key(&mut self, s: &Self::Storage, key: &K) {
+            // Logarithmic: O(log distance), independent of chunk size.
+            self.key_pos = gallop(&s.0, self.key_pos, |u| &u.0.0 < key);
+            self.val_pos = self.key_pos;
+        }
+        fn step_val(&mut self, s: &Self::Storage) {
+            if !self.val_valid(s) { return; }
+            let kv = s.0[self.val_pos].0.clone();
+            let mut i = self.val_pos;
+            while i < s.0.len() && s.0[i].0 == kv { i += 1; }
+            self.val_pos = i;
+        }
+        fn seek_val(&mut self, s: &Self::Storage, val: &V) {
+            if !self.key_valid(s) { return; }
+            let key = s.0[self.key_pos].0.0.clone();
+            self.val_pos = gallop(&s.0, self.val_pos, |u| (&u.0.0, &u.0.1) < (&key, val));
+        }
+        fn rewind_keys(&mut self, _s: &Self::Storage) { self.key_pos = 0; self.val_pos = 0; }
+        fn rewind_vals(&mut self, _s: &Self::Storage) { self.val_pos = self.key_pos; }
+    }
+
+    impl<K, V, T, R> Navigable for VecChunk<K, V, T, R>
+    where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+Semigroup+'static {
+        type Cursor = VecChunkCursor<K, V, T, R>;
+
+        fn cursor(&self) -> Self::Cursor {
+            VecChunkCursor { key_pos: 0, val_pos: 0, phantom: PhantomData }
+        }
+    }
+
+    impl<K, V, T, R> crate::trace::chunk::NavigableChunk for VecChunk<K, V, T, R>
+    where K: Ord+Clone+'static, V: Ord+Clone+'static, T: Lattice+Timestamp, R: Ord+Semigroup+'static {
+        fn bounds(&self) -> ((&K, &V, &T), (&K, &V, &T)) {
+            let s = &self.0[..];
+            let (f, l) = (&s[0], &s[s.len() - 1]);
+            ((&f.0.0, &f.0.1, &f.1), (&l.0.0, &l.0.1, &l.1))
+        }
     }
 }
 

--- a/differential-dataflow/src/trace/implementations/mod.rs
+++ b/differential-dataflow/src/trace/implementations/mod.rs
@@ -99,13 +99,6 @@ pub trait Layout {
     type OffsetContainer: for<'a> BatchContainer<ReadItem<'a> = usize>;
 }
 
-/// A type bearing a layout.
-pub trait WithLayout {
-    /// The layout.
-    type Layout: Layout;
-}
-
-
 // An easy way to provide an explicit layout: as a 5-tuple.
 // Valuable when one wants to perform layout surgery.
 impl<KC, VC, TC, DC, OC> Layout for (KC, VC, TC, DC, OC)

--- a/differential-dataflow/src/trace/implementations/ord_neu.rs
+++ b/differential-dataflow/src/trace/implementations/ord_neu.rs
@@ -295,10 +295,6 @@ pub mod val_batch {
         pub updates: usize,
     }
 
-    impl<L: Layout> WithLayout for OrdValBatch<L> {
-        type Layout = L;
-    }
-
     impl<L: Layout> crate::trace::Navigable for OrdValBatch<L> {
         type Cursor = OrdValCursor<L>;
         fn cursor(&self) -> Self::Cursor {
@@ -532,11 +528,6 @@ pub mod val_batch {
         val_cursor: usize,
         /// Phantom marker for Rust happiness.
         phantom: PhantomData<L>,
-    }
-
-    use crate::trace::implementations::WithLayout;
-    impl<L: Layout> WithLayout for OrdValCursor<L> {
-        type Layout = L;
     }
 
     impl<L: Layout> Cursor for OrdValCursor<L> {
@@ -782,10 +773,6 @@ pub mod key_batch {
         }
     }
 
-    impl<L: Layout<ValContainer: BatchContainer<Owned: Default>>> WithLayout for OrdKeyBatch<L> {
-        type Layout = L;
-    }
-
     impl<L: Layout<ValContainer: BatchContainer<Owned: Default>>> crate::trace::Navigable for OrdKeyBatch<L> {
         type Cursor = OrdKeyCursor<L>;
         fn cursor(&self) -> Self::Cursor {
@@ -943,11 +930,6 @@ pub mod key_batch {
         val_stepped: bool,
         /// Phantom marker for Rust happiness.
         phantom: PhantomData<L>,
-    }
-
-    use crate::trace::implementations::WithLayout;
-    impl<L: Layout<ValContainer: BatchContainer>> WithLayout for OrdKeyCursor<L> {
-        type Layout = L;
     }
 
     impl<L: for<'a> Layout<ValContainer: BatchContainer<Owned: Default>>> Cursor for OrdKeyCursor<L> {

--- a/differential-dataflow/tests/int_proxy_bench.rs
+++ b/differential-dataflow/tests/int_proxy_bench.rs
@@ -34,8 +34,8 @@ use differential_dataflow::operators::iterate::Iterate;
 use differential_dataflow::operators::reduce::reduce_with_tactic;
 use differential_dataflow::trace::chunk::vec::{
     ChunkBatcher as VChunkBatcher, ChunkBuilder as VChunkBuilder, ChunkSpine as VChunkSpine,
-    VecChunkCursor,
 };
+use differential_dataflow::trace::chunk::vec::cursor::VecChunkCursor;
 use differential_dataflow::trace::cursor::Cursor;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]


### PR DESCRIPTION
Some tidying around how cursors are used in other implementations, with the goal of making the boundary clearer and less porous. Also removes the `WithLayout` trait, which had implementations but no consumers.