### PR TITLE
Reduce repeated work in Corgi and server batch processing

### DIFF
--- a/interactive/server/src/main.rs
+++ b/interactive/server/src/main.rs
@@ -187,7 +187,8 @@ where
 {
     match TcpListener::bind(bind) {
         Ok(listener) => {
-            eprintln!("ddir_server: {} listening on {}", label, bind);
+            let address = listener.local_addr().expect("bound listener has an address");
+            eprintln!("ddir_server: {} listening on {}", label, address);
             let session = Arc::new(session);
             Some(std::thread::spawn(move || {
                 for incoming in listener.incoming() {

--- a/interactive/server/tests/multiworker.rs
+++ b/interactive/server/tests/multiworker.rs
@@ -1,20 +1,24 @@
 use std::io::{BufRead, BufReader, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::TcpStream;
 use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::sync_channel;
 use std::thread;
 use std::time::{Duration, Instant};
 
-struct ServerProcess(Child);
+struct ServerProcess {
+    child: Child,
+    stderr: Option<thread::JoinHandle<String>>,
+}
 
 impl ServerProcess {
     fn stop(mut self) {
-        let stdin = self.0.stdin.as_mut().expect("server stdin is piped");
+        let stdin = self.child.stdin.as_mut().expect("server stdin is piped");
         stdin.write_all(b"exit\n").unwrap();
         stdin.flush().unwrap();
 
         let deadline = Instant::now() + Duration::from_secs(10);
         loop {
-            if let Some(status) = self.0.try_wait().unwrap() {
+            if let Some(status) = self.child.try_wait().unwrap() {
                 assert!(status.success(), "server exited with {status}");
                 return;
             }
@@ -26,9 +30,17 @@ impl ServerProcess {
 
 impl Drop for ServerProcess {
     fn drop(&mut self) {
-        if self.0.try_wait().ok().flatten().is_none() {
-            let _ = self.0.kill();
-            let _ = self.0.wait();
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+        if let Some(stderr) = self.stderr.take() {
+            let output = stderr
+                .join()
+                .unwrap_or_else(|_| "stderr reader panicked".to_string());
+            if thread::panicking() {
+                eprintln!("server stderr:\n{output}");
+            }
         }
     }
 }
@@ -55,7 +67,9 @@ fn request_observing(
     loop {
         let mut line = String::new();
         assert_ne!(
-            reader.read_line(&mut line).unwrap(),
+            reader
+                .read_line(&mut line)
+                .unwrap_or_else(|error| panic!("request {reqid}: {error}")),
             0,
             "server disconnected"
         );
@@ -78,41 +92,50 @@ fn request_observing(
 }
 
 fn start_server(backend: &str, workers: usize) -> (ServerProcess, TcpStream, BufReader<TcpStream>) {
-    let listeners: Vec<_> = (0..3)
-        .map(|_| TcpListener::bind("127.0.0.1:0").unwrap())
-        .collect();
-    let ports: Vec<_> = listeners
-        .iter()
-        .map(|listener| listener.local_addr().unwrap().port())
-        .collect();
-    drop(listeners);
-
-    let child = Command::new(env!("CARGO_BIN_EXE_ddir_server"))
+    let mut child = Command::new(env!("CARGO_BIN_EXE_ddir_server"))
         .env("DDIR_WORKERS", workers.to_string())
         .env("DDIR_BACKEND", backend)
         // The retired polling/tick knob must not reintroduce wall-clock
         // progress if it remains in an old deployment environment.
         .env("DDIR_TICK_MS", "1")
-        .env("DDIR_BIND", format!("127.0.0.1:{}", ports[0]))
-        .env("DDIR_WS_BIND", format!("127.0.0.1:{}", ports[1]))
-        .env("DDIR_DIAG_PORT", ports[2].to_string())
+        // The child owns these ephemeral ports from bind through shutdown.
+        // Probing a free port and dropping its listener races other tests.
+        .env("DDIR_BIND", "127.0.0.1:0")
+        .env("DDIR_WS_BIND", "127.0.0.1:0")
+        .env("DDIR_DIAG_PORT", "0")
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()
         .unwrap();
-    let server = ServerProcess(child);
-
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let stream = loop {
-        match TcpStream::connect(("127.0.0.1", ports[0])) {
-            Ok(stream) => break stream,
-            Err(error) => {
-                assert!(Instant::now() < deadline, "server did not listen: {error}");
-                thread::sleep(Duration::from_millis(10));
+    let stderr = child.stderr.take().expect("server stderr is piped");
+    let (ready_tx, ready_rx) = sync_channel(1);
+    let stderr = thread::spawn(move || {
+        let mut output = String::new();
+        for line in BufReader::new(stderr).lines() {
+            let line = match line {
+                Ok(line) => line,
+                Err(error) => {
+                    output.push_str(&format!("reading server stderr failed: {error}\n"));
+                    break;
+                }
+            };
+            if let Some(address) = line.strip_prefix("ddir_server: tcp listening on ") {
+                let _ = ready_tx.send(address.to_string());
             }
+            output.push_str(&line);
+            output.push('\n');
         }
+        output
+    });
+    let server = ServerProcess {
+        child,
+        stderr: Some(stderr),
     };
+    let address = ready_rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("server did not announce its TCP listener");
+    let stream = TcpStream::connect(address).expect("connect to server's bound TCP listener");
     stream
         .set_read_timeout(Some(Duration::from_secs(10)))
         .unwrap();

--- a/interactive/src/corgi/chunk.rs
+++ b/interactive/src/corgi/chunk.rs
@@ -410,13 +410,15 @@ where
 
     // Walk maximal equal-`(key,val)` runs; within each, order by time and consolidate equal times.
     let (mut keep, mut ot, mut od) = (Vec::new(), Vec::new(), Vec::new());
+    let mut run = Vec::new();
     let mut i = 0;
     while i < n {
         let mut j = i + 1;
         while j < n && adj[j - 1] == 0 {
             j += 1;
         }
-        let mut run: Vec<usize> = (i..j).collect();
+        run.clear();
+        run.extend(i..j);
         run.sort_by(|&a, &b| times_s[a].cmp(&times_s[b]));
         let mut k = 0;
         while k < run.len() {

--- a/interactive/src/corgi/col_times.rs
+++ b/interactive/src/corgi/col_times.rs
@@ -17,7 +17,7 @@
 
 use std::cmp::Ordering;
 
-use columnar::{Borrow, Clear, Columnar, Index, Len, Push};
+use columnar::{Borrow, Clear, Columnar, Container, Index, Len, Push};
 
 use differential_dataflow::lattice::Lattice;
 use timely::progress::Timestamp;
@@ -98,14 +98,12 @@ impl<T: Columnar> ColTimes<T> {
         <T as Columnar>::into_owned(self.store.borrow().get(i))
     }
 
-    /// Append rows `[s, e)` of `other`, pushing `Ref`s straight across — no `T` materialized. The
-    /// range copy used by `emit`/`concat`/merge-suffix.
+    /// Append rows `[s, e)` of `other` using the container's bulk range copy.
+    /// Primitive lanes copy as slices, and nested-vector offsets are rebased
+    /// without reconstructing timestamps or pushing each row separately.
     #[inline]
     pub fn push_range(&mut self, other: &ColTimes<T>, s: usize, e: usize) {
-        let b = other.store.borrow();
-        for i in s..e {
-            self.store.push(b.get(i));
-        }
+        self.store.extend_from_self(other.store.borrow(), s..e);
     }
 
     /// Materialize the whole column to `Vec<T>` — the egress boundary (owned times for
@@ -158,6 +156,22 @@ mod cmp_agreement_tests {
 
     fn t(outer: u64, coords: &[u64]) -> T {
         Product::new(outer, PointStamp::new(coords.iter().copied().collect()))
+    }
+
+    #[test]
+    fn range_copy_rebases_variable_length_timestamps() {
+        let values = vec![t(0, &[]), t(1, &[2]), t(2, &[3, 4]), t(3, &[]), t(4, &[5, 6, 7])];
+        let source: ColTimes<T> = values.iter().cloned().collect();
+        let mut copy: ColTimes<T> = std::iter::once(t(9, &[8, 7])).collect();
+        copy.push_range(&source, 1, 4);
+        copy.push_range(&source, 2, 2);
+        copy.push_range(&source, 0, 5);
+        let expected: Vec<_> = std::iter::once(t(9, &[8, 7]))
+            .chain(values[1..4].iter().cloned()).chain(values.iter().cloned()).collect();
+        assert_eq!(copy.to_vec(), expected);
+        copy.clear();
+        copy.push_range(&source, 4, 5);
+        assert_eq!(copy.to_vec(), values[4..5]);
     }
 
     /// `ColTime::cmp_refs` (the derived `Ord` on the columnar `Ref`) must agree with the

--- a/interactive/src/corgi/container.rs
+++ b/interactive/src/corgi/container.rs
@@ -62,10 +62,15 @@ impl<T: Clone + 'static, R: Clone + 'static> CorgiContainer<T, R> {
     /// boundary** transcode (once per batch). The only rows→columns conversion in the corgi
     /// backend: inside the dataflow every operator is columnar.
     pub fn from_updates(updates: Vec<((Row, Row), T, R)>, kshape: &corgi::Shape, vshape: &corgi::Shape) -> Self {
-        let keys_rows: Vec<DValue> = updates.iter().map(|u| u.0 .0.clone()).collect();
-        let vals_rows: Vec<DValue> = updates.iter().map(|u| u.0 .1.clone()).collect();
-        let times = updates.iter().map(|u| u.1.clone()).collect();
-        let diffs = updates.iter().map(|u| u.2.clone()).collect();
+        let len = updates.len();
+        let (mut keys_rows, mut vals_rows) = (Vec::with_capacity(len), Vec::with_capacity(len));
+        let (mut times, mut diffs) = (Vec::with_capacity(len), Vec::with_capacity(len));
+        for ((key, val), time, diff) in updates {
+            keys_rows.push(key);
+            vals_rows.push(val);
+            times.push(time);
+            diffs.push(diff);
+        }
         CorgiContainer { keys: transcode(&keys_rows, kshape), vals: transcode(&vals_rows, vshape), times, diffs }
     }
 

--- a/interactive/src/corgi/reduce.rs
+++ b/interactive/src/corgi/reduce.rs
@@ -387,12 +387,15 @@ fn merge_present<T: Ord + Clone>(
         heap.push(Reverse(((khs[lo], vids[lo]), &times[lo], run, lo)));
         lo = hi;
     }
-    while let Some(Reverse((kv, time, run, index))) = heap.pop() {
+    while let Some(mut head) = heap.peek_mut() {
+        let Reverse((kv, time, run, index)) = *head;
         accumulate(kv, time, diffs[index]);
         let end = run_ends[run];
         if index + 1 < end {
             let next = index + 1;
-            heap.push(Reverse(((khs[next], vids[next]), &times[next], run, next)));
+            *head = Reverse(((khs[next], vids[next]), &times[next], run, next));
+        } else {
+            std::collections::binary_heap::PeekMut::pop(head);
         }
     }
     drop(accumulate);
@@ -786,6 +789,43 @@ mod tests {
             &keys, &vals, &[1, 2], &[10, 20], &[0u64, 0], &[1, 1], &[2], &mut bridge,
         ));
         assert_eq!(bridge.len(), 2);
+    }
+
+    #[test]
+    fn merge_present_combines_runs_with_ties_cancellation_and_different_lengths() {
+        use std::collections::BTreeMap;
+        use timely::order::Product;
+        let runs = [
+            vec![((1, 10), Product::new(0u64, 2u64), 1),
+                 ((1, 10), Product::new(1, 0), -1),
+                 ((3, 30), Product::new(0, 0), 2)],
+            vec![((1, 10), Product::new(0, 2), -1),
+                 ((1, 11), Product::new(0, 0), 5),
+                 ((3, 30), Product::new(0, 0), -2),
+                 ((4, 40), Product::new(0, 0), -1)],
+            vec![((1, 10), Product::new(1, 0), 2)],
+        ];
+        for count in 1..=runs.len() {
+            let (mut rows, mut ends) = (Vec::new(), Vec::new());
+            let mut expected = BTreeMap::new();
+            for run in &runs[..count] {
+                rows.extend_from_slice(run);
+                ends.push(rows.len());
+                for &(kv, time, diff) in run {
+                    *expected.entry((kv, time)).or_insert(0) += diff;
+                }
+            }
+            let khs: Vec<_> = rows.iter().map(|r| r.0.0).collect();
+            let vids: Vec<_> = rows.iter().map(|r| r.0.1).collect();
+            let times: Vec<_> = rows.iter().map(|r| r.1).collect();
+            let diffs: Vec<_> = rows.iter().map(|r| r.2).collect();
+            let mut bridge = Vec::new();
+            assert!(merge_present(&CValue::u64(khs.clone()), &CValue::u64(vids.clone()),
+                &khs, &vids, &times, &diffs, &ends, &mut bridge));
+            let expected: Vec<_> = expected.into_iter().filter(|(_, d)| *d != 0)
+                .map(|((kv, time), diff)| (kv, time, diff)).collect();
+            assert_eq!(bridge, expected, "run count: {count}");
+        }
     }
 
     #[test]

--- a/interactive/src/server.rs
+++ b/interactive/src/server.rs
@@ -699,15 +699,14 @@ impl Server {
     ) -> Result<(), String> {
         let time = self.epoch;
         self.validate_feed(prog, input, time)?;
+        let handle = self.programs
+            .get_mut(&canonical_source_name(prog))
+            .expect("feed target was prevalidated")
+            .inputs
+            .get_mut(&input)
+            .expect("feed input was prevalidated");
         for update in updates {
-            self.apply_feed(
-                prog,
-                input,
-                update.key,
-                update.val,
-                time,
-                update.diff,
-            );
+            handle.update_at((update.key, update.val), time, update.diff);
         }
         Ok(())
     }


### PR DESCRIPTION
Batch processing repeats allocations, field copies, and lookups inside row/group loops. Five independent commits remove that work from the existing general paths:

- Copy timestamp ranges with columnar bulk operations.
- Reuse timestamp sort indices across key/value groups.
- Resolve the server input handle once per feed batch.
- Move consumed ingress fields into buffers.
- Repair the reducer merge heap once per run advance.

Runtime diff: +29/-22 lines; regression tests: +53 lines. Tests cover variable-length timestamp copies and multi-run merging with ties, cancellation, and product timestamps.

Each change passed standalone checks on master-next. The combined `cargo test --locked -p interactive -p ddir-server -- --test-threads=1` passed 121 tests, with five existing tests ignored. Cross-backend fixtures include 1-4 workers and serializing channels. `git diff --check` passes.
