### PR TITLE
Match sorted Corgi identifier ranges monotonically

### DIFF
--- a/interactive/src/corgi/join.rs
+++ b/interactive/src/corgi/join.rs
@@ -35,7 +35,8 @@ use differential_dataflow::operators::int_proxy::{JoinInstance, ProxyBridge, Pro
 use differential_dataflow::operators::int_proxy::join::JoinMatches;
 use differential_dataflow::trace::chunk::{Chunk, ChunkBatch};
 
-use corgi::arrange::{compare_at, find_ranges, gather, gather_lanes};
+use corgi::arrange::{compare_at, gather, gather_lanes};
+use crate::corgi::search::MatchingRanges;
 use corgi::{shape_of_value, Shape, Value as CValue};
 
 use crate::corgi::chunk::{key_is_hashed, key_lane, recover_key, CorgiChunk};
@@ -459,7 +460,7 @@ impl<'a, T: ColTime> LeafView<'a, T> {
 }
 
 /// The batched probe of one PROBEE-side chunk: per driver key, its equal-range in the
-/// chunk (`find_ranges`), with the matched rows' vals gathered once as a `u64` buffer
+/// chunk, with the matched rows' vals gathered once as a `u64` buffer
 /// when leaf-shaped (`off` gives each key's slice within it).
 struct Probe<'a, T: ColTime> {
     chunk: &'a CorgiChunk<T, Diff>,
@@ -471,8 +472,13 @@ struct Probe<'a, T: ColTime> {
 }
 
 impl<'a, T: ColTime> Probe<'a, T> {
-    fn new(chunk: &'a CorgiChunk<T, Diff>, cid: usize, needles: &CValue, leaf_vals: bool) -> Self {
-        let (lo, hi) = find_ranges(needles, key_lane(chunk.keys()));
+    fn new(chunk: &'a CorgiChunk<T, Diff>, cid: usize, needles: &[u64], leaf_vals: bool) -> Self {
+        let keys = corgi::arrange::leaf_slice(key_lane(chunk.keys())).expect("identifier lane is a u64 leaf");
+        let (mut lo, mut hi) = (vec![0; needles.len()], vec![0; needles.len()]);
+        for (j, range) in MatchingRanges::new(needles, keys) {
+            lo[j] = range.start;
+            hi[j] = range.end;
+        }
         let mut off = Vec::with_capacity(lo.len() + 1);
         let mut idx: Vec<usize> = Vec::new();
         off.push(0);
@@ -576,7 +582,7 @@ fn stage_collision<T: ColTime>(
 ///
 /// Two regimes: when one side is much smaller (the fresh delta against an accumulated
 /// trace), the small side DRIVES and the large side is presented only at the driver's keys
-/// (batched `find_ranges` — cost tracks the driver plus matches). When the sides are
+/// (sorted probes — cost tracks the driver plus matches). When the sides are
 /// comparable, probing costs `n log n` against a merge's `n`, so both sides are pulled and
 /// merged symmetrically instead.
 fn advance_leaf<T: ColTime>(
@@ -628,7 +634,7 @@ fn advance_leaf<T: ColTime>(
 }
 
 /// Lopsided regime: the driver views are walked; the probee is presented only at the
-/// driver's keys, one batched `find_ranges` per probee chunk per block.
+/// driver's sorted keys, one monotone search per probee chunk per block.
 fn leaf_probe<'a, T: ColTime>(
     mut dviews: Vec<LeafView<'a, T>>,
     pchunks: &[&CorgiChunk<T, Diff>],
@@ -665,7 +671,7 @@ fn leaf_probe<'a, T: ColTime>(
     let pvleaf = leaf_valued(pchunks);
     let probes: Vec<Probe<T>> = pchunks.iter().enumerate()
         .filter(|(_, c)| c.len() > 0)
-        .map(|(cid, c)| Probe::new(c, cid, &CValue::u64(keyset.clone()), pvleaf))
+        .map(|(cid, c)| Probe::new(c, cid, &keyset, pvleaf))
         .collect();
 
     // Walk the keys in order, staging both sides and emitting the survivors.

--- a/interactive/src/corgi/mod.rs
+++ b/interactive/src/corgi/mod.rs
@@ -13,3 +13,4 @@ pub mod exchange;
 pub mod join;
 pub mod logic;
 pub mod reduce;
+mod search;

--- a/interactive/src/corgi/reduce.rs
+++ b/interactive/src/corgi/reduce.rs
@@ -34,10 +34,11 @@ use differential_dataflow::trace::chunk::ChunkBatch;
 use differential_dataflow::operators::int_proxy::ProxyBridge;
 use differential_dataflow::operators::int_proxy::reduce::{ProxyReduceBackend, ReduceInstance, ReduceWindow};
 
-use corgi::arrange::{compare_at, find_ranges, gather, gather_lanes, sort_blocks};
+use corgi::arrange::{compare_at, gather, gather_lanes, sort_blocks};
 use corgi::{ArithOp, Bounds, NumOp, OpLike, Value as CValue};
 
 use crate::corgi::col_times::ColTime;
+use crate::corgi::search::MatchingRanges;
 use crate::corgi::chunk::{columns_to_batch, key_ids, key_lane, CorgiChunk};
 use crate::ir::Diff;
 use crate::parse::Reducer;
@@ -247,65 +248,32 @@ fn ids(col: &CValue) -> Vec<u64> {
 /// `(keys_col, vals_col)` corgi columns plus per-record `(key_hash, time, diff)`. `changed` is the
 /// ASCENDING set of changed key ids; a row is kept iff its key id is in it.
 ///
-/// Seek or scan, decided per retire now that the sizes are known: seeking the changed keys wins
-/// when the changed set is narrow (the steady incremental case), and a flat membership scan wins
-/// for broad churn — loads and label-cascade retires, where most keys change and a gallop per key
-/// only adds overhead.
-///
-/// What the stored identifier changed is that BOTH branches are now available, and cheap, for every
-/// key shape. An arrangement's key leads with its identifier and is sorted by it
-/// ([`present_key`](crate::corgi::chunk::present_key)), so [`key_lane`] is a sorted `u64` leaf: the
-/// seek is `find_ranges` over it (corgi's `u64` fast path) and the scan borrows it outright, with no
-/// hashing and no allocation on either side. Previously a structural key could do neither — its
-/// identifier was hashed per chunk per retire, and a hash derived on the fly cannot be inverted into
-/// a needle, so those keys were forced onto the scan and forced to materialize to take it.
+/// Both the changed set and stored identifier lane are sorted. Match them with
+/// monotone positions, galloping over long gaps and stepping through adjacent
+/// keys. The same compiled search covers narrow updates and broad cascades.
 fn collect_present<T>(chunks: &[&CorgiChunk<T, Diff>], changed: &[u64]) -> (CValue, CValue, Vec<u64>, Vec<T>, Vec<Diff>, Vec<usize>)
 where
     T: ColTime,
 {
-    /// Seek only when the changed set is at least this many times narrower than the presented
-    /// rows: a `find_ranges` probe costs ~log(rows) compares against the scan's flat membership
-    /// test, so marginal seeks LOSE — measured, not modeled; 16 regressed load-shaped retires
-    /// before this was widened.
-    const SEEK_ADVANTAGE: usize = 64;
-
     let key_srcs: Vec<Option<&CValue>> = chunks.iter().map(|c| Some(c.keys())).collect();
     let val_srcs: Vec<Option<&CValue>> = chunks.iter().map(|c| Some(c.vals())).collect();
     let (mut tags, mut offs) = (Vec::new(), Vec::new());
     let (mut khs, mut times, mut diffs) = (Vec::new(), Vec::new(), Vec::new());
     let mut run_ends = Vec::new();
-    let total: usize = chunks.iter().map(|c| c.diffs().len()).sum();
-    let seek = changed.len().saturating_mul(SEEK_ADVANTAGE) < total;
-    let needles = CValue::u64(changed.to_vec());
-    // Chunks are id-ordered and `changed` ascends, so either branch emits in merged order.
     for (ci, ch) in chunks.iter().enumerate() {
         let before = khs.len();
         if ch.diffs().is_empty() {
             continue;
         }
         let lane = key_lane(ch.keys());
-        if seek {
-            let (lo, hi) = find_ranges(&needles, lane);
-            for (j, (&l, &h)) in lo.iter().zip(hi.iter()).enumerate() {
-                for i in l..h {
-                    tags.push(ci);
-                    offs.push(i);
-                    khs.push(changed[j]);
-                    times.push(ch.times().get(i));
-                    diffs.push(ch.diffs()[i]);
-                }
-            }
-        } else {
-            // Borrowed, never materialized: the identifier lane is a `u64` leaf whatever the key.
-            let kh = corgi::arrange::leaf_slice(lane).expect("the identifier lane is a u64 leaf");
-            for i in 0..kh.len() {
-                if changed.binary_search(&kh[i]).is_ok() {
-                    tags.push(ci);
-                    offs.push(i);
-                    khs.push(kh[i]);
-                    times.push(ch.times().get(i));
-                    diffs.push(ch.diffs()[i]);
-                }
+        let kh = corgi::arrange::leaf_slice(lane).expect("the identifier lane is a u64 leaf");
+        for (j, range) in MatchingRanges::new(changed, kh) {
+            for i in range {
+                tags.push(ci);
+                offs.push(i);
+                khs.push(changed[j]);
+                times.push(ch.times().get(i));
+                diffs.push(ch.diffs()[i]);
             }
         }
         if khs.len() > before { run_ends.push(khs.len()); }

--- a/interactive/src/corgi/search.rs
+++ b/interactive/src/corgi/search.rs
@@ -1,0 +1,114 @@
+//! Match sorted key sets without restarting a binary search for every key.
+
+use std::ops::Range;
+
+/// Matching ranges in a sorted identifier lane, indexed by a sorted, unique
+/// needle set. Both positions advance monotonically; galloping skips long gaps
+/// while adjacent keys take constant work. Absent keys produce no item.
+pub(crate) struct MatchingRanges<'a> {
+    needles: &'a [u64],
+    haystack: &'a [u64],
+    needle: usize,
+    row: usize,
+}
+
+impl<'a> MatchingRanges<'a> {
+    pub(crate) fn new(needles: &'a [u64], haystack: &'a [u64]) -> Self {
+        debug_assert!(needles.windows(2).all(|w| w[0] < w[1]));
+        debug_assert!(haystack.windows(2).all(|w| w[0] <= w[1]));
+        Self {
+            needles,
+            haystack,
+            needle: 0,
+            row: 0,
+        }
+    }
+}
+
+impl Iterator for MatchingRanges<'_> {
+    type Item = (usize, Range<usize>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let (Some(&needle), Some(&key)) =
+            (self.needles.get(self.needle), self.haystack.get(self.row))
+        {
+            match key.cmp(&needle) {
+                std::cmp::Ordering::Less => {
+                    self.row = gallop(self.haystack, self.row + 1, |x| *x < needle);
+                }
+                std::cmp::Ordering::Greater => {
+                    self.needle = gallop(self.needles, self.needle + 1, |x| *x < key);
+                }
+                std::cmp::Ordering::Equal => {
+                    let start = self.row;
+                    self.row = gallop(self.haystack, start + 1, |x| *x == key);
+                    let index = self.needle;
+                    self.needle += 1;
+                    return Some((index, start..self.row));
+                }
+            }
+        }
+        None
+    }
+}
+
+/// First index at or after `start` outside a predicate's prefix.
+fn gallop(xs: &[u64], start: usize, predicate: impl Fn(&u64) -> bool) -> usize {
+    let mut pos = start;
+    if pos < xs.len() && predicate(&xs[pos]) {
+        let mut step = 1;
+        while pos + step < xs.len() && predicate(&xs[pos + step]) {
+            pos += step;
+            step <<= 1;
+        }
+        step >>= 1;
+        while step > 0 {
+            if pos + step < xs.len() && predicate(&xs[pos + step]) {
+                pos += step;
+            }
+            step >>= 1;
+        }
+        pos += 1;
+    }
+    pos
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sorted_matches_agree_with_independent_searches() {
+        let mut seed = 0x9e3779b97f4a7c15u64;
+        let mut random = || {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            seed
+        };
+        for trial in 0..200 {
+            let mut needles: Vec<_> = (0..trial % 40).map(|_| random() % 97).collect();
+            let mut haystack: Vec<_> = (0..trial).map(|_| random() % 97).collect();
+            if trial % 3 == 0 {
+                needles.push(u64::MAX);
+                haystack.push(u64::MAX);
+            }
+            needles.sort_unstable();
+            needles.dedup();
+            haystack.sort_unstable();
+            let expected: Vec<_> = needles
+                .iter()
+                .enumerate()
+                .filter_map(|(i, key)| {
+                    let start = haystack.iter().position(|x| x == key)?;
+                    let end = haystack.iter().rposition(|x| x == key).unwrap() + 1;
+                    Some((i, start..end))
+                })
+                .collect();
+            assert_eq!(
+                MatchingRanges::new(&needles, &haystack).collect::<Vec<_>>(),
+                expected
+            );
+        }
+    }
+}


### PR DESCRIPTION
Corgi reduce restarts searches for successive changed identifiers, while lopsided joins build owned needle columns. Share a monotone matching-range iterator that gallops across gaps and borrows the existing identifier slices. State is local to the iterator; sorted unique needles match complete runs in the sorted haystack.

Based directly on master-next after ownership merged as #868. The rebase preserves the complete source tree.

On the measured one-worker Reach and SCC workloads, maintenance time falls by 15.6% and 9.5%, respectively; load time falls by 5.8% and 5.9%. These are medians of four processes on Apple M4, with 1,000 edge replacements per epoch. Runtime changes: +102/-52 lines; tests: +39.

Validation: 131 selected library/integration tests passed again after rebasing; two existing tests ignored. Existing independent graph-oracle checks cover 240 snapshots per normal and instrumented binary