### PR TITLE
Reuse proxy sweep scratch across bounded key groups

### DIFF
--- a/differential-dataflow/src/operators/int_proxy/reduce.rs
+++ b/differential-dataflow/src/operators/int_proxy/reduce.rs
@@ -134,6 +134,8 @@ pub trait ProxyReduceBackend<T, B1, B2> {
 /// A proxy-space [`ReduceTactic`]: matches input and output records by `key_hash`.
 pub struct ProxyReduceTactic<T, Bk> {
     backend: Bk,
+    /// Maximum number of key hashes with live sweep state at once.
+    key_batch_size: usize,
     /// Pending interesting times beyond the upper frontier, keyed by key hash.
     pending: BTreeMap<u64, Vec<T>>,
 }
@@ -141,7 +143,20 @@ pub struct ProxyReduceTactic<T, Bk> {
 impl<T, Bk> ProxyReduceTactic<T, Bk> {
     /// A tactic deferring all value semantics to `backend`.
     pub fn new(backend: Bk) -> Self {
-        ProxyReduceTactic { backend, pending: BTreeMap::new() }
+        ProxyReduceTactic { backend, key_batch_size: usize::MAX, pending: BTreeMap::new() }
+    }
+
+    /// Limit simultaneous sweeps independently of the backend's presentation window.
+    ///
+    /// Complete key hashes stay together, including all real keys sharing a hash.
+    /// Sweep scratch is reused between groups within a retire. The bound does not
+    /// limit a single key's size, the presentation, or the output batch. Corrections
+    /// remain batched, and emission still happens once per backend window.
+    /// By default, all keys in the presentation can have live sweeps at once.
+    pub fn with_key_batch_size(mut self, key_batch_size: usize) -> Self {
+        assert!(key_batch_size > 0, "key batch size must be positive");
+        self.key_batch_size = key_batch_size;
+        self
     }
 }
 
@@ -224,7 +239,7 @@ where
         let mut from = Some(0u64);
         let mut window: ReduceWindow<T, Bk::RIn, Bk::ROut> = ReduceWindow::default();
 
-        // Retire-wide reusable scratch: cleared per window or wave, never reallocated. Fresh
+        // Retire-wide reusable scratch: cleared per group, window or wave, retaining capacity. Fresh
         // per-key/per-wave `Vec`s were once the dominant cost here, which is why the slots and the
         // staging buffers are held across the whole retire rather than built where they are used.
         let mut slots: Vec<KeySweep<T, Bk::RIn, Bk::ROut>> = Vec::new();
@@ -279,105 +294,107 @@ where
             //
             // Each key gets a `Sweep`, which discovers and evaluates in ONE ascending pass,
             // suspending where the conventional reduce would call user logic. Slots are reused
-            // across windows, so a key costs no allocation of its own beyond the first window wide
-            // enough to need it. Peak state is O(window presentation), bounded by what
-            // `next_window` already materialized.
-            let mut n_slots = 0usize;
+            // across bounded groups as well as windows. A backend can present a large
+            // window without allocating sweep state for every key simultaneously.
             let (mut is, mut ns, mut os) = (0usize, 0usize, 0usize);
-            live.clear();
-            // Mapped to hashes before the min: the sources differ in shape.
-            while let Some(key) = [
-                p_in.get(is).map(|record| record.0.0),
-                seeds.get(ns).map(|seed| seed.0),
-                p_out.get(os).map(|record| record.0.0),
-            ].into_iter().flatten().min() {
-                let i0 = is;
-                while is < p_in.len() && p_in[is].0.0 == key { is += 1; }
-                let i1 = is;
-                let n0 = ns;
-                while ns < seeds.len() && seeds[ns].0 == key { ns += 1; }
-                let n1 = ns;
-                let o0 = os;
-                while os < p_out.len() && p_out[os].0.0 == key { os += 1; }
-                let o1 = os;
+            while is < p_in.len() || ns < seeds.len() || os < p_out.len() {
+                let mut n_slots = 0usize;
+                live.clear();
+                // Mapped to hashes before the min: the sources differ in shape.
+                while let Some(key) = [
+                    p_in.get(is).map(|record| record.0.0),
+                    seeds.get(ns).map(|seed| seed.0),
+                    p_out.get(os).map(|record| record.0.0),
+                ].into_iter().flatten().min() {
+                    let i0 = is;
+                    while is < p_in.len() && p_in[is].0.0 == key { is += 1; }
+                    let i1 = is;
+                    let n0 = ns;
+                    while ns < seeds.len() && seeds[ns].0 == key { ns += 1; }
+                    let n1 = ns;
+                    let o0 = os;
+                    while os < p_out.len() && p_out[os].0.0 == key { os += 1; }
+                    let o1 = os;
 
-                if n_slots == slots.len() { slots.push(KeySweep::empty()); }
-                let slot = &mut slots[n_slots];
-                slot.key = key;
-                slot.pended.clear();
-                // Only the DUE times seed the sweep; the carried ones remain in `self.pending`.
-                let owed = due.get(&key).map(|p| &p[..]).unwrap_or(&[]);
-                slot.sweep.load(
-                    owed,
-                    (n0..n1).map(|n| seeds[n].1.clone()),
-                    (i0..i1).map(|i| (p_in[i].0.1, p_in[i].1.clone(), p_in[i].2.clone())),
-                    (o0..o1).map(|o| (p_out[o].0.1, p_out[o].1.clone(), p_out[o].2.clone())),
-                );
-                slot.at = slot.sweep.next_crossing(upper, &mut slot.pended);
-                if slot.at.is_some() { live.push(n_slots); }
-                else if !slot.pended.is_empty() {
-                    for time in &slot.pended { pending_frontier.insert_ref(time); }
-                    self.pending.entry(key).or_default().append(&mut slot.pended);
-                }
-                n_slots += 1;
-            }
-
-            // Each wave: read every suspended key's accumulations, cross the non-empty ones in one
-            // call, hand the corrections back, and step every live key on. A key retires when its
-            // sweep runs dry, at which point its pended times are carried forward.
-            while !live.is_empty() {
-                batch_keys.clear();
-                in_ends.clear();
-                in_all.clear();
-                out_ends.clear();
-                out_all.clear();
-                active.clear();
-
-                for &si in live.iter() {
-                    let at = slots[si].at.clone().expect("live slots are suspended at a time");
-                    in_accum.clear();
-                    cur_out.clear();
-                    slots[si].sweep.input_at(&at, &mut in_accum);
-                    slots[si].sweep.output_at(&at, &mut cur_out);
-                    // An interesting time can still reach the gate with nothing to read; the
-                    // conventional reduce skips user logic there and so do we.
-                    if in_accum.is_empty() && cur_out.is_empty() { continue; }
-                    batch_keys.push(slots[si].key);
-                    in_all.append(&mut in_accum);
-                    in_ends.push(in_all.len());
-                    out_all.append(&mut cur_out);
-                    out_ends.push(out_all.len());
-                    active.push((si, at));
-                }
-
-                if !batch_keys.is_empty() {
-                    let (corr, corr_ends) = self.backend.reduce_corrections(&batch_keys, &in_ends, &in_all, &out_ends, &out_all);
-                    let mut cstart = 0usize;
-                    for (bi, (si, at)) in active.iter().enumerate() {
-                        let cend = corr_ends[bi];
-                        if cstart != cend {
-                            debug_assert!(held.elements().iter().any(|h| h.less_equal(at)), "no held capability <= active time");
-                            for (vid, d) in &corr[cstart..cend] {
-                                deltas.push(((slots[*si].key, *vid), at.clone(), d.clone()));
-                            }
-                            slots[*si].sweep.commit(at, corr[cstart..cend].iter().cloned());
-                        }
-                        cstart = cend;
-                    }
-                }
-
-                // Step every live key past the time it was suspended at, and retire the spent ones.
-                for &si in live.iter() {
-                    let slot = &mut slots[si];
+                    if n_slots == slots.len() { slots.push(KeySweep::empty()); }
+                    let slot = &mut slots[n_slots];
+                    slot.key = key;
+                    slot.pended.clear();
+                    // Only the DUE times seed the sweep; the carried ones remain in `self.pending`.
+                    let owed = due.get(&key).map(|p| &p[..]).unwrap_or(&[]);
+                    slot.sweep.load(
+                        owed,
+                        (n0..n1).map(|n| seeds[n].1.clone()),
+                        (i0..i1).map(|i| (p_in[i].0.1, p_in[i].1.clone(), p_in[i].2.clone())),
+                        (o0..o1).map(|o| (p_out[o].0.1, p_out[o].1.clone(), p_out[o].2.clone())),
+                    );
                     slot.at = slot.sweep.next_crossing(upper, &mut slot.pended);
-                    if slot.at.is_none() && !slot.pended.is_empty() {
+                    if slot.at.is_some() { live.push(n_slots); }
+                    else if !slot.pended.is_empty() {
                         for time in &slot.pended { pending_frontier.insert_ref(time); }
-                        let entry = self.pending.entry(slot.key).or_default();
-                        entry.append(&mut slot.pended);
-                        crate::operators::reduce::sort_dedup(entry);
+                        self.pending.entry(key).or_default().append(&mut slot.pended);
                     }
+                    n_slots += 1;
+                    if n_slots == self.key_batch_size { break; }
                 }
-                live.retain(|&si| slots[si].at.is_some());
+
+                // Each wave: read every suspended key's accumulations, cross the non-empty ones in one
+                // call, hand the corrections back, and step every live key on. A key retires when its
+                // sweep runs dry, at which point its pended times are carried forward.
+                while !live.is_empty() {
+                    batch_keys.clear();
+                    in_ends.clear();
+                    in_all.clear();
+                    out_ends.clear();
+                    out_all.clear();
+                    active.clear();
+
+                    for &si in live.iter() {
+                        let at = slots[si].at.clone().expect("live slots are suspended at a time");
+                        in_accum.clear();
+                        cur_out.clear();
+                        slots[si].sweep.input_at(&at, &mut in_accum);
+                        slots[si].sweep.output_at(&at, &mut cur_out);
+                        // An interesting time can still reach the gate with nothing to read; the
+                        // conventional reduce skips user logic there and so do we.
+                        if in_accum.is_empty() && cur_out.is_empty() { continue; }
+                        batch_keys.push(slots[si].key);
+                        in_all.append(&mut in_accum);
+                        in_ends.push(in_all.len());
+                        out_all.append(&mut cur_out);
+                        out_ends.push(out_all.len());
+                        active.push((si, at));
+                    }
+
+                    if !batch_keys.is_empty() {
+                        let (corr, corr_ends) = self.backend.reduce_corrections(&batch_keys, &in_ends, &in_all, &out_ends, &out_all);
+                        let mut cstart = 0usize;
+                        for (bi, (si, at)) in active.iter().enumerate() {
+                            let cend = corr_ends[bi];
+                            if cstart != cend {
+                                debug_assert!(held.elements().iter().any(|h| h.less_equal(at)), "no held capability <= active time");
+                                for (vid, d) in &corr[cstart..cend] {
+                                    deltas.push(((slots[*si].key, *vid), at.clone(), d.clone()));
+                                }
+                                slots[*si].sweep.commit(at, corr[cstart..cend].iter().cloned());
+                            }
+                            cstart = cend;
+                        }
+                    }
+
+                    // Step every live key past the time it was suspended at, and retire the spent ones.
+                    for &si in live.iter() {
+                        let slot = &mut slots[si];
+                        slot.at = slot.sweep.next_crossing(upper, &mut slot.pended);
+                        if slot.at.is_none() && !slot.pended.is_empty() {
+                            for time in &slot.pended { pending_frontier.insert_ref(time); }
+                            let entry = self.pending.entry(slot.key).or_default();
+                            entry.append(&mut slot.pended);
+                            crate::operators::reduce::sort_dedup(entry);
+                        }
+                    }
+                    live.retain(|&si| slots[si].at.is_some());
+                }
             }
 
             if !deltas.is_empty() {
@@ -393,8 +410,8 @@ where
 }
 
 /// One key's slot in a window: its [`Sweep`], the time it is suspended at, and the times it has
-/// pended so far. Slots are reused across windows, so a key costs no allocation of its own beyond
-/// the first window wide enough to need it.
+/// pended so far. Slots and their scratch capacity are reused across groups and windows
+/// within a retire, then dropped when the retire completes.
 struct KeySweep<T, RIn, ROut> {
     key: u64,
     sweep: Sweep<T, RIn, ROut>,
@@ -486,7 +503,7 @@ enum Tick<T> {
 }
 
 impl<T: Timestamp + Lattice, RIn: Semigroup + Clone, ROut: Semigroup + Clone> Sweep<T, RIn, ROut> {
-    /// An empty sweep, to be `load`ed. Reuse one per key rather than allocating per key.
+    /// An empty sweep, to be `load`ed and reused for successive keys.
     fn new() -> Self {
         Sweep {
             input: ValueHistory::new(), output: ValueHistory::new(),

--- a/differential-dataflow/tests/int_proxy.rs
+++ b/differential-dataflow/tests/int_proxy.rs
@@ -311,7 +311,7 @@ fn reduce_collision_inside_iterate() {
             let result = input.iterate(|_scope, inner| {
                 let hashed = inner.map(|(k, v)| (k % 2, (k, v)));
                 let arr = arrange_core::<Pipeline, Vec<((u64, (u64, u64)), Product<u64, u64>, i64)>, _, VChunkSpine<u64, (u64, u64), Product<u64, u64>, i64>>(hashed.inner, Pipeline, "ArrCollide", VChunkBatcher::new);
-                reduce_with_tactic::<_, VChunkSpine<u64, (u64, u64), Product<u64, u64>, i64>, _>(arr, "CollideReduce", ProxyReduceTactic::new(VecReduceBackend::with_window(max_logic, 1)))
+                reduce_with_tactic::<_, VChunkSpine<u64, (u64, u64), Product<u64, u64>, i64>, _>(arr, "CollideReduce", ProxyReduceTactic::new(VecReduceBackend::with_window(max_logic, usize::MAX)).with_key_batch_size(1))
                     .as_collection(|_h, kw: &(u64, u64)| (kw.0, kw.1))
             });
             result.inspect(move |(d, t, r)| os.lock().unwrap().push((*d, *t, *r)));
@@ -448,4 +448,74 @@ fn reduce_seed_survives_cancellation() {
     );
     let out1: Vec<_> = p1.into_iter().filter_map(|b| b.inner).flat_map(|b| hread(&[b])).collect();
     assert_eq!(out1, vec![((7u64, 3u64), 1u64, -1i64)], "the stale output must be retracted");
+}
+
+/// Reusing slots must preserve incomparable times, pending-only retires, and
+/// cancellations against compacted history across multiple groups in one window.
+#[test]
+fn bounded_sweeps_match_partial_order_oracle() {
+    type T = Product<u64, u64>;
+    let time = T::new;
+    let mut initial = Vec::new();
+    let mut novel = Vec::new();
+    let mut expected = Vec::new();
+    for key in 0..1031u64 {
+        let mut rows = vec![((key, 3), time(0, 0), 1i64),
+                            ((key, 7), time(1, 0), 1),
+                            ((key, 9), time(0, 1), 1)];
+        initial.extend(rows.iter().cloned());
+        let mut changes = Vec::new();
+        if key % 2 == 0 { changes.push(((key, 9), time(2, 2), -1)); }
+        if key % 3 == 0 { changes.push(((key, 7), time(2, 2), -1)); }
+        // Some keys cancel entirely after compaction: only the raw novel seeds
+        // and stale output remain to trigger their final retraction.
+        if key % 6 == 0 { changes.push(((key, 3), time(2, 2), -1)); }
+        novel.extend(changes.iter().cloned());
+        rows.extend(changes);
+
+        // Recompute the desired maximum at each time from the original updates,
+        // then subtract the output in its partial-order past. No sweep machinery.
+        let mut prior: Vec<((u64, u64), T, i64)> = Vec::new();
+        for at in [time(0, 0), time(0, 1), time(1, 0), time(1, 1), time(2, 2)] {
+            let mut counts = std::collections::BTreeMap::new();
+            for ((_, value), t, diff) in &rows {
+                if timely::PartialOrder::less_equal(t, &at) {
+                    *counts.entry(*value).or_insert(0i64) += diff;
+                }
+            }
+            let mut correction = std::collections::BTreeMap::new();
+            if let Some((&value, _)) = counts.iter().rev().find(|(_, d)| **d > 0) {
+                correction.insert(value, 1i64);
+            }
+            for ((_, value), t, diff) in &prior {
+                if timely::PartialOrder::less_equal(t, &at) {
+                    *correction.entry(*value).or_default() -= diff;
+                }
+            }
+            prior.extend(correction.into_iter().filter(|(_, d)| *d != 0)
+                .map(|(value, diff)| ((key, value), at, diff)));
+        }
+        expected.extend(prior);
+    }
+    consolidate_updates(&mut expected);
+    for limit in [1, 7, 256, 1024, usize::MAX] {
+        let backend = VecReduceBackend::with_window(max_logic, usize::MAX);
+        let mut tactic = ProxyReduceTactic::new(backend).with_key_batch_size(limit);
+        let source = hbatch(initial.clone(), time(0, 0), time(1, 1));
+        let lower = Antichain::from_elem(time(0, 0));
+        let middle = Antichain::from_elem(time(1, 1));
+        let upper = Antichain::from_elem(time(2, 2));
+        let (first, pending) = tactic.retire(vec![], vec![], vec![source.clone()], &lower, &middle, &lower);
+        assert_eq!(pending, middle, "limit {limit}: synthesized crossing must remain carried");
+        let mut all: Vec<_> = first.into_iter().filter_map(|s| s.inner).collect();
+        // No new records: every key is revisited solely because of its pending join.
+        let (second, pending) = tactic.retire(vec![source.clone()], all.clone(), vec![], &middle, &upper, &pending);
+        assert!(pending.is_empty(), "limit {limit}: pending-only retire");
+        all.extend(second.into_iter().filter_map(|s| s.inner));
+        let input = hbatch(novel.clone(), time(2, 2), time(3, 3));
+        let (third, pending) = tactic.retire(vec![source], all.clone(), vec![input], &upper, &Antichain::from_elem(time(3, 3)), &upper);
+        assert!(pending.is_empty(), "limit {limit}: cancellations");
+        all.extend(third.into_iter().filter_map(|s| s.inner));
+        assert_eq!(hread(&all), expected, "limit {limit}");
+    }
 }

--- a/interactive/src/backend/corgi.rs
+++ b/interactive/src/backend/corgi.rs
@@ -326,7 +326,9 @@ impl Backend for CorgiBackend {
     }
 
     fn reduce<'s>(a: Self::Arr<'s>, reducer: &Reducer) -> Self::Arr<'s> {
-        reduce_with_tactic::<_, CTrace, _>(a, "CorgiReduce", ProxyReduceTactic::new(CorgiReduceBackend::new(reducer.clone())))
+        // Amortize columnar corrections while reusing sweep scratch across wide presentations.
+        let tactic = ProxyReduceTactic::new(CorgiReduceBackend::new(reducer.clone())).with_key_batch_size(256);
+        reduce_with_tactic::<_, CTrace, _>(a, "CorgiReduce", tactic)
     }
 
     fn inspect<'s>(c: Collection<'s, Time, CC>, label: String) -> Collection<'s, Time, CC> {


### PR DESCRIPTION
A wide Corgi reduce presentation creates a sweep for every key hash. Process groups of up to 256 hashes to completion and refill the same sweep slots for later groups, reusing their scratch capacity. Keep whole hashes together, existing batched corrections, and one emission per presentation window. The generic tactic retains its unbounded default; there is no new correction callback.

Standalone maintenance timings against master-next `626c80ce`:

| Workload | Base maintain ms | Bounded maintain ms | Time saved |
| --- | ---: | ---: | ---: |
| Reach | 99.77 | 90.01 | 9.8% |
| SCC | 531.64 | 489.62 | 7.9% |
| Pair-key Reach | 120.30 | 110.03 | 8.5% |

Four-process medians on Apple M4, one worker, mimalloc, release/LTO. Reach: 200k nodes/400k edges; SCC: 100k/200k; 1k replacements per epoch, seed 0, averaging epochs 6–25. Load time improves 17.6%/5.7%/14.2%, respectively.

Separate memory runs: allocation calls fall 63.2% for Reach and 8.5% for SCC; peak requested heap falls 203→173 MiB and 412→321 MiB. Post-tick requested heap is about 12 KiB higher. Scratch is dropped at the end of each retire.

Trade-off: sparse SCC (5k nodes/5k edges, 500 replacements) is 1.5–1.6% slower in longer four-process comparisons at two seeds.

Validation: 155 selected Rust/server tests passed, two existing ignores; all 41 maintained SNB queries on four workers with both backends; 348 independent graph-oracle snapshots across base/candidate timing and memory binaries. The new partial-order test covers pending-only retires and cancellations at five sweep bounds; collision coverage crosses bounded groups.

Runtime diff +114/−95, mostly indentation (+29/−10 ignoring whitespace); tests +71/−1. No UNIT/reducer or timestamp specialization is included.
